### PR TITLE
Log warning instead of fail test if driver is already closed

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ScreenshotOnFailureRule.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ScreenshotOnFailureRule.java
@@ -17,12 +17,15 @@ import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
 
+import com.vaadin.testbench.screenshot.ImageFileUtil;
+
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-
-import com.vaadin.testbench.screenshot.ImageFileUtil;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 /**
  * This JUnit {@link org.junit.Rule} grabs a screenshot when a test fails.
@@ -99,6 +102,15 @@ public class ScreenshotOnFailureRule extends TestWatcher {
         super.failed(throwable, description);
 
         if (driverHolder.getDriver() == null) {
+            return;
+        }
+
+        WebDriver realDriver = driverHolder.getDriver();
+        while (realDriver instanceof WrapsDriver) {
+            realDriver = ((WrapsDriver)realDriver).getWrappedDriver();
+        }
+        if (realDriver instanceof RemoteWebDriver &&  ((RemoteWebDriver)realDriver).getSessionId() == null) {
+            logger.warning("Unable capture failure screenshot: web driver is no longer available");
             return;
         }
 


### PR DESCRIPTION
If you set up the driver lifecycle incorrectly, the screenshot on failure rule can be called after somebody called `driver.quit()`. In this case you do not want the test to fail because of `org.openqa.selenium.NoSuchSessionException: Session ID is null. Using WebDriver after calling quit()?` rather you want to see the real exception causing the failure