### PR TITLE
 Return all elements found by selector in all Vaadin clients

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchDriverProxy.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchDriverProxy.java
@@ -118,7 +118,7 @@ public class TestBenchDriverProxy extends TestBenchCommandExecutor implements
 
     /**
      * Finds a list of elements by a Vaadin selector string.
-     * 
+     *
      * @param selector
      *            TestBench4 style Vaadin selector.
      * @param context
@@ -148,9 +148,10 @@ public class TestBenchDriverProxy extends TestBenchCommandExecutor implements
         }
 
         String findByVaadinScript = "var clients = window.vaadin.clients;"
+                + "var elements = [];"
                 + "for (client in clients) {" + elementSelectionString
-                + "  if (element) {" + " return element;" + "  }" + "}"
-                + "return null;";
+                + "  if (element) {" + " elements = elements.concat(element);" + "  }" + "}"
+                + "return elements;";
 
         WebDriver driver = ((HasDriver) context).getDriver();
 
@@ -177,6 +178,7 @@ public class TestBenchDriverProxy extends TestBenchCommandExecutor implements
                 if (context instanceof WebDriver) {
                     Object output = jse.executeScript(findByVaadinScript,
                             selector);
+
                     elements.addAll(extractWebElements(output));
                 } else {
                     Object output = jse.executeScript(findByVaadinScript,


### PR DESCRIPTION
Change JS logic to accumulate all elements found by Vaadin clients instead of returning only for the first client

Fixes #756

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1071)
<!-- Reviewable:end -->
