### PR TITLE
Update testbench-quickstart.asciidoc

### DIFF
--- a/documentation/testbench-quickstart.asciidoc
+++ b/documentation/testbench-quickstart.asciidoc
@@ -16,7 +16,7 @@ If you do not have a Vaadin application, you can generate it using Maven archety
  [prompt]#$# [command]#mvn# -B archetype:generate \
     -DarchetypeGroupId=com.vaadin \
     -DarchetypeArtifactId=[replaceable]#vaadin-archetype-application# \
-    -DarchetypeVersion=[replaceable]#8.6.x# \
+    -DarchetypeVersion=[replaceable]#8.11.x# \
     -DgroupId=[replaceable]#org.test# \
     -DartifactId=[replaceable]#vaadin-app# \
     -Dversion=[replaceable]#0.1# \
@@ -51,7 +51,7 @@ Add the following dependency declaration just before the end tag ([elementname]#
    <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-testbench</artifactId>
-      <version>4.1.0</version>
+      <version>5.2.0</version>
       <scope>test</scope>
    </dependency>
 ----


### PR DESCRIPTION
Bumped some version numbers. 
Note that the NOTE section probably also needs updating (Firefox ESR is currently 68.8) and I don't know if the issues mentioned still persist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench/1257)
<!-- Reviewable:end -->
