### PR TITLE
Yey, more Firefox 59 workarounds

### DIFF
--- a/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/cyclic-object-workaround.js
+++ b/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/cyclic-object-workaround.js
@@ -3,7 +3,7 @@ if (jsObject && jsObject.forEach) {
 		Object.keys(e).filter(
 			function(k) {
 				return e.hasOwnProperty(k)
-						&& (k.indexOf('__') == 0 || k == '$') && e[k];
+						&& (k.indexOf('__') == 0 || k == '$' || k == 'X') && e[k];
 		}).forEach(function(key) {
 				e[key].toJSON = function() {
 					return;


### PR DESCRIPTION
Webcomponentsjs 1.1.1 sets an `X` property also..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1042)
<!-- Reviewable:end -->
