### PR TITLE
Make ComboBoxElement.selectByText throw an exception for no match

### DIFF
--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/ComboBoxInputNotAllowedIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/ComboBoxInputNotAllowedIT.java
@@ -2,6 +2,7 @@ package com.vaadin.tests.testbenchapi.components.combobox;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
 
 import com.vaadin.testUI.ComboBoxInputNotAllowed;
 import com.vaadin.testbench.elements.ComboBoxElement;
@@ -10,7 +11,7 @@ import com.vaadin.tests.testbenchapi.MultiBrowserTest;
 
 public class ComboBoxInputNotAllowedIT extends MultiBrowserTest {
 
-    @Test
+    @Test(expected = NoSuchElementException.class)
     public void selectByTextComboBoxWithTextInputDisabled_invalidSelection() {
         openTestURL();
         ComboBoxElement cb = $(ComboBoxElement.class).first();

--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/ComboBoxUIIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/ComboBoxUIIT.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.testUI.ComboBoxUI;
@@ -49,13 +50,14 @@ public class ComboBoxUIIT extends MultiBrowserTest {
         testMultipleSelectByTextOperationsIn(cb);
     }
 
-    @Test
+    @Test(expected = NoSuchElementException.class)
     public void testSelectByTextNotFound() {
         ComboBoxElement cb = $(ComboBoxElement.class).first();
         cb.selectByText("foobar");
     }
 
-    private void testMultipleSelectByTextOperationsIn(ComboBoxElement comboBox) {
+    private void testMultipleSelectByTextOperationsIn(
+            ComboBoxElement comboBox) {
         // Select all items from the menu
         for (String currency : ComboBoxUI.currencies) {
             comboBox.selectByText(currency);

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -48,7 +48,10 @@ public class ComboBoxElement extends AbstractSelectElement {
         getInputField().clear();
         sendInputFieldKeys(text);
 
-        selectSuggestion(text);
+        if (!selectSuggestion(text)) {
+            throw new NoSuchElementException(
+                    "No option with text '" + text + "' found");
+        }
     }
 
     /**
@@ -74,6 +77,8 @@ public class ComboBoxElement extends AbstractSelectElement {
                 return;
             }
         } while (openNextPage());
+        throw new NoSuchElementException(
+                "No option with text '" + text + "' found");
     }
 
     private boolean selectSuggestion(String text) {


### PR DESCRIPTION
In most (all) cases you want selectByText to select an option. If no
option is selected, you most typically have a problem with your test
and this should not be hidden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/835)
<!-- Reviewable:end -->
