### PR TITLE
feat: Added component query helpers for expected result size

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -240,6 +240,87 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Requires the search to find exactly the given number of components
+     *
+     * @param count
+     *            the expected number of component retrieved by the search
+     *
+     * @return this element query instance for chaining
+     * @throws IllegalArgumentException
+     *             if {@code count} is negative
+     */
+    public ComponentQuery<T> withResultsSize(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException(
+                    "count must be greater or equal than zero, but was "
+                            + count);
+        }
+        locatorSpec.count = new IntRange(count, count);
+        return this;
+    }
+
+    /**
+     * Requires the search to find a number of components within given range
+     *
+     * @param min
+     *            minimum number of components that should be found (inclusive)
+     * @param max
+     *            maximum number of components that should be found (inclusive)
+     *
+     * @return this element query instance for chaining
+     * @throws IllegalArgumentException
+     *             if {@code min} or {@code max} are negative, or if {@code min}
+     *             is greater than {@code max}
+     */
+    public ComponentQuery<T> withResultsSize(int min, int max) {
+        if (min < 0) {
+            throw new IllegalArgumentException(
+                    "min must be greater or equal than zero, but was " + min);
+        }
+        if (max < 0) {
+            throw new IllegalArgumentException(
+                    "max must be greater or equal than zero, but was " + max);
+        }
+        if (min > max) {
+            throw new IllegalArgumentException(
+                    "max must be greater or equal than min, but was min=" + min
+                            + ", max=" + max + "");
+        }
+        locatorSpec.count = new IntRange(min, max);
+        return this;
+    }
+
+    /**
+     * Requires the search to find at least the given number of components
+     *
+     * @param min
+     *            minimum number of components that should be found (inclusive)
+     *
+     * @return this element query instance for chaining
+     * @throws IllegalArgumentException
+     *             if {@code min} or {@code max} are negative, or if {@code min}
+     *             is greater than {@code max}
+     */
+    public ComponentQuery<T> withMinResults(int min) {
+        return withResultsSize(min, locatorSpec.count.getEndInclusive());
+    }
+
+    /**
+     * Requires the search to find at most the given number of components
+     *
+     * @param max
+     *            maximum number of components that should be found (inclusive)
+     *
+     * @return this element query instance for chaining
+     * @throws IllegalArgumentException
+     *             if {@code min} or {@code max} are negative, or if {@code min}
+     *             is greater than {@code max}
+     */
+    public ComponentQuery<T> withMaxResults(int max) {
+        return withResultsSize(locatorSpec.count.getStart(), max);
+    }
+
+    /**
      * Gets a new {@link ComponentQuery} to search for given component type on
      * the context of first matching component for current query.
      *

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -605,23 +605,47 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withResultsSize_afterWithMaxResults_overwritesRange() {
-        ComponentQuery<Div> query = $(Div.class);
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> query.withResultsSize(-1));
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        List<Div> result = $(Div.class).withMaxResults(2).withResultsSize(4)
+                .allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
     }
 
     @Test
     void withResultsSize_afterWithMinResults_overwritesRange() {
-        ComponentQuery<Div> query = $(Div.class);
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> query.withResultsSize(-1));
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        List<Div> result = $(Div.class).withMinResults(10).withResultsSize(4)
+                .allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
     }
 
     @Test
-    void withResultsSize_afterWithResults_overwritesRange() {
-        ComponentQuery<Div> query = $(Div.class);
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> query.withResultsSize(-1));
+    void withResultsSize_afterWithResultSizeRange_overwritesRange() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        List<Div> result = $(Div.class).withResultsSize(2, 3).withResultsSize(4)
+                .allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
     }
 
     @Test
@@ -679,8 +703,8 @@ class ComponentQueryTest extends UIUnitTest {
         Div div4 = new Div();
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
-        List<Div> result = $(Div.class).withResultsSize(1)
-                .withMaxResults(4).allComponents();
+        List<Div> result = $(Div.class).withResultsSize(1).withMaxResults(4)
+                .allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
     }
@@ -737,8 +761,8 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement());
 
-        List<Div> result = $(Div.class).withResultsSize(4)
-                .withMinResults(1).allComponents();
+        List<Div> result = $(Div.class).withResultsSize(4).withMinResults(1)
+                .allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3), result);
     }
 
@@ -788,8 +812,8 @@ class ComponentQueryTest extends UIUnitTest {
         Div div4 = new Div();
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
-        List<Div> result = $(Div.class).withResultsSize(5)
-                .withResultsSize(2, 5).allComponents();
+        List<Div> result = $(Div.class).withResultsSize(5).withResultsSize(2, 5)
+                .allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
     }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -555,6 +555,246 @@ class ComponentQueryTest extends UIUnitTest {
     }
 
     @Test
+    void withResultsSize_zeroMatchingResultsSize_emptyResult() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        Assertions.assertTrue(select(TestComponent.class).withResultsSize(0)
+                .allComponents().isEmpty());
+    }
+
+    @Test
+    void withResultsSize_matchingResultsSize_getsComponents() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        List<Div> result = select(Div.class).withResultsSize(4).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
+    }
+
+    @Test
+    void withResultsSize_notMatchingResultsSize_throws() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        IntStream.rangeClosed(0, 10).filter(i -> i != 4).forEach(i -> {
+            ComponentQuery<Div> query = select(Div.class).withResultsSize(i);
+            Assertions.assertThrows(AssertionError.class, query::allComponents);
+        });
+    }
+
+    @Test
+    void withResultsSize_negative_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(-1));
+    }
+
+    @Test
+    void withResultsSize_afterWithMaxResults_overwritesRange() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(-1));
+    }
+
+    @Test
+    void withResultsSize_afterWithMinResults_overwritesRange() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(-1));
+    }
+
+    @Test
+    void withResultsSize_afterWithResults_overwritesRange() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(-1));
+    }
+
+    @Test
+    void withMaxResults_resultsSizeWithinUpperBound_getsComponents() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        List<Div> result = select(Div.class).withMaxResults(10).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
+        result = select(Div.class).withMaxResults(4).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
+    }
+
+    @Test
+    void withMaxResults_resultsSizeExceededUpperBound_throws() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        IntStream.rangeClosed(1, 3).forEach(count -> {
+            ComponentQuery<Div> query = select(Div.class).withMaxResults(count);
+            Assertions.assertThrows(AssertionError.class, query::allComponents);
+        });
+    }
+
+    @Test
+    void withMaxResults_negative_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withMaxResults(-1));
+    }
+
+    @Test
+    void withMaxResults_lowerThanMin_throws() {
+        ComponentQuery<Div> query = select(Div.class).withMinResults(4);
+        query.withMaxResults(4); // same as min is OK, must not throw
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withMaxResults(2));
+    }
+
+    @Test
+    void withMaxResults_afterResultsSize_overwritesRange() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+        List<Div> result = select(Div.class).withResultsSize(1)
+                .withMaxResults(4).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
+    }
+
+    @Test
+    void withMinResults_resultsSizeWithinLowerBound_getsComponents() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        IntStream.rangeClosed(0, 4).forEach(count -> {
+            List<Div> result = select(Div.class).withMinResults(count)
+                    .allComponents();
+            Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                    result);
+        });
+    }
+
+    @Test
+    void withMinResults_resultsSizeLessThanLowerBound_throws() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement());
+
+        IntStream.rangeClosed(3, 10).forEach(count -> {
+            ComponentQuery<Div> query = select(Div.class).withMinResults(count);
+            Assertions.assertThrows(AssertionError.class, query::allComponents);
+        });
+    }
+
+    @Test
+    void withMinResults_negative_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withMinResults(-1));
+    }
+
+    @Test
+    void withMinResults_greaterThanMax_throws() {
+        ComponentQuery<Div> query = select(Div.class).withMaxResults(2);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withMinResults(10));
+    }
+
+    @Test
+    void withMinResults_afterResultsSize_overwritesLowerRange() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement());
+
+        List<Div> result = select(Div.class).withResultsSize(4)
+                .withMinResults(1).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3), result);
+    }
+
+    @Test
+    void withResults_resultsSizeOutOfBounds_throws() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+
+        ComponentQuery<Div> query = select(Div.class).withResultsSize(5, 10);
+        Assertions.assertThrows(AssertionError.class, query::allComponents);
+
+        query = select(Div.class).withResultsSize(1, 3);
+        Assertions.assertThrows(AssertionError.class, query::allComponents);
+
+    }
+
+    @Test
+    void withResultsSize_minNegative_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(-1, 10));
+    }
+
+    @Test
+    void withResultsSize_maxNegative_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(2, -1));
+    }
+
+    @Test
+    void withResultsSize_maxLowerThanMin_throws() {
+        ComponentQuery<Div> query = select(Div.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withResultsSize(5, 2));
+    }
+
+    @Test
+    void withResultsSize_afterResultsSize_overwritesRange() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        Div div3 = new Div();
+        Div div4 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement(), div3.getElement(), div4.getElement());
+        List<Div> result = select(Div.class).withResultsSize(5)
+                .withResultsSize(2, 5).allComponents();
+        Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
+                result);
+    }
+
+    @Test
     void thenOnFirst_chainedQuery_getsNestedComponents() {
         TextField deepNested = new TextField();
         Div nestedDiv = new Div(deepNested);

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -563,7 +563,7 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        Assertions.assertTrue(select(TestComponent.class).withResultsSize(0)
+        Assertions.assertTrue($(TestComponent.class).withResultsSize(0)
                 .allComponents().isEmpty());
     }
 
@@ -576,7 +576,7 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        List<Div> result = select(Div.class).withResultsSize(4).allComponents();
+        List<Div> result = $(Div.class).withResultsSize(4).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
     }
@@ -591,35 +591,35 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement(), div3.getElement(), div4.getElement());
 
         IntStream.rangeClosed(0, 10).filter(i -> i != 4).forEach(i -> {
-            ComponentQuery<Div> query = select(Div.class).withResultsSize(i);
+            ComponentQuery<Div> query = $(Div.class).withResultsSize(i);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withResultsSize_negative_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1));
     }
 
     @Test
     void withResultsSize_afterWithMaxResults_overwritesRange() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1));
     }
 
     @Test
     void withResultsSize_afterWithMinResults_overwritesRange() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1));
     }
 
     @Test
     void withResultsSize_afterWithResults_overwritesRange() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1));
     }
@@ -633,10 +633,10 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        List<Div> result = select(Div.class).withMaxResults(10).allComponents();
+        List<Div> result = $(Div.class).withMaxResults(10).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
-        result = select(Div.class).withMaxResults(4).allComponents();
+        result = $(Div.class).withMaxResults(4).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
     }
@@ -651,21 +651,21 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement(), div3.getElement(), div4.getElement());
 
         IntStream.rangeClosed(1, 3).forEach(count -> {
-            ComponentQuery<Div> query = select(Div.class).withMaxResults(count);
+            ComponentQuery<Div> query = $(Div.class).withMaxResults(count);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withMaxResults_negative_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMaxResults(-1));
     }
 
     @Test
     void withMaxResults_lowerThanMin_throws() {
-        ComponentQuery<Div> query = select(Div.class).withMinResults(4);
+        ComponentQuery<Div> query = $(Div.class).withMinResults(4);
         query.withMaxResults(4); // same as min is OK, must not throw
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMaxResults(2));
@@ -679,7 +679,7 @@ class ComponentQueryTest extends UIUnitTest {
         Div div4 = new Div();
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
-        List<Div> result = select(Div.class).withResultsSize(1)
+        List<Div> result = $(Div.class).withResultsSize(1)
                 .withMaxResults(4).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);
@@ -695,7 +695,7 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement(), div3.getElement(), div4.getElement());
 
         IntStream.rangeClosed(0, 4).forEach(count -> {
-            List<Div> result = select(Div.class).withMinResults(count)
+            List<Div> result = $(Div.class).withMinResults(count)
                     .allComponents();
             Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                     result);
@@ -710,21 +710,21 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement());
 
         IntStream.rangeClosed(3, 10).forEach(count -> {
-            ComponentQuery<Div> query = select(Div.class).withMinResults(count);
+            ComponentQuery<Div> query = $(Div.class).withMinResults(count);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withMinResults_negative_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMinResults(-1));
     }
 
     @Test
     void withMinResults_greaterThanMax_throws() {
-        ComponentQuery<Div> query = select(Div.class).withMaxResults(2);
+        ComponentQuery<Div> query = $(Div.class).withMaxResults(2);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMinResults(10));
     }
@@ -737,7 +737,7 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement());
 
-        List<Div> result = select(Div.class).withResultsSize(4)
+        List<Div> result = $(Div.class).withResultsSize(4)
                 .withMinResults(1).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3), result);
     }
@@ -751,31 +751,31 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        ComponentQuery<Div> query = select(Div.class).withResultsSize(5, 10);
+        ComponentQuery<Div> query = $(Div.class).withResultsSize(5, 10);
         Assertions.assertThrows(AssertionError.class, query::allComponents);
 
-        query = select(Div.class).withResultsSize(1, 3);
+        query = $(Div.class).withResultsSize(1, 3);
         Assertions.assertThrows(AssertionError.class, query::allComponents);
 
     }
 
     @Test
     void withResultsSize_minNegative_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1, 10));
     }
 
     @Test
     void withResultsSize_maxNegative_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(2, -1));
     }
 
     @Test
     void withResultsSize_maxLowerThanMin_throws() {
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(5, 2));
     }
@@ -788,7 +788,7 @@ class ComponentQueryTest extends UIUnitTest {
         Div div4 = new Div();
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
-        List<Div> result = select(Div.class).withResultsSize(5)
+        List<Div> result = $(Div.class).withResultsSize(5)
                 .withResultsSize(2, 5).allComponents();
         Assertions.assertIterableEquals(List.of(div1, div2, div3, div4),
                 result);


### PR DESCRIPTION
Added helpers to verify the size of the search results:
exact size, in a range, min and max

Part of #1370