### PR TITLE
chore: Added support for Kotlin sources

### DIFF
--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,6 +25,7 @@
 
     <properties>
         <kotlin.version>1.6.21</kotlin.version>
+        <dokka.version>1.6.21</dokka.version>
     </properties>
     <repositories>
         <repository>
@@ -34,18 +36,41 @@
 
     <profiles>
         <profile>
+            <id>dokka-javadocs</id>
+            <activation>
+                <property>
+                    <name>testbench.javadocs</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadoc</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>attach-javadocs</id>
+                                <phase>package</phase>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>javadocJar</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -61,12 +86,14 @@
                                     <addClasspath>true</addClasspath>
                                     <!-- Implementation-Title and Implementation-Version 
                                         come from the POM by default -->
-                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    <addDefaultImplementationEntries>true
+                                    </addDefaultImplementationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <!-- Package format version - do not 
                                         change -->
-                                    <Vaadin-Package-Version>1</Vaadin-Package-Version>
+                                    <Vaadin-Package-Version>1
+                                    </Vaadin-Package-Version>
                                 </manifestEntries>
                             </archive>
                             <excludes>
@@ -102,18 +129,24 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/kotlin
+                                </sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java
+                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <goals> <goal>test-compile</goal> </goals>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/kotlin
+                                </sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java
+                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
@@ -150,7 +183,40 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <configuration>
+                    <jdkVersion>${maven.compiler.source}</jdkVersion>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.basedir}/src/main/java
+                        </sourceDirectory>
+                        <sourceDirectory>
+                            ${project.basedir}/src/main/kotlin
+                        </sourceDirectory>
+                    </sourceDirectories>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-kotlin-sources-for-source-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -22,6 +22,9 @@
         </license>
     </licenses>
 
+    <properties>
+        <kotlin.version>1.6.21</kotlin.version>
+    </properties>
     <repositories>
         <repository>
             <id>vaadin-prereleases</id>
@@ -88,9 +91,64 @@
 
         <plugins>
             <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.9.0</version>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -216,6 +274,11 @@
             <groupId>com.vaadin.external.gwt</groupId>
             <artifactId>gwt-elemental</artifactId>
             <version>2.8.2.vaadin2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -86,14 +86,12 @@
                                     <addClasspath>true</addClasspath>
                                     <!-- Implementation-Title and Implementation-Version 
                                         come from the POM by default -->
-                                    <addDefaultImplementationEntries>true
-                                    </addDefaultImplementationEntries>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 </manifest>
                                 <manifestEntries>
                                     <!-- Package format version - do not 
                                         change -->
-                                    <Vaadin-Package-Version>1
-                                    </Vaadin-Package-Version>
+                                    <Vaadin-Package-Version>1</Vaadin-Package-Version>
                                 </manifestEntries>
                             </archive>
                             <excludes>
@@ -117,6 +115,11 @@
         </resources>
 
         <plugins>
+            <!--
+                To compile projects that include Kotlin and Java source code, the Kotlin compiler should run before
+                the Java compiler.
+                That means that kotlin-maven-plugin definition must be placed before maven-compiler-plugin
+            -->
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
@@ -129,10 +132,8 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin
-                                </sourceDir>
-                                <sourceDir>${project.basedir}/src/main/java
-                                </sourceDir>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
@@ -143,10 +144,8 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin
-                                </sourceDir>
-                                <sourceDir>${project.basedir}/src/test/java
-                                </sourceDir>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
@@ -190,11 +189,8 @@
                 <configuration>
                     <jdkVersion>${maven.compiler.source}</jdkVersion>
                     <sourceDirectories>
-                        <sourceDirectory>${project.basedir}/src/main/java
-                        </sourceDirectory>
-                        <sourceDirectory>
-                            ${project.basedir}/src/main/kotlin
-                        </sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
                     </sourceDirectories>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description

Configured kotlin-maven-plugin to allow compilation of Kotlin source code along with Java sources.
Replaced maven-javadoc-plugin with dokka-maven-plugin in core module to generate Javadocs also for Kotlin classes.
Attached kotlin source files to sources jar.

Fixes #1328 

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
