### PR TITLE
Remove mention of deprecated recorder

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
@@ -34,8 +34,7 @@ import com.vaadin.testbench.commands.TestBenchCommandExecutor;
 import com.vaadin.testbench.commands.TestBenchCommands;
 
 /**
- * A superclass with some helpers to aid TestBench developers. This superclass
- * is also used by tests created by the Recorder.
+ * A superclass with some helpers to aid TestBench developers.
  */
 public abstract class TestBenchTestCase
         implements HasDriver, HasTestBenchCommandExecutor, HasElementQuery {


### PR DESCRIPTION
Recorder was dropped in 4.0 in favor of ElementQuery and TestBench section in the debug window

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1048)
<!-- Reviewable:end -->
