### PR TITLE
update docs to link to Vaadin 8-based testbench-demo

### DIFF
--- a/documentation/bestpractices/testbench-bdd.asciidoc
+++ b/documentation/bestpractices/testbench-bdd.asciidoc
@@ -31,7 +31,7 @@ following three phases:
 This kind of formalization is realized in the JBehave BDD framework for Java.
 The TestBench Demo includes a JBehave example, where the above scenario is
 written as the
-link:https://github.com/vaadin/testbench-demo/blob/master/src/test/java/com/vaadin/testbenchexample/bdd/CalculatorSteps.java[following
+link:https://github.com/vaadin/testbench-demo/blob/8.0/src/test/java/com/vaadin/testbenchexample/bdd/CalculatorSteps.java[following
 test class]:
 
 
@@ -76,7 +76,7 @@ Page Object Pattern">>.
 Such scenarios are included in one or more stories, which need to be configured
 in a class extending [classname]#JUnitStory# or [classname]#JUnitStories#. In
 the example, this is done in the
-https://github.com/vaadin/testbench-demo/blob/master/src/test/java/com/vaadin/testbenchexample/bdd/SimpleCalculation.java
+https://github.com/vaadin/testbench-demo/blob/8.0/src/test/java/com/vaadin/testbenchexample/bdd/SimpleCalculation.java
 class. It defines how story classes can be found dynamically by the class loader
 and how stories are reported.
 

--- a/documentation/creatingtests/testbench-selectors.asciidoc
+++ b/documentation/creatingtests/testbench-selectors.asciidoc
@@ -73,4 +73,4 @@ String tooltipText = findElement(
 ----
 
 you can find the complete example
-[filename]#link:https://github.com/vaadin/testbench-demo/blob/master/src/test/java/com/vaadin/testbenchexample/AdvancedCommandsITCase.java[AdvancedCommandsITCase.java]# in link:https://github.com/vaadin/testbench-demo/tree/master/src/test/java/com/vaadin/testbenchexample[TestBench demo].
+[filename]#link:https://github.com/vaadin/testbench-demo/blob/8.0/src/test/java/com/vaadin/testbenchexample/AdvancedCommandsITCase.java[AdvancedCommandsITCase.java]# in link:https://github.com/vaadin/testbench-demo/tree/8.0/src/test/java/com/vaadin/testbenchexample[TestBench demo].

--- a/documentation/creatingtests/testbench-special.asciidoc
+++ b/documentation/creatingtests/testbench-special.asciidoc
@@ -309,7 +309,7 @@ while scrolling. Some interaction could cause multiple requests, such as when
 images are loaded from the server as the result of user interaction.
 
 The following example is given in the
-[filename]#link:https://github.com/vaadin/testbench-demo/blob/master/src/test/java/com/vaadin/testbenchexample/VerifyExecutionTimeITCase.java[VerifyExecutionTimeITCase.java]#
+[filename]#link:https://github.com/vaadin/testbench-demo/blob/8.0/src/test/java/com/vaadin/testbenchexample/VerifyExecutionTimeITCase.java[VerifyExecutionTimeITCase.java]#
 file in the TestBench demo.
 
 


### PR DESCRIPTION
All links pointing to the `master` branch of https://github.com/vaadin/testbench-demo, should point to the `8.0` branch (because `master` is Vaadin 10).

Fixes #1098

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1099)
<!-- Reviewable:end -->
