### PR TITLE
chore: set snapshot version to 8.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-testbench-parent</artifactId>
     <packaging>pom</packaging>
-    <version>9.0-SNAPSHOT</version>
+    <version>8.1-SNAPSHOT</version>
     <name>Vaadin TestBench parent</name>
 
     <organization>

--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-bom</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core</artifactId>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests</artifactId>


### PR DESCRIPTION
Set the version to be 8.1-SNAPSHOT as there is no reason to update the major.