### PR TITLE
Fix ComboBox.selectByText when multiple options match the text

### DIFF
--- a/testbench-integration-tests/src/main/java/com/vaadin/testUI/SelectByText.java
+++ b/testbench-integration-tests/src/main/java/com/vaadin/testUI/SelectByText.java
@@ -18,10 +18,13 @@ package com.vaadin.testUI;
 import javax.servlet.annotation.WebServlet;
 
 import com.vaadin.annotations.VaadinServletConfiguration;
+import com.vaadin.data.Property.ValueChangeEvent;
+import com.vaadin.data.Property.ValueChangeListener;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinServlet;
 import com.vaadin.tests.AbstractTestUI;
 import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
 /**
@@ -30,7 +33,8 @@ import com.vaadin.ui.VerticalLayout;
  */
 @SuppressWarnings("serial")
 public class SelectByText extends AbstractTestUI {
-    @WebServlet(value = { "/VAADIN/*", "/SelectByText/*" }, asyncSupported = true)
+    @WebServlet(value = { "/VAADIN/*",
+            "/SelectByText/*" }, asyncSupported = true)
     @VaadinServletConfiguration(productionMode = false, ui = SelectByText.class)
     public static class Servlet extends VaadinServlet {
     }
@@ -44,12 +48,21 @@ public class SelectByText extends AbstractTestUI {
         combobox.addItem("Value 1");
         combobox.addItem("(");
         combobox.addItem("(Value");
+        combobox.addItem("Value 222");
+        combobox.addItem("Value 22");
         combobox.addItem("Value 2");
         combobox.addItem("Value(");
         combobox.addItem("Value(i)");
         combobox.addItem("((Test ) selectByTest() method(with' parentheses)((");
         combobox.addItem("Value 3");
         layout.addComponent(combobox);
+        combobox.addValueChangeListener(new ValueChangeListener() {
+            @Override
+            public void valueChange(ValueChangeEvent e) {
+                layout.addComponent(new Label(
+                        "Value is now '" + e.getProperty().getValue() + "'"));
+            }
+        });
     }
 
     @Override

--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/SelectByTextIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/SelectByTextIT.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.By;
 import com.vaadin.testbench.elements.ComboBoxElement;
+import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.tests.testbenchapi.MultiBrowserTest;
 
 /**
@@ -81,4 +82,16 @@ public class SelectByTextIT extends MultiBrowserTest {
         WebElement textbox = comboBox.findElement(By.vaadin("#textbox"));
         return textbox.getAttribute("value");
     }
+
+    @Test
+    public void selectSharedPrefixOption() {
+        for (String text : new String[] { "Value 2", "Value 22",
+                "Value 222" }) {
+            selectByText(text);
+            assertEquals(text, getComboBoxValue());
+            assertEquals("Value is now '" + text + "'",
+                    $(LabelElement.class).last().getText());
+        }
+    }
+
 }

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -48,11 +48,7 @@ public class ComboBoxElement extends AbstractSelectElement {
         getInputField().clear();
         sendInputFieldKeys(text);
 
-        List<String> popupSuggestions = getPopupSuggestions();
-        if (popupSuggestions.size() != 0
-                && text.equals(popupSuggestions.get(0))) {
-            getSuggestionPopup().findElement(By.tagName("td")).click();
-        }
+        selectSuggestion(text);
     }
 
     /**
@@ -74,13 +70,20 @@ public class ComboBoxElement extends AbstractSelectElement {
         }
 
         do {
-            for (WebElement suggestion : getPopupSuggestionElements()) {
-                if (text.equals(suggestion.getText())) {
-                    suggestion.click();
-                    return;
-                }
+            if (selectSuggestion(text)) {
+                return;
             }
         } while (openNextPage());
+    }
+
+    private boolean selectSuggestion(String text) {
+        for (WebElement suggestion : getPopupSuggestionElements()) {
+            if (text.equals(suggestion.getText())) {
+                suggestion.click();
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isReadOnly(WebElement elem) {


### PR DESCRIPTION
If a ComboBox contains
* Option 100
* Option 10
* Option 1

Then selectByText("Option 1") should select the last, not the first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/833)
<!-- Reviewable:end -->
