### PR TITLE
Always return a list on TestBenchDriverProxy#executeSearch

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchDriverProxy.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchDriverProxy.java
@@ -151,8 +151,7 @@ public class TestBenchDriverProxy extends TestBenchCommandExecutor implements
                 + "var elements = [];"
                 + "for (client in clients) {" + elementSelectionString
                 + "  if (element) {" + " elements = elements.concat(element);" + "  }" + "}"
-                + "if (elements.length > 0) {" + " return elements;" + "}"
-                + "return null;";
+                + "return elements;";
 
         WebDriver driver = ((HasDriver) context).getDriver();
 


### PR DESCRIPTION
Last change was returning null if list of elements was empty which potentially changes the contract of returning an empty list when no element is found with given selector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1069)
<!-- Reviewable:end -->
