### PR TITLE
Allow test to be run in a hub with system property

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
@@ -119,7 +119,8 @@ public class ParallelTest extends TestBenchTestCase {
         } else if (Parameters.isLocalWebDriverUsed()) {
             WebDriver driver = driverConfiguration.setupLocalDriver();
             setDriver(driver);
-        } else if (getRunOnHub(getClass()) != null) {
+        } else if (getRunOnHub(getClass()) != null
+                || Parameters.getHubHostname() != null) {
             WebDriver driver = driverConfiguration
                     .setupRemoteDriver(getHubURL());
             setDriver(driver);


### PR DESCRIPTION
According to documentation, it should be possible
to run a test in hub without setting @RunOnHub
annotation with using only the system property.
However, without the annotation ParallelTest
doesn't create a driver in setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/899)
<!-- Reviewable:end -->
