### PR TITLE
Fix javadoc generation with java 8

### DIFF
--- a/vaadin-testbench-api/pom.xml
+++ b/vaadin-testbench-api/pom.xml
@@ -7,8 +7,9 @@
     <version>8.0-SNAPSHOT</version>
 
     <properties>
-        <snapshot.repository.url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/
-        </snapshot.repository.url>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <snapshot.repository.url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</snapshot.repository.url>
         <testbench.core.version>5.0-SNAPSHOT</testbench.core.version>
     </properties>
 

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/GridElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/GridElement.java
@@ -98,7 +98,7 @@ public class GridElement extends AbstractComponentElement {
          * @param colIndex
          *            the column index
          * @return {@code true} if the column has an editor field, {@code false}
-         *          otherwise
+         *         otherwise
          */
         public boolean isEditable(int colIndex) {
             return grid

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/TableElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/TableElement.java
@@ -36,7 +36,8 @@ public class TableElement extends AbstractSelectElement {
      * @param column
      *            0 based column index
      * @return TestBenchElement containing wanted cell.
-     * @throw NoSuchElementException if the cell (row, column) is not found.
+     * @throws NoSuchElementException
+     *             if the cell (row, column) is not found.
      */
     public TestBenchElement getCell(int row, int column) {
 

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -179,7 +179,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-				<version>2.6</version>
+                <version>2.6</version>
                 <configuration>
                     <basedir>${basedir}</basedir>
                     <header>${basedir}/src/license/cval3/header.txt</header>

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/annotations/BrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/annotations/BrowserFactory.java
@@ -24,7 +24,7 @@ import com.vaadin.testbench.parallel.TestBenchBrowserFactory;
 /**
  * <p>
  * {@link BrowserFactory} annotation is used to define which
- * {@link TestBenchBrowserFactory} implementation to use in a test.
+ * {@link TestBenchBrowserFactory} implementation to use in a test.
  * </p>
  * <p>
  * {@link TestBenchBrowserFactory} should be implemented by another class, or

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
@@ -151,7 +151,7 @@ public class ParallelTest extends TestBenchTestCase {
     }
 
     /**
-     * @return Version value of the {@link RunLocally} annotation of current
+     * @return Version value of the {@link RunLocally} annotation of current
      *         Class, or empty empty String if annotation is not present.
      */
     protected String getRunLocallyBrowserVersion() {
@@ -161,7 +161,7 @@ public class ParallelTest extends TestBenchTestCase {
     /**
      * 
      * @return default capabilities, used if no {@link BrowserConfiguration}
-     *          method was found
+     *         method was found
      */
     public static List<DesiredCapabilities> getDefaultCapabilities() {
         return Collections.singletonList(BrowserUtil.firefox());

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/TestBenchBrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/TestBenchBrowserFactory.java
@@ -24,7 +24,7 @@ import com.vaadin.testbench.annotations.BrowserFactory;
  * </p>
  * <p>
  * This interface should be implemented and used in test cases through the
- * {@link BrowserFactory} annotation. Classes that implement this interface must
+ * {@link BrowserFactory} annotation. Classes that implement this interface must
  * have a constructor with zero arguments.
  * </p>
  */

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/SetupDriver.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/SetupDriver.java
@@ -92,7 +92,7 @@ public class SetupDriver {
 
     /**
      * <p>
-     * Sets up and returns a {@link WebDriver} to run test. This driver will run
+     * Sets up and returns a {@link WebDriver} to run test. This driver will run
      * the test on the {@link Browser} provided in the {@link RunLocally}
      * annotation.
      * </p>
@@ -113,7 +113,7 @@ public class SetupDriver {
 
     /**
      * <p>
-     * Sets up and returns a {@link WebDriver} to run test. This driver will run
+     * Sets up and returns a {@link WebDriver} to run test. This driver will run
      * the test on the {@link Browser} provided in the {@link RunLocally}
      * annotation.
      * </p>


### PR DESCRIPTION
Set encoding for testbench api
Remove unmappable characted
Fix incorrect annotation in TableElement javadoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/834)
<!-- Reviewable:end -->
