### PR TITLE
Define the core version again in the Framework API module

### DIFF
--- a/vaadin-testbench-api/pom.xml
+++ b/vaadin-testbench-api/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <snapshot.repository.url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</snapshot.repository.url>
-        <testbench.core.version>5.0-SNAPSHOT</testbench.core.version>
+        <testbench.core.version>5.0.0.alpha2</testbench.core.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This ensures that the Framework API classes are compatible with
a release version and not only a snapshot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/856)
<!-- Reviewable:end -->
