### PR TITLE
Fixes #905 License checker should respect log level

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/tools/LicenseChecker.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/tools/LicenseChecker.java
@@ -88,7 +88,7 @@ public class LicenseChecker {
 
     private static void printValidationInfo(CvalInfo validationInfo) {
         printLine(validationInfo.getMessage().length());
-        System.out.println(validationInfo.getMessage());
+        getLogger().log(Level.FINE, validationInfo.getMessage());
         printLine(validationInfo.getMessage().length());
     }
 
@@ -103,7 +103,6 @@ public class LicenseChecker {
     // print formating line of "-" symbols
     private static void printLine(int n) {
         String line = getLine(n);
-        System.out.print(line);
-        System.out.println();
+        getLogger().log(Level.FINE, line);
     }
 }


### PR DESCRIPTION

- Using log level fine for printValidationInfo and printLine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/906)
<!-- Reviewable:end -->
