### PR TITLE
chore: skip javadocs plugin in core module

### DIFF
--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -44,6 +44,9 @@
                     <name>testbench.javadocs</name>
                 </property>
             </activation>
+            <properties>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
maven javadocs plugin fails when Kotlin source code is referenced
in Java documentation.
Maven javadocs plugin can be skipped because javadocs are generated
by dokka plugin, bound to package phase and activated by relase
profile or by setting testbench.javadocs system property.