### PR TITLE
do not run the 'deploy' maven goal twice in release builds

### DIFF
--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -71,14 +71,6 @@
                             </excludes>
                         </configuration>
                     </plugin>
-
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.5</version>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
The current release build in TC runs `mvn clean install deploy -Prelease` which triggers deployment twice. This change removes the 'deploy' goal from the 'release' profile so that deployment happens only once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/972)
<!-- Reviewable:end -->

  