### PR TITLE
feat: added component query api

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -235,7 +235,7 @@ class BaseUIUnitTest {
 
     /**
      * Gets a query object for finding a component inside the UI
-     * 
+     *
      * @param componentType
      *            the type of the component(s) to search for
      * @param <T>

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -234,6 +234,37 @@ class BaseUIUnitTest {
     }
 
     /**
+     * Gets a query object for finding a component inside the UI
+     * 
+     * @param componentType
+     *            the type of the component(s) to search for
+     * @param <T>
+     *            the type of the component(s) to search for
+     * @return a query object for finding components
+     */
+    public <T extends Component> ComponentQuery<T> select(
+            Class<T> componentType) {
+        return new ComponentQuery<>(componentType, this::$);
+    }
+
+    /**
+     * Gets a query object for finding a component inside the current view
+     *
+     * @param componentType
+     *            the type of the component(s) to search for
+     * @param <T>
+     *            the type of the component(s) to search for
+     * @return a query object for finding components
+     */
+    public <T extends Component> ComponentQuery<T> selectFromCurrentView(
+            Class<T> componentType) {
+        Component viewComponent = getCurrentView().getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(componentType, this::$).from(viewComponent);
+    }
+
+    /**
      * Private initializer for wrapper classes.
      *
      * @param clazz

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -28,7 +28,7 @@ import com.vaadin.testbench.unit.internal.SearchSpec;
  * Query class used for finding a component inside a given search context.
  *
  * The search context is either the current {@link com.vaadin.flow.component.UI}
- * instance which searches through the whole components tree, or a
+ * instance which searches through the whole component tree, or a
  * {@link com.vaadin.flow.component.Component} instance, which limits the search
  * to the component subtree.
  *

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -1,19 +1,12 @@
 /*
- * Copyright 2000-2022 Vaadin Ltd.
+ * Copyright (C) 2022 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
-
 package com.vaadin.testbench.unit;
 
 import java.util.ArrayList;

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -16,16 +16,20 @@
 
 package com.vaadin.testbench.unit;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import kotlin.Unit;
+import kotlin.ranges.IntRange;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.testbench.unit.internal.LocatorKt;
+import com.vaadin.testbench.unit.internal.SearchSpec;
 
 /**
  * Query class used for finding a component inside a given search context.
@@ -49,6 +53,7 @@ public class ComponentQuery<T extends Component> {
 
     private final Class<T> componentType;
     private final Function<T, ? extends ComponentWrap<T>> wrapperFactory;
+    private final LocatorSpec<T> locatorSpec = new LocatorSpec<>();
 
     private Component context;
 
@@ -94,6 +99,23 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Executes a search for a component with the given id.
+     *
+     * @param id
+     *            the id to look up
+     * @return the wrapper for the component with the given id
+     *
+     * @throws NoSuchElementException
+     *             if no component is found
+     */
+    public <X extends ComponentWrap<T>> X id(String id) {
+        Objects.requireNonNull(id, "id must not be null");
+        locatorSpec.id = id;
+        locatorSpec.count = new IntRange(1, 1);
+        return find();
+    }
+
+    /**
      * Executes the search against current context and returns a list of test
      * wrappers for matching components.
      *
@@ -124,10 +146,10 @@ public class ComponentQuery<T extends Component> {
 
     /**
      * Sets the context to search inside.
-     * 
+     *
      * If a {@literal null} value is given, the search will be performed againt
      * the UI.
-     * 
+     *
      * @param context
      *            a component used as starting element for search.
      * @return this component query instance for chaining.
@@ -136,4 +158,62 @@ public class ComponentQuery<T extends Component> {
         this.context = context;
         return this;
     }
+
+    @SuppressWarnings("unchecked")
+    protected <X extends ComponentWrap<T>> X find() {
+        try {
+            return (X) wrapperFactory.apply(findComponent());
+        } catch (AssertionError e) {
+            throw new NoSuchElementException(e.getMessage());
+        }
+    }
+
+    protected T findComponent() {
+        if (context != null) {
+            LocatorKt._get(context, componentType, locatorSpec::populate);
+        }
+        return LocatorKt._get(componentType, locatorSpec::populate);
+    }
+
+    /**
+     * Private locator content holder used for searching the component.
+     *
+     * @param <T>
+     *            component type for search object.
+     */
+    private static class LocatorSpec<T extends Component> {
+
+        public String id;
+        public String caption;
+        public String placeholder;
+        public String text;
+        public IntRange count = new IntRange(0, Integer.MAX_VALUE);
+        public Object value;
+        public String classes;
+        public String withoutClasses;
+        public List<Predicate<T>> predicates = new ArrayList<>(0);
+
+        public Unit populate(SearchSpec<T> spec) {
+            if (id != null)
+                spec.setId(id);
+            if (caption != null)
+                spec.setCaption(caption);
+            if (placeholder != null)
+                spec.setPlaceholder(placeholder);
+            if (text != null)
+                spec.setText(text);
+            if (value != null)
+                spec.setValue(value);
+            if (classes != null)
+                spec.setClasses(classes);
+            if (withoutClasses != null)
+                spec.setWithoutClasses(withoutClasses);
+            spec.setCount(count);
+            spec.getPredicates().addAll(predicates);
+
+            return Unit.INSTANCE;
+        }
+
+    }
+
 }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -78,6 +78,19 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Requires the components to satisfy the given condition.
+     *
+     * @param condition
+     *            the condition to check against the components.
+     * @return this element query instance for chaining
+     */
+    public ComponentQuery<T> withCondition(Predicate<T> condition) {
+        Objects.requireNonNull(condition, "condition must not be null");
+        locatorSpec.predicates.add(condition);
+        return this;
+    }
+
+    /**
      * Executes the search against current context and returns the test wrapper
      * for first result.
      * 
@@ -182,7 +195,8 @@ public class ComponentQuery<T extends Component> {
 
     protected T findComponent() {
         if (context != null) {
-            return LocatorKt._get(context, componentType, locatorSpec::populate);
+            return LocatorKt._get(context, componentType,
+                    locatorSpec::populate);
         }
         return LocatorKt._get(componentType, locatorSpec::populate);
     }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -182,7 +182,7 @@ public class ComponentQuery<T extends Component> {
 
     protected T findComponent() {
         if (context != null) {
-            LocatorKt._get(context, componentType, locatorSpec::populate);
+            return LocatorKt._get(context, componentType, locatorSpec::populate);
         }
         return LocatorKt._get(componentType, locatorSpec::populate);
     }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.testbench.unit;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import kotlin.Unit;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.testbench.unit.internal.LocatorKt;
+
+/**
+ * Query class used for finding a component inside a given search context.
+ * 
+ * The search context is either the current {@link com.vaadin.flow.component.UI}
+ * instance which searches through the whole components tree, or a
+ * {@link com.vaadin.flow.component.Component} instance, which limits the search
+ * to the component subtree.
+ *
+ * Depending on the used terminal operator, the result of the search can be
+ * either a UI component (single or list) or a component wrapper.
+ * 
+ * The component type specified in the constructor defines the type of the
+ * component which is searched for and also the type for the component wrapper.
+ *
+ * @param <T>
+ *            the type of the component(s) to search for
+ * @see ComponentWrap
+ */
+public class ComponentQuery<T extends Component> {
+
+    private final Class<T> componentType;
+    private final Function<T, ? extends ComponentWrap<T>> wrapperFactory;
+
+    private Component context;
+
+    public ComponentQuery(Class<T> componentType,
+            Function<T, ComponentWrap<T>> wrapperFactory) {
+        this.componentType = Objects.requireNonNull(componentType,
+                "Component type must not be null");
+        this.wrapperFactory = Objects.requireNonNull(wrapperFactory,
+                "Component Wrapper Factory type must not be null");
+    }
+
+    /**
+     * Executes the search against current context and returns the test wrapper
+     * for first result.
+     * 
+     * @return a test wrapper for the component of the type specified in the
+     *         constructor.
+     * @throws java.util.NoSuchElementException
+     *             if no component is found
+     */
+    @SuppressWarnings("unchecked")
+    public <X extends ComponentWrap<T>> X first() {
+        return (X) allComponents().stream().findFirst().map(wrapperFactory)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Cannot find component for current query"));
+    }
+
+    /**
+     * Executes the search against current context and returns the test wrapper
+     * for last result.
+     *
+     * @return a test wrapper for the component of the type specified in the
+     *         constructor.
+     * @throws java.util.NoSuchElementException
+     *             if no component is found
+     */
+    @SuppressWarnings("unchecked")
+    public <X extends ComponentWrap<T>> X last() {
+        return (X) allComponents().stream().reduce((first, second) -> second)
+                .map(wrapperFactory)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Cannot find component for current query"));
+    }
+
+    /**
+     * Executes the search against current context and returns a list of test
+     * wrappers for matching components.
+     *
+     * @return a list of test wrappers for found components, or an empty list if
+     *         search does not produce results. Never {@literal null}.
+     */
+    @SuppressWarnings("unchecked")
+    public <X extends ComponentWrap<T>> List<X> all() {
+        return allComponents().stream()
+                .map(component -> (X) wrapperFactory.apply(component))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Executes the search against current context and returns a list of
+     * matching components.
+     *
+     * @return a list of found components, or an empty list if search does not
+     *         produce results. Never {@literal null}.
+     */
+    public List<T> allComponents() {
+        if (context != null) {
+            return LocatorKt._find(context, componentType,
+                    spec -> Unit.INSTANCE);
+        }
+        return LocatorKt._find(componentType, spec -> Unit.INSTANCE);
+    }
+
+    /**
+     * Sets the context to search inside.
+     * 
+     * If a {@literal null} value is given, the search will be performed againt
+     * the UI.
+     * 
+     * @param context
+     *            a component used as starting element for search.
+     * @return this component query instance for chaining.
+     */
+    public ComponentQuery<T> from(Component context) {
+        this.context = context;
+        return this;
+    }
+}

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -136,7 +136,7 @@ public class ComponentQuery<T extends Component> {
      * the context of the matching component at given index for current query.
      *
      * Index is 1-based. Given a zero or negative index or an index higher than
-     * the actual number of components found results in an At
+     * the actual number of components found results in an
      * {@link IndexOutOfBoundsException}.
      *
      * @param componentType
@@ -196,7 +196,7 @@ public class ComponentQuery<T extends Component> {
      * for the component at given index.
      *
      * Index is 1-based. Given a zero or negative index or an index higher than
-     * the actual number of components found results in an At
+     * the actual number of components found results in an
      * {@link IndexOutOfBoundsException}.
      *
      * @return a test wrapper for the component of the type specified in the

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -59,6 +59,25 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Requires the given property to have expected value.
+     *
+     * @param getter
+     *            the function to get the value of the property of the field,
+     *            not null
+     * @param expectedValue
+     *            value to be compared with the one obtained by applying the
+     *            getter function to a component instance
+     * @return this element query instance for chaining
+     */
+    public <V> ComponentQuery<T> withPropertyValue(Function<T, V> getter,
+            V expectedValue) {
+        Objects.requireNonNull(getter, "getter function must not be null");
+        locatorSpec.predicates
+                .add(c -> Objects.equals(getter.apply(c), expectedValue));
+        return this;
+    }
+
+    /**
      * Executes the search against current context and returns the test wrapper
      * for first result.
      * 
@@ -132,9 +151,9 @@ public class ComponentQuery<T extends Component> {
     public List<T> allComponents() {
         if (context != null) {
             return LocatorKt._find(context, componentType,
-                    spec -> Unit.INSTANCE);
+                    locatorSpec::populate);
         }
-        return LocatorKt._find(componentType, spec -> Unit.INSTANCE);
+        return LocatorKt._find(componentType, locatorSpec::populate);
     }
 
     /**

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.testbench.unit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.dom.Element;
+
+import static java.util.Arrays.asList;
+
+class ComponentQueryTest extends UIUnitTest {
+
+    @Test
+    void first_exactMatch_getsComponent() {
+        Element root = getCurrentView().getElement();
+
+        TextField textField = new TextField();
+        root.appendChild(textField.getElement());
+        Button button = new Button();
+        root.appendChild(button.getElement());
+
+        ComponentQuery<TextField> textFieldQuery = select(TextField.class);
+        Assertions.assertSame(textField, textFieldQuery.first().getComponent(),
+                "Expecting query to find TextField component, but got different instance");
+
+        ComponentQuery<Button> buttonQuery = select(Button.class);
+        Assertions.assertSame(button, buttonQuery.first().getComponent(),
+                "Expecting query to find Button component, but got different instance");
+
+    }
+
+    @Test
+    void first_multipleMatching_getsFirstComponent() {
+        TextField first = new TextField();
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(first.getElement(),
+                new TextField().getElement(), new TextField().getElement(),
+                new TextField().getElement());
+
+        ComponentQuery<TextField> query = select(TextField.class);
+        Assertions.assertSame(first, query.first().getComponent(),
+                "Expecting query to find TextField component, but got different instance");
+    }
+
+    @Test
+    void first_noMatching_throws() {
+        ComponentQuery<TextField> query = select(TextField.class);
+        Assertions.assertThrows(NoSuchElementException.class, query::first);
+    }
+
+    @Test
+    void last_exactMatch_getsComponent() {
+        Element root = getCurrentView().getElement();
+
+        TextField textField = new TextField();
+        root.appendChild(textField.getElement());
+        Button button = new Button();
+        root.appendChild(button.getElement());
+
+        ComponentQuery<TextField> textFieldQuery = select(TextField.class);
+        Assertions.assertSame(textField, textFieldQuery.last().getComponent(),
+                "Expecting query to find TextField component, but got different instance");
+
+        ComponentQuery<Button> buttonQuery = select(Button.class);
+        Assertions.assertSame(button, buttonQuery.last().getComponent(),
+                "Expecting query to find Button component, but got different instance");
+
+    }
+
+    @Test
+    void last_multipleMatching_getsFirstComponent() {
+        TextField last = new TextField();
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement(),
+                new TextField().getElement(), new TextField().getElement(),
+                last.getElement());
+
+        ComponentQuery<TextField> query = select(TextField.class);
+        Assertions.assertSame(last, query.last().getComponent(),
+                "Expecting query to find TextField component, but got different instance");
+    }
+
+    @Test
+    void last_noMatching_throws() {
+        ComponentQuery<TextField> query = select(TextField.class);
+        Assertions.assertThrows(NoSuchElementException.class, query::last);
+    }
+
+    @Test
+    void all_noMatching_getsEmptyList() {
+        ComponentQuery<TextField> query = select(TextField.class);
+        List<ComponentWrap<TextField>> result = query.all();
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isEmpty(),
+                "Expecting no results from search, but got " + result);
+    }
+
+    @Test
+    void all_matching_getsMatchingComponents() {
+
+        List<TextField> expectedComponents = asList(new TextField(),
+                new TextField(), new TextField());
+        Element rootElement = getCurrentView().getElement();
+        expectedComponents
+                .forEach(text -> rootElement.appendChild(text.getElement()));
+
+        ComponentQuery<TextField> query = select(TextField.class);
+        List<ComponentWrap<TextField>> result = query.all();
+        Assertions.assertNotNull(result);
+        List<TextField> foundComponents = result.stream()
+                .map(ComponentWrap::getComponent).collect(Collectors.toList());
+        Assertions.assertIterableEquals(expectedComponents, foundComponents);
+
+        Assertions.assertIterableEquals(
+                Collections
+                        .singleton(getCurrentView().getElement().getChild(0)),
+                select(Text.class).allComponents().stream()
+                        .map(Component::getElement)
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    void allComponents_noMatching_getsEmptyList() {
+        ComponentQuery<TextField> query = select(TextField.class);
+        List<TextField> result = query.allComponents();
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.size(),
+                "Expecting zero results from search, but got " + result.size());
+    }
+
+    @Test
+    void allComponents_matching_getsMatchingComponents() {
+
+        List<TextField> expectedComponents = asList(new TextField(),
+                new TextField(), new TextField());
+        Element rootElement = getCurrentView().getElement();
+        expectedComponents
+                .forEach(text -> rootElement.appendChild(text.getElement()));
+
+        ComponentQuery<TextField> query = select(TextField.class);
+        List<TextField> result = query.allComponents();
+        Assertions.assertIterableEquals(expectedComponents, result);
+
+        Assertions.assertIterableEquals(
+                Collections
+                        .singleton(getCurrentView().getElement().getChild(0)),
+                select(Text.class).allComponents().stream()
+                        .map(Component::getElement)
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    void from_matchingChildren_getsNestedComponents() {
+        Div context = new Div();
+        TextField textField1 = new TextField();
+        TextField textField2 = new TextField();
+        TextField textField3 = new TextField();
+        TextField textField4 = new TextField();
+        TextField textField5 = new TextField();
+
+        context.add(new Div(textField1), textField2);
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(textField5.getElement(),
+                new Div(context, textField3).getElement(),
+                textField4.getElement());
+
+        List<TextField> result = select(TextField.class).from(context)
+                .allComponents();
+        Assertions.assertIterableEquals(List.of(textField1, textField2),
+                result);
+
+        result = selectFromCurrentView(TextField.class).allComponents();
+        Assertions.assertIterableEquals(List.of(textField5, textField1,
+                textField2, textField3, textField4), result);
+
+    }
+
+    @Test
+    void from_emptyContext_getsEmptyList() {
+        Div context = new Div();
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement(),
+                new Div(context, new TextField()).getElement(),
+                new TextField().getElement());
+
+        List<TextField> result = select(TextField.class).from(context)
+                .allComponents();
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void from_noMatchingChildren_getsEmptyList() {
+        Div context = new Div();
+        context.add(new Div(new Button()), new Button());
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new Div(context, new TextField()).getElement(),
+                new TextField().getElement());
+
+        List<TextField> result = select(TextField.class).from(context)
+                .allComponents();
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+}

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -1,19 +1,12 @@
 /*
- * Copyright 2000-2022 Vaadin Ltd.
+ * Copyright (C) 2022 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
-
 package com.vaadin.testbench.unit;
 
 import java.util.Collections;

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -31,6 +31,17 @@ import static java.util.Arrays.asList;
 class ComponentQueryTest extends UIUnitTest {
 
     @Test
+    void find_invisibleComponents_noResults() {
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new Div().getElement(), new Div().getElement(),
+                new Div().getElement());
+        rootElement.getChildren().filter(el -> !el.isTextNode())
+                .forEach(el -> el.setVisible(false));
+
+        Assertions.assertTrue(select(Div.class).allComponents().isEmpty());
+    }
+
+    @Test
     void first_exactMatch_getsComponent() {
         Element root = getCurrentView().getElement();
 

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.TextField;
@@ -218,6 +219,30 @@ class ComponentQueryTest extends UIUnitTest {
         List<TextField> result = select(TextField.class).from(context)
                 .allComponents();
         Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void from_withCriteria_getsComponentInContext() {
+        TextField notInViewTextField = new TextField();
+        notInViewTextField.setId("myId");
+        UI.getCurrent().getElement()
+                .appendChild(notInViewTextField.getElement());
+
+        TextField inViewTextField = new TextField();
+        inViewTextField.setId("myId");
+        Div context = new Div(inViewTextField);
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(context.getElement());
+
+        List<TextField> result = select(TextField.class).from(context)
+                .allComponents();
+        Assertions.assertIterableEquals(Collections.singleton(inViewTextField),
+                result);
+
+        ComponentWrap<TextField> foundTextField = select(TextField.class)
+                .from(context).id("myId");
+        Assertions.assertSame(inViewTextField, foundTextField.getComponent());
+
     }
 
     @Test

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -254,7 +254,6 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void id_matchingDifferentComponentType_throws() {
-
         Element rootElement = getCurrentView().getElement();
         rootElement.appendChild(new TextField().getElement());
         Button button = new Button();
@@ -265,6 +264,53 @@ class ComponentQueryTest extends UIUnitTest {
                 TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.id("myId"));
+    }
+
+    @Test
+    void withPropertyValue_matchingValue_findsComponent() {
+        Element rootElement = getCurrentView().getElement();
+        TextField textField = new TextField();
+        String label = "field label";
+        textField.setLabel(label);
+        rootElement.appendChild(textField.getElement());
+        TextField textField2 = new TextField();
+        textField2.setLabel("Another label");
+        rootElement.appendChild(textField2.getElement());
+        rootElement.appendChild(new TextField().getElement());
+
+        Assertions.assertSame(textField,
+                select(TextField.class)
+                        .withPropertyValue(TextField::getLabel, label).first()
+                        .getComponent());
+    }
+
+    @Test
+    void withPropertyValue_expectedNull_findsComponent() {
+        Element rootElement = getCurrentView().getElement();
+        TextField textField = new TextField();
+        rootElement.appendChild(textField.getElement());
+        TextField textField2 = new TextField();
+        textField2.setLabel("Another label");
+        rootElement.appendChild(textField2.getElement());
+
+        Assertions.assertSame(textField,
+                select(TextField.class)
+                        .withPropertyValue(TextField::getLabel, null).first()
+                        .getComponent());
+    }
+
+    @Test
+    void withPropertyValue_noMatchingValue_doesNotFindComponent() {
+        Element rootElement = getCurrentView().getElement();
+        TextField textField = new TextField();
+        rootElement.appendChild(textField.getElement());
+        TextField textField2 = new TextField();
+        textField2.setLabel("Another label");
+        rootElement.appendChild(textField2.getElement());
+
+        Assertions.assertTrue(select(TextField.class)
+                .withPropertyValue(TextField::getLabel, "The label").all()
+                .isEmpty());
     }
 
 }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -88,7 +88,7 @@ class ComponentQueryTest extends UIUnitTest {
     }
 
     @Test
-    void last_multipleMatching_getsFirstComponent() {
+    void last_multipleMatching_getsLastComponent() {
         TextField last = new TextField();
         Element rootElement = getCurrentView().getElement();
         rootElement.appendChild(new TextField().getElement(),

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -338,4 +338,27 @@ class ComponentQueryTest extends UIUnitTest {
                 .isEmpty());
     }
 
+    @Test
+    void withCondition_predicateMatched_getsComponents() {
+        Div div1 = new Div();
+        div1.getElement().setProperty("numeric-prop", 4.5);
+        Div div2 = new Div(new Div(), new Div());
+        div2.getElement().setProperty("numeric-prop", 2.0);
+        Div div3 = new Div();
+        div3.getElement().setProperty("numeric-prop", 1.5);
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement());
+
+        List<Div> result = select(Div.class)
+                .withCondition(div -> div.getChildren().findAny().isPresent())
+                .allComponents();
+        Assertions.assertIterableEquals(Collections.singleton(div2), result);
+
+        result = select(Div.class).withCondition(div -> {
+            double value = div.getElement().getProperty("numeric-prop", 0.0);
+            return value > 1 && value < 3;
+        }).allComponents();
+        Assertions.assertIterableEquals(List.of(div2, div3), result);
+    }
+
 }


### PR DESCRIPTION
The component query API that allows to scan the UI or a subtree for components matching given predicates,
and provides component wrappers for found elements.

Part of #1338