### PR TITLE
Fix typo in note about PhantomJS

### DIFF
--- a/documentation/testbench-ci-server.asciidoc
+++ b/documentation/testbench-ci-server.asciidoc
@@ -65,7 +65,7 @@ setDriver(new FirefoxDriver(options));
 The `--disable-gpu` flag is only needed on Windows and until http://crbug.com/737678 is resolved but it should not hurt on other platforms.
 
 [NOTE]
-Prevoiusly PhantomJS was recommended as a good way to do headless testing. You should no longer use PhantomJS as it has fallen far behind the latest browser versions and will likely not work properly with Vaadin platform.
+Previously PhantomJS was recommended as a good way to do headless testing. You should no longer use PhantomJS as it has fallen far behind the latest browser versions and will likely not work properly with Vaadin platform.
 
 
 [[testbench.ci-server.independent-tests]]


### PR DESCRIPTION
Changed "Prevoiusly" to "Previously". Should be self explanatory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1101)
<!-- Reviewable:end -->
