### PR TITLE
Provide a default implementation of getContainerInfo

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -23,13 +23,6 @@
 
       <dependency>
         <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-testbench-it-test-data</artifactId>
-        <scope>test</scope>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-container-runtime-none</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/configuration/TestConfiguration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/configuration/TestConfiguration.java
@@ -35,7 +35,9 @@ public interface TestConfiguration {
 
     List<Target> getBrowserTargets();
 
-    ContainerInfo getContainerInfo();
+    default ContainerInfo getContainerInfo() {
+        return defaultContainerInfo();
+    }
 
     static ContainerInfo defaultContainerInfo() {
         return new ContainerInfo(NetworkFunctions.localIp(),

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/configuration/SampleTestConfiguration.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/configuration/SampleTestConfiguration.java
@@ -17,10 +17,6 @@ package com.vaadin.testbench.configuration;
  * #L%
  */
 
-import com.vaadin.testbench.addons.junit5.extensions.container.ContainerInfo;
-import com.vaadin.testbench.configuration.Target;
-import com.vaadin.testbench.configuration.TestConfiguration;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -29,10 +25,5 @@ public class SampleTestConfiguration implements TestConfiguration {
     @Override
     public List<Target> getBrowserTargets() {
         return Collections.singletonList(TestConfiguration.localSafari());
-    }
-
-    @Override
-    public ContainerInfo getContainerInfo() {
-        return TestConfiguration.defaultContainerInfo();
     }
 }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/configuration/additionaltargetconfiguration/AdditionalTestConfiguration.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/configuration/additionaltargetconfiguration/AdditionalTestConfiguration.java
@@ -17,7 +17,6 @@ package com.vaadin.testbench.configuration.additionaltargetconfiguration;
  * #L%
  */
 
-import com.vaadin.testbench.addons.junit5.extensions.container.ContainerInfo;
 import com.vaadin.testbench.configuration.Target;
 import com.vaadin.testbench.configuration.TestConfiguration;
 
@@ -29,10 +28,5 @@ public class AdditionalTestConfiguration implements TestConfiguration {
     @Override
     public List<Target> getBrowserTargets() {
         return Collections.singletonList(TestConfiguration.localSafari());
-    }
-
-    @Override
-    public ContainerInfo getContainerInfo() {
-        return TestConfiguration.defaultContainerInfo();
     }
 }


### PR DESCRIPTION
. Remove old test-data module dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1215)
<!-- Reviewable:end -->
