### PR TITLE
Fix ComboBox.selectByText when multiple options match the text

### DIFF
--- a/testbench-integration-tests/src/main/java/com/vaadin/testUI/SelectByText.java
+++ b/testbench-integration-tests/src/main/java/com/vaadin/testUI/SelectByText.java
@@ -22,6 +22,7 @@ import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.data.ListDataProvider;
 import com.vaadin.tests.AbstractTestUI;
 import com.vaadin.ui.ComboBox;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
 /**
@@ -36,12 +37,14 @@ public class SelectByText extends AbstractTestUI {
         final VerticalLayout layout = new VerticalLayout();
         addComponent(layout);
 
-        ComboBox combobox = new ComboBox();
+        ComboBox<String> combobox = new ComboBox<>();
         List<String> options = new ArrayList<String>();
 
         options.add("Value 1");
         options.add("(");
         options.add("(Value");
+        options.add("Value 222");
+        options.add("Value 22");
         options.add("Value 2");
         options.add("Value(");
         options.add("Value(i)");
@@ -51,6 +54,11 @@ public class SelectByText extends AbstractTestUI {
         combobox.setDataProvider(new ListDataProvider<String>(options));
 
         layout.addComponent(combobox);
+        combobox.addValueChangeListener(e -> {
+            layout.addComponent(
+                    new Label("Value is now '" + e.getValue() + "'"));
+        });
+
     }
 
     @Override

--- a/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/SelectByTextIT.java
+++ b/testbench-integration-tests/src/test/java/com/vaadin/tests/testbenchapi/components/combobox/SelectByTextIT.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.testbench.By;
 import com.vaadin.testbench.elements.ComboBoxElement;
+import com.vaadin.testbench.elements.LabelElement;
 import com.vaadin.tests.testbenchapi.MultiBrowserTest;
 
 /**
@@ -81,4 +82,16 @@ public class SelectByTextIT extends MultiBrowserTest {
         WebElement textbox = comboBox.findElement(By.vaadin("#textbox"));
         return textbox.getAttribute("value");
     }
+
+    @Test
+    public void selectSharedPrefixOption() {
+        for (String text : new String[] { "Value 2", "Value 22",
+                "Value 222" }) {
+            selectByText(text);
+            assertEquals(text, getComboBoxValue());
+            assertEquals("Value is now '" + text + "'",
+                    $(LabelElement.class).last().getText());
+        }
+    }
+
 }

--- a/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
+++ b/vaadin-testbench-api/src/main/java/com/vaadin/testbench/elements/ComboBoxElement.java
@@ -48,11 +48,7 @@ public class ComboBoxElement extends AbstractSelectElement {
         getInputField().clear();
         sendInputFieldKeys(text);
 
-        List<String> popupSuggestions = getPopupSuggestions();
-        if (popupSuggestions.size() != 0
-                && text.equals(popupSuggestions.get(0))) {
-            getSuggestionPopup().findElement(By.tagName("td")).click();
-        }
+        selectSuggestion(text);
     }
 
     /**
@@ -74,13 +70,20 @@ public class ComboBoxElement extends AbstractSelectElement {
         }
 
         do {
-            for (WebElement suggestion : getPopupSuggestionElements()) {
-                if (text.equals(suggestion.getText())) {
-                    suggestion.click();
-                    return;
-                }
+            if (selectSuggestion(text)) {
+                return;
             }
         } while (openNextPage());
+    }
+
+    private boolean selectSuggestion(String text) {
+        for (WebElement suggestion : getPopupSuggestionElements()) {
+            if (text.equals(suggestion.getText())) {
+                suggestion.click();
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isReadOnly(WebElement elem) {


### PR DESCRIPTION
If a ComboBox contains
* Option 100
* Option 10
* Option 1

Then selectByText("Option 1") should select the last, not the first.

From the 4.2 branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/842)
<!-- Reviewable:end -->
