### PR TITLE
Use fixed version of webcomponentsjs

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>polymer</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>webcomponentsjs</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -72,10 +72,11 @@
             <artifactId>polymer</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <!--PIN webcomponentsjs as workaround for https://github.com/webjars/webjars/issues/1763-->
         <dependency>
             <groupId>org.webjars.bowergithub.webcomponents</groupId>
             <artifactId>webcomponentsjs</artifactId>
-            <version>1.2.0</version>
+            <version>[1.0.0,1.999.999)</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Incorrect range in polymer webjar resolves to webcomponentsjs 2.0.0.beta2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1057)
<!-- Reviewable:end -->
