### PR TITLE
add unique Sauce Connect tunnel ID for each build

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -23,6 +23,8 @@
         <node.version>v8.1.2</node.version>
         <yarn.version>v0.27.5</yarn.version>
         <buildtools.directory>build-tools</buildtools.directory>
+
+        <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
     </properties>
     <repositories>
         <repository>
@@ -56,6 +58,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.saucelabs</groupId>
+            <artifactId>ci-sauce</artifactId>
+            <version>1.129</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -136,6 +144,7 @@
                     <systemPropertyVariables>
                         <sauce.user>${sauce.user}</sauce.user>
                         <sauce.sauceAccessKey>${sauce.sauceAccessKey}</sauce.sauceAccessKey>
+                        <sauce.options>${sauce.options}</sauce.options>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -15,9 +15,8 @@
 
     <url>http://maven.apache.org</url>
     <properties>
-        <snapshot.repository.url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/
-        </snapshot.repository.url>
         <jetty.version>9.3.12.v20160915</jetty.version>
+        <vaadin.version>10.0.0.alpha7</vaadin.version>
 
         <!-- Frontend -->
         <node.version>v8.1.2</node.version>
@@ -32,13 +31,6 @@
             <url>https://repo.vaadin.com/nexus/content/repositories/flow</url>
         </repository>
         <repository>
-            <id>flow-internal-snapshots</id>
-            <url>https://repo.vaadin.com/nexus/content/repositories/flow-snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>vaadin-addons</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
@@ -48,11 +40,28 @@
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-bom</artifactId>
+                <version>${vaadin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin</artifactId>
+                <version>${vaadin.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <artifactId>vaadin</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Pass a unique value (the maven build timestamp) as a tunnel id to the sauce connect plugin to ensure two builds started from two machines around the same time would not interfere with one another.

+ switch the flow dependency from SNAPSHOT to a specific version

fixes #959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/965)
<!-- Reviewable:end -->
