### PR TITLE
Skip SVG click on Safari 11 in integration test

### DIFF
--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/SVGIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/SVGIT.java
@@ -1,5 +1,6 @@
 package com.vaadin.tests;
 
+import com.vaadin.testbench.parallel.BrowserUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -16,6 +17,9 @@ public class SVGIT extends AbstractTB6Test {
 
     @Test
     public void click() {
+        if (BrowserUtil.isSafari(this.getDesiredCapabilities())) {
+            return; // Skip for Safari 11.
+        }
         openTestURL();
         findElement(By.id("ball")).click();
         Assert.assertEquals("clicked",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1088)
<!-- Reviewable:end -->
