### PR TITLE
Empty before selecting to prevent invalid options moving

### DIFF
--- a/testbench-integration-tests/src/main/java/com/vaadin/testUI/TwinColSelectUI.java
+++ b/testbench-integration-tests/src/main/java/com/vaadin/testUI/TwinColSelectUI.java
@@ -17,7 +17,7 @@ public class TwinColSelectUI extends AbstractTestUI {
 
     @Override
     protected void setup(VaadinRequest request) {
-        TwinColSelect twinColSelect = new TwinColSelect();
+        TwinColSelect<String> twinColSelect = new TwinColSelect<String>();
         multiCounterLbl.setValue("0");
         List<String> options = new ArrayList<String>();
         options.add("item1");

--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/listselect/ListSelectOptionClickIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/listselect/ListSelectOptionClickIT.java
@@ -27,8 +27,7 @@ public class ListSelectOptionClickIT extends MultiBrowserTest {
     @Test
     @Ignore("depends on framework8-issues/issues/464 fix")
     public void testOptionClick() {
-        List<WebElement> options = select.findElements(By
-                .tagName("option"));
+        List<WebElement> options = select.findElements(By.tagName("option"));
         WebElement option = options.get(1);
         option.click();
         checkValueChanged();
@@ -49,6 +48,18 @@ public class ListSelectOptionClickIT extends MultiBrowserTest {
         Assert.assertEquals("2: [item1, item2, item3]", counterLbl.getText());
         select.deselectByText("item2");
         Assert.assertEquals("3: [item1, item3]", counterLbl.getText());
+    }
+
+    @Test
+    public void testDeselectSelectByText() {
+        select.deselectByText("item1");
+        Assert.assertEquals("1: []", counterLbl.getText());
+        select.selectByText("item1");
+        Assert.assertEquals("2: [item1]", counterLbl.getText());
+        select.selectByText("item3");
+        Assert.assertEquals("3: [item1, item3]", counterLbl.getText());
+        select.deselectByText("item1");
+        Assert.assertEquals("4: [item3]", counterLbl.getText());
     }
 
     /*

--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/twincolselect/TwinColSelectUIIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/twincolselect/TwinColSelectUIIT.java
@@ -33,6 +33,14 @@ public class TwinColSelectUIIT extends MultiBrowserTest {
     }
 
     @Test
+    public void testDeselectSelectByText() {
+        multiSelect.deselectByText("item1");
+        Assert.assertEquals("1: []", multiCounterLbl.getText());
+        multiSelect.selectByText("item1");
+        Assert.assertEquals("2: [item1]", multiCounterLbl.getText());
+    }
+
+    @Test
     public void testGetAvailableOptions() {
         assertAvailableOptions("item2", "item3");
         multiSelect.selectByText("item2");
@@ -45,5 +53,4 @@ public class TwinColSelectUIIT extends MultiBrowserTest {
         List<String> optionTexts = multiSelect.getAvailableOptions();
         Assert.assertArrayEquals(items, optionTexts.toArray());
     }
-
 }

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/TwinColSelectElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/TwinColSelectElement.java
@@ -59,9 +59,7 @@ public class TwinColSelectElement extends AbstractSelectElement {
     }
 
     public void deselectByText(String text) {
-        if (selectedOptions.isMultiple()) {
-            selectedOptions.deselectAll();
-        }
+        selectedOptions.deselectAll();
         selectedOptions.selectByVisibleText(text);
         deselButton.click();
     }
@@ -97,6 +95,7 @@ public class TwinColSelectElement extends AbstractSelectElement {
     }
 
     public void selectByText(String text) {
+        options.deselectAll();
         options.selectByVisibleText(text);
         selButton.click();
     }


### PR DESCRIPTION
Fixes #810
Also removed check for multiple selection as it's always multiple
Added regression test for TwinColSelect and ListSelect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/824)
<!-- Reviewable:end -->
