### PR TITLE
Allow customising ReferenceNameGenerator

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
@@ -172,11 +172,11 @@ public class ScreenshotComparator {
             String referenceName, ImageComparison imageComparison,
             TakesScreenshot takesScreenshot, HasCapabilities driver)
             throws IOException {
+        Capabilities capabilities = driver.getCapabilities();
         for (int times = 0; times < Parameters
                 .getMaxScreenshotRetries(); times++) {
             BufferedImage screenshotImage = getScreenshot(
-                    (TakesScreenshot) driver, takesScreenshot,
-                    driver.getCapabilities());
+                    (TakesScreenshot) driver, takesScreenshot, capabilities);
             if (reference == null) {
                 // Store the screenshot in the errors directory and fail the
                 // test

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
@@ -174,9 +174,9 @@ public class ScreenshotComparator {
             throws IOException {
         for (int times = 0; times < Parameters
                 .getMaxScreenshotRetries(); times++) {
-            BufferedImage screenshotImage = ImageIO
-                    .read(new ByteArrayInputStream(
-                            takesScreenshot.getScreenshotAs(OutputType.BYTES)));
+            BufferedImage screenshotImage = getScreenshot(
+                    (TakesScreenshot) driver, takesScreenshot,
+                    driver.getCapabilities());
             if (reference == null) {
                 // Store the screenshot in the errors directory and fail the
                 // test

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -49,7 +50,7 @@ public class TestBenchCommandExecutor
 
     private final WebDriver actualDriver;
     private final ImageComparison imageComparison;
-    private final ReferenceNameGenerator referenceNameGenerator;
+    private ReferenceNameGenerator referenceNameGenerator;
     private boolean enableWaitForVaadin = true;
     private boolean autoScrollIntoView = true;
 
@@ -346,13 +347,15 @@ public class TestBenchCommandExecutor
         assert (ret == null);
     }
 
-    /**
-     * Gets the name generator used for screenshot references.
-     *
-     * @return the name generator for screenshot references
-     */
     public ReferenceNameGenerator getReferenceNameGenerator() {
         return referenceNameGenerator;
+    }
+
+    public void setReferenceNameGenerator(
+            ReferenceNameGenerator nameGenerator) {
+        Objects.requireNonNull(nameGenerator,
+                "ReferenceNameGenerator can not be null");
+        referenceNameGenerator = nameGenerator;
     }
 
     /**

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommands.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommands.java
@@ -12,6 +12,12 @@
  */
 package com.vaadin.testbench.commands;
 
+import java.util.function.BiFunction;
+
+import org.openqa.selenium.Capabilities;
+
+import com.vaadin.testbench.screenshot.ReferenceNameGenerator;
+
 public interface TestBenchCommands
         extends CanWaitForVaadin, CanCompareScreenshots {
 
@@ -146,4 +152,36 @@ public interface TestBenchCommands
      */
     void resizeViewPortTo(int width, int height)
             throws UnsupportedOperationException;
+
+    /**
+     * Gets the name generator used for screenshot references.
+     *
+     * @return the name generator for screenshot references
+     */
+    public ReferenceNameGenerator getReferenceNameGenerator();
+
+    /**
+     * Sets the name generator used for screenshot references.
+     *
+     * @param nameGenerator
+     *            the name generator for screenshot references
+     */
+    public void setReferenceNameGenerator(ReferenceNameGenerator nameGenerator);
+
+    /**
+     * Sets the name generator used for screenshot references.
+     *
+     * @param nameGenerator
+     *            the name generator for screenshot references
+     */
+    public default void setReferenceNameGenerator(
+            BiFunction<String, Capabilities, String> nameGenerator) {
+        setReferenceNameGenerator(new ReferenceNameGenerator() {
+            @Override
+            public String generateName(String referenceId,
+                    Capabilities browserCapabilities) {
+                return nameGenerator.apply(referenceId, browserCapabilities);
+            }
+        });
+    }
 }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommands.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommands.java
@@ -158,7 +158,7 @@ public interface TestBenchCommands
      *
      * @return the name generator for screenshot references
      */
-    public ReferenceNameGenerator getReferenceNameGenerator();
+    ReferenceNameGenerator getReferenceNameGenerator();
 
     /**
      * Sets the name generator used for screenshot references.
@@ -166,7 +166,7 @@ public interface TestBenchCommands
      * @param nameGenerator
      *            the name generator for screenshot references
      */
-    public void setReferenceNameGenerator(ReferenceNameGenerator nameGenerator);
+    void setReferenceNameGenerator(ReferenceNameGenerator nameGenerator);
 
     /**
      * Sets the name generator used for screenshot references.
@@ -174,7 +174,7 @@ public interface TestBenchCommands
      * @param nameGenerator
      *            the name generator for screenshot references
      */
-    public default void setReferenceNameGenerator(
+    default void setReferenceNameGenerator(
             BiFunction<String, Capabilities, String> nameGenerator) {
         setReferenceNameGenerator(new ReferenceNameGenerator() {
             @Override

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/commands/TestBenchCommandExecutorTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/commands/TestBenchCommandExecutorTest.java
@@ -126,7 +126,7 @@ public class TestBenchCommandExecutorTest {
         File referenceFile = ImageLoader.getImageFile(IMG_FOLDER,
                 "cursor-bottom-edge-off.png");
 
-        WebDriver driver = mockScreenshotDriver(1, false);
+        WebDriver driver = mockScreenshotDriver(1, true);
         ImageComparison icMock = createMock(ImageComparison.class);
         expect(
                 icMock.imageEqualToReference(isA(BufferedImage.class),
@@ -150,7 +150,7 @@ public class TestBenchCommandExecutorTest {
             File referenceFile = ImageLoader.getImageFile(IMG_FOLDER,
                     "cursor-bottom-edge-off.png");
 
-            WebDriver driver = mockScreenshotDriver(4, false);
+            WebDriver driver = mockScreenshotDriver(4, true);
             ImageComparison icMock = createMock(ImageComparison.class);
             expect(
                     icMock.imageEqualToReference(isA(BufferedImage.class),
@@ -174,7 +174,7 @@ public class TestBenchCommandExecutorTest {
     public void testCompareScreen_acceptsBufferedImage() throws IOException {
         BufferedImage mockImg = createNiceMock(BufferedImage.class);
 
-        WebDriver driver = mockScreenshotDriver(1, false);
+        WebDriver driver = mockScreenshotDriver(1, true);
         ImageComparison icMock = createMock(ImageComparison.class);
         expect(
                 icMock.imageEqualToReference(isA(BufferedImage.class),
@@ -197,7 +197,7 @@ public class TestBenchCommandExecutorTest {
         try {
             BufferedImage mockImg = createNiceMock(BufferedImage.class);
 
-            WebDriver driver = mockScreenshotDriver(4, false);
+            WebDriver driver = mockScreenshotDriver(4, true);
             ImageComparison icMock = createMock(ImageComparison.class);
             expect(
                     icMock.imageEqualToReference(isA(BufferedImage.class),


### PR DESCRIPTION
This patch adds an API to change the used ReferenceNameGenerator to a custom one.

Fixes #1060
Fixes #1059

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1062)
<!-- Reviewable:end -->
