### PR TITLE
feat: add button wrapper

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ButtonWrap.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ButtonWrap.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.testbench.unit;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
+
+/**
+ *
+ * Test wrapper for Button components.
+ *
+ * @param <T>
+ *         component type
+ */
+public class ButtonWrap<T extends Button> extends ComponentWrap<T> {
+    /**
+     * Wrap given button for testing.
+     *
+     * @param component
+     *         target button
+     */
+    public ButtonWrap(T component) {
+        super(component);
+    }
+
+    /**
+     * If the component is usable send click to component asi fit was from the client.
+     */
+    public void click() {
+        click(0, new MetaKeys());
+    }
+
+    /**
+     * If the component is usable send click to component asi fit was from the client
+     * with defined meta keys pressed.
+     */
+    public void click(MetaKeys metaKeys) {
+        click(0, metaKeys);
+    }
+
+    /**
+     * Click with middle button.
+     */
+    public void middleClick() {
+        click(1, new MetaKeys());
+    }
+
+    /**
+     * Click with middle button and given meta keys.
+     */
+    public void middleClick(MetaKeys metaKeys) {
+        click(1, metaKeys);
+    }
+
+    /**
+     * Click with right button.
+     */
+    public void rightClick() {
+        click(2, new MetaKeys());
+    }
+
+    /**
+     * Click with right button and given meta keys.
+     */
+    public void rightClick(MetaKeys metaKeys) {
+        click(2, metaKeys);
+    }
+
+    private void click(int button, MetaKeys metaKeys) {
+        if (!isUsable()) {
+            throw new IllegalStateException(
+                    PrettyPrintTreeKt.toPrettyString(getComponent())
+                            + " is not usable");
+        }
+        ComponentUtil.fireEvent(getComponent(),
+                new ClickEvent(getComponent(), true, 0, 0, 0, 0, 0, button,
+                        metaKeys.isCtrl(), metaKeys.isShift(), metaKeys.isAlt(),
+                        metaKeys.isMeta()));
+    }
+}

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/MetaKeys.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/MetaKeys.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.testbench.unit;
+
+/**
+ * Class for setting any down meta keys for events supporting meta keys.
+ */
+public class MetaKeys {
+    private boolean ctrl = false;
+    private boolean shift = false;
+    private boolean alt = false;
+    private boolean meta = false;
+
+    public MetaKeys() {
+    }
+
+    public MetaKeys(boolean ctrl, boolean shift, boolean alt, boolean meta) {
+        this.ctrl = ctrl;
+        this.shift = shift;
+        this.alt = alt;
+        this.meta = meta;
+    }
+
+    public void setCtrl(boolean ctrl) {
+        this.ctrl = ctrl;
+    }
+
+    public void setShift(boolean shift) {
+        this.shift = shift;
+    }
+
+    public void setAlt(boolean alt) {
+        this.alt = alt;
+    }
+
+    public void setMeta(boolean meta) {
+        this.meta = meta;
+    }
+
+    public boolean isCtrl() {
+        return ctrl;
+    }
+
+    public boolean isShift() {
+        return shift;
+    }
+
+    public boolean isAlt() {
+        return alt;
+    }
+
+    public boolean isMeta() {
+        return meta;
+    }
+}

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/TextFieldWrap.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/TextFieldWrap.java
@@ -9,9 +9,6 @@
  */
 package com.vaadin.testbench.unit;
 
-import com.vaadin.flow.component.AbstractField;
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
 import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
 

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ButtonWrapTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ButtonWrapTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.testbench.unit;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.HasValue.ValueChangeListener;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.textfield.TextField;
+
+public class ButtonWrapTest extends UIUnitTest {
+
+    @Override
+    protected String scanPackage() {
+        return "com.example";
+    }
+
+    @Test
+    public void buttonWithDisableOnClick_notUsableAfterClick() {
+        Button button = new Button();
+        button.setDisableOnClick(true);
+        getCurrentView().getElement().appendChild(button.getElement());
+
+        final ButtonWrap button_ = $(ButtonWrap.class, button);
+
+        Assertions.assertTrue(button_.isUsable(),
+                "Button should be usable before click");
+
+        button_.click();
+
+        Assertions.assertFalse(button_.isUsable(),
+                "Button should have been disabled after click");
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> button_.click(),
+                "Illegal state should be thrown for disabled button");
+    }
+
+    @Test
+    public void clickWithMiddleButton_middleButtonClickShouldBeRegistered() {
+        Button button = new Button();
+        AtomicInteger mouseButton = new AtomicInteger(-1);
+        button.addClickListener(event -> mouseButton.set(event.getButton()));
+
+        getCurrentView().getElement().appendChild(button.getElement());
+
+        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        button_.middleClick();
+
+        Assertions.assertEquals(1, mouseButton.get(),
+                "Click event should have sent with middle click");
+    }
+
+    @Test
+    public void clickWithRightButton_rightButtonClickShouldBeRegistered() {
+        Button button = new Button();
+        AtomicInteger mouseButton = new AtomicInteger(-1);
+        button.addClickListener(event -> mouseButton.set(event.getButton()));
+
+        getCurrentView().getElement().appendChild(button.getElement());
+
+        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        button_.rightClick();
+
+        Assertions.assertEquals(2, mouseButton.get(),
+                "Click event should have sent with right click");
+    }
+
+    @Test
+    public void normalClick_noMetaKeysMarkedAsUsed() {
+        Button button = new Button();
+        AtomicReference<ClickEvent> event = new AtomicReference<>(null);
+        button.addClickListener(clickEvent -> event.compareAndSet(null, clickEvent));
+        getCurrentView().getElement().appendChild(button.getElement());
+
+        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        button_.click();
+
+        Assertions.assertNotNull(event.get(), "event should have fired and recorded");
+        Assertions.assertFalse(event.get().isCtrlKey(), "Ctrl should not have been used");
+        Assertions.assertFalse(event.get().isShiftKey(), "Shift should not have been used");
+        Assertions.assertFalse(event.get().isAltKey(), "Alt should not have been used");
+        Assertions.assertFalse(event.get().isMetaKey(), "Meta should not have been used");
+    }
+
+    @Test
+    public void clickWithMeta_metaKeysMarkedAsUsed() {
+        Button button = new Button();
+        AtomicReference<ClickEvent> event = new AtomicReference<>(null);
+        button.addClickListener(clickEvent -> event.set(clickEvent));
+        getCurrentView().getElement().appendChild(button.getElement());
+
+        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        button_.click(new MetaKeys(true,true,true,true));
+
+        Assertions.assertNotNull(event.get(), "event should have fired and recorded");
+        Assertions.assertTrue(event.get().isCtrlKey(), "Ctrl should have been used");
+        Assertions.assertTrue(event.get().isShiftKey(), "Shift should have been used");
+        Assertions.assertTrue(event.get().isAltKey(), "Alt should have been used");
+        Assertions.assertTrue(event.get().isMetaKey(), "Meta should have been used");
+
+        button_.click(new MetaKeys(true, true, false, false));
+        Assertions.assertTrue(event.get().isCtrlKey(), "Ctrl should have been used");
+        Assertions.assertTrue(event.get().isShiftKey(), "Shift should have been used");
+        Assertions.assertFalse(event.get().isAltKey(), "Alt should not have been used");
+        Assertions.assertFalse(event.get().isMetaKey(), "Meta should not have been used");
+    }
+}


### PR DESCRIPTION
Add wrapper for button with methods
for clicking with different buttons and
for having meta keys pressed for click.

Fixes #1334
