### PR TITLE
Add info to docs, that FF is not supoorted.

### DIFF
--- a/documentation/testbench-quickstart.asciidoc
+++ b/documentation/testbench-quickstart.asciidoc
@@ -33,7 +33,8 @@ Geckodriver requires a separate installation.
 
 [NOTE]
 Geckodriver used for the latest Firefox versions (48 and newer) does not support link:https://github.com/mozilla/geckodriver/issues/159[actions API].
-It is recommended you use link:https://www.mozilla.org/en-US/firefox/organizations/all/[Firefox ESR] (currently at 45.3) to execute tests on Firefox until this has been fixed.
+In practice, meaning that you can not simulate context click and double click in tests.
+It is recommended you use link:https://www.mozilla.org/en-US/firefox/organizations/all/[Firefox 51] to execute tests on Firefox, when this is fixed.
 
 [[testbench.quickstart.adding-dependency]]
 == Adding the Maven Dependency

--- a/documentation/testbench-tutorial.asciidoc
+++ b/documentation/testbench-tutorial.asciidoc
@@ -128,7 +128,8 @@ All supported browsers require a special driver and some additional setup, see
 
 [NOTE]
 Geckodriver used for the latest Firefox versions (48 and newer) does not support link:https://github.com/mozilla/geckodriver/issues/159[actions API].
-It is recommended you use link:https://www.mozilla.org/en-US/firefox/organizations/all/[Firefox ESR] (currently at 45.3) to execute tests on Firefox until this has been fixed.
+In practice, meaning that you can not simulate context click and double click in tests.
+It is recommended you use link:https://www.mozilla.org/en-US/firefox/organizations/all/[Firefox 51] to execute tests on Firefox, when this is fixed.
 
 Run the test with the following command and observe that it opens up a Firefox browser and immediately closes it again.
 


### PR DESCRIPTION
Different versions of FF have different problems,
with GeckoDriver. Basically non of the FF versions works with
Selenium 3. This is mentioned in docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/868)
<!-- Reviewable:end -->
