### PR TITLE
Add a runtime check that the expected Selenium version is found

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
@@ -13,6 +13,9 @@
 package com.vaadin.testbench;
 
 import java.util.List;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.Rule;
 import org.openqa.selenium.JavascriptExecutor;
@@ -21,6 +24,7 @@ import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.BuildInfo;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -42,6 +46,30 @@ public abstract class TestBenchTestCase
         // Check the license here, before any driver has been initialized
         // (#15102)
         LicenseChecker.nag();
+    }
+
+    static {
+        try {
+            String seleniumVersion = new BuildInfo().getReleaseLabel();
+
+            Properties properties = new Properties();
+            properties.load(TestBenchTestCase.class
+                    .getResourceAsStream("testbench.properties"));
+            String expectedVersion = properties.getProperty("selenium.version");
+            if (seleniumVersion == null
+                    || !seleniumVersion.equals(expectedVersion)) {
+                Logger.getLogger(TestBenchTestCase.class.getName()).warning(
+                        "This version of TestBench depends on Selenium version "
+                                + expectedVersion + " but version "
+                                + seleniumVersion
+                                + " was found. Make sure you do not have multiple versions of Selenium on the classpath.");
+            }
+        } catch (Exception e) {
+            Logger.getLogger(TestBenchTestCase.class.getName()).log(
+                    Level.WARNING,
+                    "Unable to validate that the correct Selenium version is in use",
+                    e);
+        }
     }
 
     /**

--- a/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/testbench.properties
+++ b/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/testbench.properties
@@ -1,0 +1,1 @@
+selenium.version=${selenium.version}


### PR DESCRIPTION
This is a back-port of #961

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/962)
<!-- Reviewable:end -->
