### PR TITLE
update Vaadin Nexus urls to the latest version (#929)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
          <repository>
              <id>vaadin-addons</id>
              <name>Vaadin add-ons repository</name>
-             <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+             <url>https://maven.vaadin.com/vaadin-addons</url>
          </repository>
      </distributionManagement>
     

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -27,7 +27,7 @@
         </repository>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <repository>
             <id>vaadin-prereleases</id>

--- a/vaadin-testbench-standalone/pom.xml
+++ b/vaadin-testbench-standalone/pom.xml
@@ -36,7 +36,7 @@
         </repository>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <repository>
             <id>vaadin-prereleases</id>

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -41,7 +41,7 @@
                 <repository>
                     <id>vaadin-addons</id>
                     <name>Vaadin add-ons repository</name>
-                    <url>http://vaadin.com/nexus/content/repositories/vaadin-addons</url>
+                    <url>https://tools.vaadin.com/nexus/</url>
                 </repository>
             </distributionManagement>
             <build>


### PR DESCRIPTION
In distribution management: http://vaadin.com/nexus/ -> https://tools.vaadin.com/nexus/
In repositories: http://vaadin.com/nexus/content/repositories/vaadin-addons -> https://maven.vaadin.com/vaadin-addons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/931)
<!-- Reviewable:end -->
