### PR TITLE
Don't encourage xpath in docs

### DIFF
--- a/documentation/testbench-advanced-testing-concepts.asciidoc
+++ b/documentation/testbench-advanced-testing-concepts.asciidoc
@@ -50,7 +50,7 @@ the web page.
 
 
 ```java
-waitUntil(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@title='Debug message log']"));
+waitUntil(ExpectedConditions.presenceOfElementLocated(By.id("first")));
 ```
 
 The above waits until the specified element is present or times out after


### PR DESCRIPTION
Usage of xpath is limited now due to shadow dom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1065)
<!-- Reviewable:end -->
