### PR TITLE
Updated add-on urls, old ones deprecated/not working

### DIFF
--- a/vaadin-testbench-api/pom.xml
+++ b/vaadin-testbench-api/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>vaadin-addons</id>
-            <url>https://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>http://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
     <licenses>
@@ -38,7 +38,7 @@
                 <repository>
                     <id>vaadin-addons</id>
                     <name>Vaadin add-ons repository</name>
-                    <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+                    <url>http://maven.vaadin.com/vaadin-addons</url>
                 </repository>
             </distributionManagement>
             <build>


### PR DESCRIPTION
The build of the test bench api for Vaadin 7.7.11 fails due to non-working deployment url. The vaadin.com/nexus-urls are deprecated. This is an attempt to fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/926)
<!-- Reviewable:end -->
