### PR TITLE
Fix ElementQuery for built-in elements or elements without a shadow root

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ElementQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ElementQuery.java
@@ -259,15 +259,15 @@ public class ElementQuery<T extends TestBenchElement> {
         TestBenchElement elementContext;
         JavascriptExecutor executor;
         if (getContext() instanceof TestBenchElement) {
-            script.append(
-                    "var result = arguments[0].shadowRoot.querySelectorAll(arguments[1]+arguments[2]);");
-            script.append(
-                    "var light = arguments[0].querySelectorAll(arguments[1]+arguments[2]);");
-            script.append("if (light.length > 0) {");
-            script.append(
-                    "result = Array.prototype.slice.call(result).concat(Array.prototype.slice.call(light));");
-            script.append("}");
-            script.append("return result");
+            script.append("var result = [];" //
+                    + "if (arguments[0].shadowRoot) {" //
+                    + "  var shadow = arguments[0].shadowRoot.querySelectorAll(arguments[1]+arguments[2]);" //
+                    + "  result = result.concat(Array.prototype.slice.call(shadow));" //
+                    + "}" //
+                    + "var light = arguments[0].querySelectorAll(arguments[1]+arguments[2]);" //
+                    + "result = result.concat(Array.prototype.slice.call(light));" //
+                    + "return result" //
+            );
             elementContext = (TestBenchElement) getContext();
             executor = elementContext.getCommandExecutor().getDriver();
         } else if (getContext() instanceof WebDriver) {

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
@@ -99,4 +99,14 @@ public class ElementQueryIT extends AbstractTB6Test {
                 .waitForFirst().$(TestBenchElement.class).id("shadow-button-2");
         Assert.assertNotNull(button);
     }
+
+    @Test
+    public void findTestBenchElementChild() throws Exception {
+        openTestURL();
+
+        TestBenchElement button = $(PolymerTemplateViewElement.class)
+                .waitForFirst().$(TestBenchElement.class).first()
+                .$(TestBenchElement.class).first();
+        Assert.assertEquals("Shadow Button 1", button.getText());
+    }
 }


### PR DESCRIPTION
Fixes #989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/990)
<!-- Reviewable:end -->
