### PR TITLE
Use JS click() instead of a simulated mouse click to avoid 'element is not clickable at point'

### DIFF
--- a/vaadin-testbench-integration-tests/src/main/java/com/vaadin/testUI/SVGView.java
+++ b/vaadin-testbench-integration-tests/src/main/java/com/vaadin/testUI/SVGView.java
@@ -1,0 +1,25 @@
+package com.vaadin.testUI;
+
+import com.vaadin.router.Route;
+import com.vaadin.ui.event.AttachEvent;
+import com.vaadin.ui.html.Div;
+
+@Route("SVGView")
+public class SVGView extends Div {
+
+    private Div placeholder;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        add(placeholder = new Div());
+
+        placeholder.getElement().setProperty("innerHTML",
+                "<svg height=\"100\" width=\"100\">\n"
+                        + "  <circle id='ball' cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\" />\n"
+                        + "  Sorry, your browser does not support inline SVG."
+                        + "</svg>");
+        attachEvent.getUI().getPage().executeJavaScript(
+                "document.getElementById('ball').addEventListener('click', function() {document.body.innerText='clicked';})");
+    }
+}

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/SVGIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/SVGIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.testUI.SVGView;
+import com.vaadin.ui.Component;
+
+public class SVGIT extends MultiBrowserTest {
+
+    @Override
+    protected Class<? extends Component> getTestView() {
+        return SVGView.class;
+    }
+
+    @Test
+    public void click() {
+        openTestURL();
+        findElement(By.id("ball")).click();
+        Assert.assertEquals("clicked",
+                findElement(By.tagName("body")).getText());
+    }
+}

--- a/vaadin-testbench/src/main/java/com/vaadin/testbench/TestBenchElement.java
+++ b/vaadin-testbench/src/main/java/com/vaadin/testbench/TestBenchElement.java
@@ -183,9 +183,15 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
 
     @Override
     public void click() {
-        autoScrollIntoView();
-        waitForVaadin();
-        wrappedElement.click();
+        try {
+            // Avoid strange "element not clickable at point" problems
+            callFunction("click");
+        } catch (Exception e) {
+            // SVG elements and maybe others do not have a 'click' method
+            autoScrollIntoView();
+            waitForVaadin();
+            wrappedElement.click();
+        }
     }
 
     @Override
@@ -256,16 +262,6 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
         waitForVaadin();
         return wrapElement(wrappedElement.findElement(by),
                 getCommandExecutor());
-    }
-
-    /**
-     * Calls the Javascript click method on the element.
-     *
-     * Useful for elements that are hidden or covered by a pseudo-element on
-     * some browser-theme combinations (for instance Firefox-Valo)
-     */
-    public void clickHiddenElement() {
-        callFunction("click");
     }
 
     @Override


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/981)
<!-- Reviewable:end -->
