### PR TITLE
remove the deprecated method from code example

### DIFF
--- a/documentation/testbench-screenshots.asciidoc
+++ b/documentation/testbench-screenshots.asciidoc
@@ -39,7 +39,6 @@ public void setUp() throws Exception {
     Parameters.setScreenshotComparisonTolerance(1.0);
     Parameters.setScreenshotRetryDelay(10);
     Parameters.setScreenshotComparisonCursorDetection(true);
-    Parameters.setCaptureScreenshotOnFailure(true);
 }
 ```
 


### PR DESCRIPTION
Parameters.setCaptureScreenshotOnFailure(true) is deprecated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1185)
<!-- Reviewable:end -->
