### PR TITLE
chore: Fix deprecation warnings

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
@@ -11,7 +11,6 @@ package com.vaadin.testbench.parallel;
 
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
-import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -87,7 +86,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.IE.equals(capabilities.getBrowserName());
+        return Browser.IE11.name().equals(capabilities.getBrowserName());
     }
 
     /**
@@ -103,7 +102,7 @@ public class BrowserUtil {
             return false;
         }
         return isIE(capabilities)
-                && ("" + version).equals(capabilities.getVersion());
+                && ("" + version).equals(capabilities.getBrowserVersion());
     }
 
     /**
@@ -115,7 +114,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.EDGE.equals(capabilities.getBrowserName());
+        return Browser.EDGE.name().equals(capabilities.getBrowserName());
     }
 
     /**
@@ -127,7 +126,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.CHROME.equals(capabilities.getBrowserName());
+        return Browser.CHROME.name().equals(capabilities.getBrowserName());
     }
 
     /**
@@ -139,7 +138,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.SAFARI.equals(capabilities.getBrowserName());
+        return Browser.SAFARI.name().equals(capabilities.getBrowserName());
     }
 
     /**
@@ -151,7 +150,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.FIREFOX.equals(capabilities.getBrowserName());
+        return Browser.FIREFOX.name().equals(capabilities.getBrowserName());
     }
 
     /**
@@ -191,7 +190,7 @@ public class BrowserUtil {
             return "Unknown";
         }
         try {
-            Platform p = capabilities.getPlatform();
+            Platform p = capabilities.getPlatformName();
             Platform family = p != null ? p.family():null;
             if (family == Platform.WINDOWS || p == Platform.WINDOWS) {
                 return "Windows";
@@ -202,7 +201,7 @@ public class BrowserUtil {
         } catch (Exception e) {
         }
         Object rawPlatform = capabilities
-                .getCapability(CapabilityType.PLATFORM);
+                .getCapability(CapabilityType.PLATFORM_NAME);
         if (rawPlatform == null) {
             return "Unknown";
         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
@@ -9,8 +9,6 @@
  */
 package com.vaadin.testbench.parallel;
 
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
-
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -67,8 +65,8 @@ public class DefaultBrowserFactory implements TestBenchBrowserFactory {
         default:
             desiredCapabilities = new FirefoxOptions();
         }
-        desiredCapabilities.setCapability(CapabilityType.VERSION, version);
-        desiredCapabilities.setCapability(PLATFORM, platform);
+        desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION, version);
+        desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platform);
 
         return new DesiredCapabilities(desiredCapabilities);
     }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
@@ -270,7 +270,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
         String exclude = System.getProperty("browsers.exclude");
 
         for (DesiredCapabilities d : desiredCapabilites) {
-            String browserName = (d.getBrowserName() + d.getVersion())
+            String browserName = (d.getBrowserName() + d.getBrowserVersion())
                     .toLowerCase();
             if (include != null && include.trim().length() > 0) {
                 if (include.trim().toLowerCase().contains(browserName)) {
@@ -519,7 +519,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
             if (capabilities == null) {
                 version = "Unknown";
             } else {
-                version = capabilities.getVersion();
+                version = capabilities.getBrowserVersion();
             }
             return platform + "_" + browser + "_" + version;
         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
@@ -33,7 +33,7 @@ public class ReferenceNameGenerator {
             Capabilities browserCapabilities) {
         String platformString;
 
-        Platform platform = browserCapabilities.getPlatform();
+        Platform platform = browserCapabilities.getPlatformName();
         if (platform != null && platform.family() != null) {
             platform = platform.family();
         }
@@ -56,7 +56,7 @@ public class ReferenceNameGenerator {
      * @return the major version of the browser.
      */
     public static String getMajorVersion(Capabilities browserCapabilities) {
-        String versionString = browserCapabilities.getVersion();
+        String versionString = browserCapabilities.getBrowserVersion();
         if (versionString.equals("")) {
             Object browserVersion = browserCapabilities
                     .getCapability("browserVersion");

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/BrowserUtilTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/BrowserUtilTest.java
@@ -12,6 +12,7 @@ package com.vaadin.testbench;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.parallel.BrowserUtil;
@@ -39,7 +40,7 @@ public class BrowserUtilTest {
     @Test
     public void platformWithoutEnum() {
         DesiredCapabilities dc = new DesiredCapabilities();
-        dc.setCapability("platform", "foobar");
+        dc.setCapability(CapabilityType.PLATFORM_NAME, "foobar");
         Assert.assertEquals("foobar", BrowserUtil.getPlatform(dc));
     }
 }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/DefaultBrowserConfigurationTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/DefaultBrowserConfigurationTest.java
@@ -38,10 +38,10 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method = (TBMethod) testMethods.get(0);
             Assert.assertEquals(caps.getBrowserName(),
                     method.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps.getVersion(),
-                    method.getCapabilities().getVersion());
-            Assert.assertEquals(caps.getPlatform(),
-                    method.getCapabilities().getPlatform());
+            Assert.assertEquals(caps.getBrowserVersion(),
+                    method.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps.getPlatformName(),
+                    method.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }
@@ -66,16 +66,16 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method2 = (TBMethod) testMethods.get(1);
             Assert.assertEquals(caps1.getBrowserName(),
                     method1.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps1.getVersion(),
-                    method1.getCapabilities().getVersion());
-            Assert.assertEquals(caps1.getPlatform(),
-                    method1.getCapabilities().getPlatform());
+            Assert.assertEquals(caps1.getBrowserVersion(),
+                    method1.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps1.getPlatformName(),
+                    method1.getCapabilities().getPlatformName());
             Assert.assertEquals(caps2.getBrowserName(),
                     method2.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps2.getVersion(),
-                    method2.getCapabilities().getVersion());
-            Assert.assertEquals(caps2.getPlatform(),
-                    method2.getCapabilities().getPlatform());
+            Assert.assertEquals(caps2.getBrowserVersion(),
+                    method2.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps2.getPlatformName(),
+                    method2.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }
@@ -95,10 +95,10 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method = (TBMethod) testMethods.get(0);
             Assert.assertEquals(caps.getBrowserName(),
                     method.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps.getVersion(),
-                    method.getCapabilities().getVersion());
-            Assert.assertEquals(caps.getPlatform(),
-                    method.getCapabilities().getPlatform());
+            Assert.assertEquals(caps.getBrowserVersion(),
+                    method.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps.getPlatformName(),
+                    method.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
@@ -35,9 +35,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_shotFirefox11inCapabilities_returnsGeneratedName() {
         Capabilities ffcaps = Mockito.mock(Capabilities.class);
-        Mockito.when(ffcaps.getPlatform()).thenReturn(Platform.XP);
+        Mockito.when(ffcaps.getPlatformName()).thenReturn(Platform.XP);
         Mockito.when(ffcaps.getBrowserName()).thenReturn("Firefox");
-        Mockito.when(ffcaps.getVersion()).thenReturn("13.0.1");
+        Mockito.when(ffcaps.getBrowserVersion()).thenReturn("13.0.1");
         String name = rng.generateName("shot", ffcaps);
         assertEquals("shot_windows_Firefox_13", name);
     }
@@ -46,7 +46,7 @@ public class ReferenceNameGeneratorTest {
     public void testGenerateName_shotNoPlatformInCapabilities_returnsGeneratedName() {
         Capabilities someBrowser = Mockito.mock(Capabilities.class);
         Mockito.when(someBrowser.getBrowserName()).thenReturn("SomeBrowser");
-        Mockito.when(someBrowser.getVersion()).thenReturn("12.3");
+        Mockito.when(someBrowser.getBrowserVersion()).thenReturn("12.3");
         String name = rng.generateName("shot", someBrowser);
         assertEquals("shot_unknown_SomeBrowser_12", name);
     }
@@ -54,9 +54,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_fooSafari5inCapabilities_returnsGeneratedName() {
         Capabilities safari = Mockito.mock(Capabilities.class);
-        Mockito.when(safari.getPlatform()).thenReturn(Platform.MAC);
+        Mockito.when(safari.getPlatformName()).thenReturn(Platform.MAC);
         Mockito.when(safari.getBrowserName()).thenReturn("Safari");
-        Mockito.when(safari.getVersion()).thenReturn("5");
+        Mockito.when(safari.getBrowserVersion()).thenReturn("5");
         String name = rng.generateName("foo", safari);
         assertEquals("foo_mac_Safari_5", name);
     }
@@ -64,10 +64,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_shotEdgeinCapabilities_returnsGeneratedName() {
         Capabilities chrome = Mockito.mock(Capabilities.class);
-        Mockito.when(chrome.getPlatform()).thenReturn(Platform.XP);
+        Mockito.when(chrome.getPlatformName()).thenReturn(Platform.XP);
         Mockito.when(chrome.getBrowserName()).thenReturn("MicrosoftEdge");
-        Mockito.when(chrome.getVersion()).thenReturn("");
-        Mockito.when(chrome.getCapability("browserVersion")).thenReturn("25");
+        Mockito.when(chrome.getBrowserVersion()).thenReturn("25");
         String name = rng.generateName("shot", chrome);
         assertEquals("shot_windows_MicrosoftEdge_25", name);
     }


### PR DESCRIPTION
Use Browser instead of BrowserType
Use getPlatformName instead of getPlatform
Use getBrowserVersion instead of getVersion
