### PR TITLE
Add helpers for getting and setting element properties

### DIFF
--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/TestBenchElementIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/TestBenchElementIT.java
@@ -1,0 +1,59 @@
+package com.vaadin.tests.elements;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.testUI.ElementQueryUI;
+import com.vaadin.testbench.By;
+import com.vaadin.testbench.TestBenchElement;
+
+public class TestBenchElementIT extends MultiBrowserTest {
+
+    @Override
+    protected Class<?> getUIClass() {
+        return ElementQueryUI.class;
+    }
+
+    @Test
+    public void getSetStringProperty() {
+        openTestURL();
+
+        TestBenchElement buttonElement = (TestBenchElement) findElements(
+                By.className("v-button")).get(0);
+
+        Assert.assertNull(buttonElement.getPropertyString("foo"));
+        buttonElement.setProperty("foo", "12");
+        Assert.assertEquals("12", buttonElement.getPropertyString("foo"));
+        Assert.assertEquals(12.0, buttonElement.getPropertyDouble("foo"), 0);
+        Assert.assertTrue(buttonElement.getPropertyBoolean("foo"));
+    }
+
+    @Test
+    public void getSetBooleanProperty() {
+        openTestURL();
+
+        TestBenchElement buttonElement = (TestBenchElement) findElements(
+                By.className("v-button")).get(0);
+
+        Assert.assertNull(buttonElement.getPropertyBoolean("foo"));
+        buttonElement.setProperty("foo", true);
+        Assert.assertEquals("true", buttonElement.getPropertyString("foo"));
+        Assert.assertEquals(1.0, buttonElement.getPropertyDouble("foo"), 0);
+        Assert.assertTrue(buttonElement.getPropertyBoolean("foo"));
+    }
+
+    @Test
+    public void getSetDoubleProperty() {
+        openTestURL();
+
+        TestBenchElement buttonElement = (TestBenchElement) findElements(
+                By.className("v-button")).get(0);
+
+        Assert.assertNull(buttonElement.getPropertyDouble("foo"));
+        buttonElement.setProperty("foo", 12.5);
+        Assert.assertEquals("12.5", buttonElement.getPropertyString("foo"));
+        Assert.assertEquals(12.5, buttonElement.getPropertyDouble("foo"), 0);
+        Assert.assertTrue(buttonElement.getPropertyBoolean("foo"));
+    }
+
+}


### PR DESCRIPTION
If a property is set using one type and retrieved as another type, it is converted automatically according to JavaScript conversion rules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/920)
<!-- Reviewable:end -->
