### PR TITLE
Use system properties for Saucelabs credentials 

### DIFF
--- a/vaadin-testbench-integration-tests/.gitignore
+++ b/vaadin-testbench-integration-tests/.gitignore
@@ -14,6 +14,7 @@ target/
 .driver
 error-screenshots
 selenium_standalone_zips
+local.properties
 
 # macOs
 .DS_Store

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -116,6 +116,10 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <systemPropertyVariables>
+                        <sauce.user>${sauce.user}</sauce.user>
+                        <sauce.sauceAccessKey>${sauce.sauceAccessKey}</sauce.sauceAccessKey>
+                    </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
@@ -130,10 +134,6 @@
                         <version>1.129</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <sauceUsername>${SAUCE_USERNAME}</sauceUsername>
-                    <sauceAccessKey>${SAUCE_ACCESS_KEY}</sauceAccessKey>
-                </configuration>
                 <executions>
                     <!-- Start Sauce Connect prior to running the integration 
                         tests -->
@@ -152,6 +152,26 @@
                         <goals>
                             <goal>stop-sauceconnect</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>read-local-properties-if-present</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>local.properties</file>
+                            </files>
+                            <quiet>true</quiet>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/PrivateTB3Configuration.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/PrivateTB3Configuration.java
@@ -64,10 +64,19 @@ public abstract class PrivateTB3Configuration extends AbstractTB3Test {
 
     @Override
     protected String getHubURL() {
-        String username = System.getenv("SAUCE_USERNAME");
-        String accessKey = System.getenv("SAUCE_ACCESS_KEY");
+        String username = System.getProperty("sauce.user");
+        String accessKey = System.getProperty("sauce.sauceAccessKey");
 
-        return "http://" + username + ":" + accessKey + "@localhost:4445/wd/hub";
+        if (username == null) {
+            throw new IllegalArgumentException(
+                    "You must give a Sauce Labs user name using -Dsauce.user=<username> or by adding sauce.user=<username> to local.properties");
+        }
+        if (accessKey == null) {
+            throw new IllegalArgumentException(
+                    "You must give a Sauce Labs access key using -Dsauce.sauceAccessKey=<accesskey> or by adding sauce.sauceAccessKey=<accesskey> to local.properties");
+        }
+        return "http://" + username + ":" + accessKey
+                + "@localhost:4445/wd/hub";
     }
 
     public static String getProperty(String name) {


### PR DESCRIPTION
Locally you can define credentials in vaadin-testbench-integration-tests/local.properties as e.g.
```
sauce.user=myusername
sauce.sauceAccessKey=myaccesskey
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/938)
<!-- Reviewable:end -->
