### PR TITLE
update Vaadin Nexus urls to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
          <repository>
              <id>vaadin-addons</id>
              <name>Vaadin add-ons repository</name>
-             <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+             <url>https://tools.vaadin.com/nexus/content/repositories/vaadin-addons</url>
          </repository>
      </distributionManagement>
     

--- a/testbench-integration-tests/pom.xml
+++ b/testbench-integration-tests/pom.xml
@@ -25,7 +25,7 @@
         </repository>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
     <build>

--- a/vaadin-testbench-api/pom.xml
+++ b/vaadin-testbench-api/pom.xml
@@ -38,7 +38,7 @@
                 <repository>
                     <id>vaadin-addons</id>
                     <name>Vaadin add-ons repository</name>
-                    <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+                    <url>https://tools.vaadin.com/nexus/content/repositories/vaadin-addons</url>
                 </repository>
             </distributionManagement>
             <build>

--- a/vaadin-testbench-assembly/pom.xml
+++ b/vaadin-testbench-assembly/pom.xml
@@ -30,7 +30,7 @@
     <repositories>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
 

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -41,7 +41,7 @@
                 <repository>
                     <id>vaadin-addons</id>
                     <name>Vaadin add-ons repository</name>
-                    <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+                    <url>https://tools.vaadin.com/nexus/content/repositories/vaadin-addons</url>
                 </repository>
             </distributionManagement>
             <build>

--- a/vaadin-testbench-standalone/pom.xml
+++ b/vaadin-testbench-standalone/pom.xml
@@ -37,7 +37,7 @@
         </repository>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
 

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -30,7 +30,7 @@
     <repositories>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
 
@@ -42,7 +42,7 @@
         </snapshotRepository>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://tools.vaadin.com/nexus/content/repositories/vaadin-addons</url>
         </repository>
     </distributionManagement>
     <build>


### PR DESCRIPTION
[partially adopted from #926]

In distribution management: http://vaadin.com/nexus/ -> https://tools.vaadin.com/nexus/
In repositories: http://vaadin.com/nexus/content/repositories/vaadin-addons -> https://maven.vaadin.com/vaadin-addons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/929)
<!-- Reviewable:end -->
