### PR TITLE
Make CyclicObjectWorkaround specific for firefox

### DIFF
--- a/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/cyclic-object-workaround.js
+++ b/vaadin-testbench-core/src/main/resources/com/vaadin/testbench/cyclic-object-workaround.js
@@ -1,13 +1,16 @@
-if (jsObject && jsObject.forEach) {
-	jsObject.forEach(function(e) {
-		Object.keys(e).filter(
-			function(k) {
-				return e.hasOwnProperty(k)
-						&& (k.indexOf('__') == 0 || k == '$' || k == 'X') && e[k];
-		}).forEach(function(key) {
-				e[key].toJSON = function() {
-					return;
-				}
+if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1){
+	if (jsObject && jsObject.forEach) {
+		jsObject.forEach(function(e) {
+			Object.keys(e).filter(
+				function(k) {
+					return e.hasOwnProperty(k)
+							&& (k.indexOf('_') == 0 || k == '$' || k == 'X') && e[k];
+			}).forEach(function(key) {
+					e[key].toJSON = function() {
+						return;
+					}
+			});
 		});
-	});
-};
+	};
+}
+


### PR DESCRIPTION
Also consider protected properties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1050)
<!-- Reviewable:end -->
