### PR TITLE
Do not fail if scrollIntoView fails

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchElement.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchElement.java
@@ -489,10 +489,13 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * element is not displayed
      */
     private void autoScrollIntoView() {
-        if (getCommandExecutor().isAutoScrollIntoView()) {
-            if (!wrappedElement.isDisplayed()) {
-                scrollIntoView();
+        try {
+            if (getCommandExecutor().isAutoScrollIntoView()) {
+                if (!wrappedElement.isDisplayed()) {
+                    scrollIntoView();
+                }
             }
+        } catch (Exception e) {
         }
     }
 


### PR DESCRIPTION
Some Safari web driver versions always fails on element.isDisplayed...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/987)
<!-- Reviewable:end -->
