### PR TITLE
refactor!: renamed $ and select methods

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -47,8 +47,8 @@ class BaseUIUnitTest {
 
     static {
         try (ScanResult scan = new ClassGraph().enableClassInfo()
-                .enableAnnotationInfo().acceptPackages("com.vaadin.flow.component")
-                .scan(2)) {
+                .enableAnnotationInfo()
+                .acceptPackages("com.vaadin.flow.component").scan(2)) {
             ClassInfoList wrapperList = scan
                     .getClassesWithAnnotation(Wraps.class.getName());
             Map<Class<?>, Class<? extends ComponentWrap>> wrapperMap = new HashMap<>();
@@ -199,7 +199,8 @@ class BaseUIUnitTest {
      *            component type
      * @return component in wrapper with test helpers
      */
-    public <T extends ComponentWrap<Y>, Y extends Component> T $(Y component) {
+    public <T extends ComponentWrap<Y>, Y extends Component> T wrap(
+            Y component) {
         return (T) initialize(getWrapper(component.getClass()), component);
     }
 
@@ -216,8 +217,8 @@ class BaseUIUnitTest {
      *            component type
      * @return initialized test wrapper for component
      */
-    public <T extends ComponentWrap<Y>, Y extends Component> T $(Class<T> wrap,
-            Y component) {
+    public <T extends ComponentWrap<Y>, Y extends Component> T wrap(
+            Class<T> wrap, Y component) {
         return (T) initialize(wrap, component);
     }
 
@@ -242,9 +243,8 @@ class BaseUIUnitTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
-    public <T extends Component> ComponentQuery<T> select(
-            Class<T> componentType) {
-        return new ComponentQuery<>(componentType, this::$);
+    public <T extends Component> ComponentQuery<T> $(Class<T> componentType) {
+        return new ComponentQuery<>(componentType, this::wrap);
     }
 
     /**
@@ -256,12 +256,13 @@ class BaseUIUnitTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
-    public <T extends Component> ComponentQuery<T> selectFromCurrentView(
+    public <T extends Component> ComponentQuery<T> $view(
             Class<T> componentType) {
         Component viewComponent = getCurrentView().getElement().getComponent()
                 .orElseThrow(() -> new AssertionError(
                         "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(componentType, this::$).from(viewComponent);
+        return new ComponentQuery<>(componentType, this::wrap)
+                .from(viewComponent);
     }
 
     /**

--- a/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
@@ -32,7 +32,7 @@ public class ButtonWrapTest extends UIUnitTest {
         button.setDisableOnClick(true);
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
 
         Assertions.assertTrue(button_.isUsable(),
                 "Button should be usable before click");
@@ -55,7 +55,7 @@ public class ButtonWrapTest extends UIUnitTest {
 
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.middleClick();
 
         Assertions.assertEquals(1, mouseButton.get(),
@@ -70,7 +70,7 @@ public class ButtonWrapTest extends UIUnitTest {
 
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.rightClick();
 
         Assertions.assertEquals(2, mouseButton.get(),
@@ -85,7 +85,7 @@ public class ButtonWrapTest extends UIUnitTest {
                 clickEvent -> event.compareAndSet(null, clickEvent));
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.click();
 
         Assertions.assertNotNull(event.get(),
@@ -107,7 +107,7 @@ public class ButtonWrapTest extends UIUnitTest {
         button.addClickListener(clickEvent -> event.set(clickEvent));
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = $(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.click(new MetaKeys(true, true, true, true));
 
         Assertions.assertNotNull(event.get(),

--- a/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
@@ -25,7 +25,7 @@ class NotificationWrapTest extends UIUnitTest {
     void notOpenedNotification_isNotUsable() {
         Notification notification = new Notification("Not Opened");
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
 
         Assertions.assertFalse(notification_.isUsable(),
@@ -38,7 +38,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show(notificationText);
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         Assertions.assertTrue(notification_.isUsable(),
                 "Opened Notification should be usable");
@@ -51,7 +51,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setEnabled(false);
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         Assertions.assertTrue(notification_.isUsable(),
                 "Disabled Notification should be usable");
@@ -64,7 +64,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setVisible(false);
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         Assertions.assertFalse(notification_.isUsable(),
                 "Hidden Notification should not be usable");
@@ -77,7 +77,7 @@ class NotificationWrapTest extends UIUnitTest {
         roundTrip();
         notification.close();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         Assertions.assertFalse(notification_.isUsable(),
                 "Closed Notification should not be usable");
@@ -88,7 +88,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show("Some text");
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         notification_.autoClose();
 
@@ -99,7 +99,7 @@ class NotificationWrapTest extends UIUnitTest {
     @Test
     void autoClose_notOpenedNotification_throws() {
         Notification notification = new Notification("Some text");
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
 
         Assertions.assertThrows(IllegalStateException.class,
@@ -112,7 +112,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show("Some text");
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         notification_.autoClose();
         Assertions.assertThrows(IllegalStateException.class,
@@ -126,7 +126,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setDuration(0);
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::autoClose,
@@ -139,7 +139,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show(notificationText);
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
 
         Assertions.assertEquals(notificationText, notification_.getText());
@@ -149,7 +149,7 @@ class NotificationWrapTest extends UIUnitTest {
     void getText_notOpenedNotification_throws() {
         Notification notification = new Notification("Some text");
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
 
         Assertions.assertThrows(IllegalStateException.class,
@@ -163,7 +163,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.close();
         roundTrip();
 
-        NotificationWrap<?> notification_ = $(NotificationWrap.class,
+        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
                 notification);
 
         Assertions.assertThrows(IllegalStateException.class,

--- a/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -31,7 +31,7 @@ public class TextFieldWrapTest extends UIUnitTest {
         tf.setReadOnly(true);
         getCurrentView().getElement().appendChild(tf.getElement());
 
-        final TextFieldWrap tf_ = $(TextFieldWrap.class, tf);
+        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
 
         Assertions.assertFalse(tf_.isUsable(),
                 "Read only TextField shouldn't be usable");
@@ -43,7 +43,7 @@ public class TextFieldWrapTest extends UIUnitTest {
         tf.setReadOnly(true);
         getCurrentView().getElement().appendChild(tf.getElement());
 
-        Assertions.assertFalse($(tf).isUsable(),
+        Assertions.assertFalse(wrap(tf).isUsable(),
                 "Read only TextField shouldn't be usable");
     }
 
@@ -59,7 +59,7 @@ public class TextFieldWrapTest extends UIUnitTest {
                     value.compareAndSet(null, event.getValue());
                 });
 
-        final TextFieldWrap tf_ = $(TextFieldWrap.class, tf);
+        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
         final String newValue = "Test";
         tf_.setValue(newValue);
 
@@ -72,7 +72,7 @@ public class TextFieldWrapTest extends UIUnitTest {
         getCurrentView().getElement().appendChild(tf.getElement());
 
         tf.getElement().setEnabled(false);
-        final TextFieldWrap tf_ = $(TextFieldWrap.class, tf);
+        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
 
         Assertions.assertThrows(IllegalStateException.class,
                 () -> tf_.setValue("fail"),

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -38,7 +38,7 @@ class ComponentQueryTest extends UIUnitTest {
         rootElement.getChildren().filter(el -> !el.isTextNode())
                 .forEach(el -> el.setVisible(false));
 
-        Assertions.assertTrue(select(Div.class).allComponents().isEmpty());
+        Assertions.assertTrue($(Div.class).allComponents().isEmpty());
     }
 
     @Test
@@ -50,11 +50,11 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = select(TextField.class);
+        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField, textFieldQuery.first().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = select(Button.class);
+        ComponentQuery<Button> buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.first().getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -68,14 +68,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 new TextField().getElement());
 
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertSame(first, query.first().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void first_noMatching_throws() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class, query::first);
     }
 
@@ -88,11 +88,11 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = select(TextField.class);
+        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField, textFieldQuery.last().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = select(Button.class);
+        ComponentQuery<Button> buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.last().getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -106,14 +106,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 last.getElement());
 
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertSame(last, query.last().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void last_noMatching_throws() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class, query::last);
     }
 
@@ -126,12 +126,12 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = select(TextField.class);
+        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField,
                 textFieldQuery.atIndex(1).getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = select(Button.class);
+        ComponentQuery<Button> buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.atIndex(1).getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -145,14 +145,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 last.getElement());
 
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertSame(last, query.atIndex(4).getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void atIndex_negativeOrZeroIndex_throws() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.atIndex(-10));
         Assertions.assertThrows(IllegalArgumentException.class,
@@ -164,7 +164,7 @@ class ComponentQueryTest extends UIUnitTest {
         Element rootElement = getCurrentView().getElement();
         rootElement.appendChild(new TextField().getElement(),
                 new TextField().getElement(), new TextField().getElement());
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertThrows(IndexOutOfBoundsException.class,
                 () -> query.atIndex(4));
         Assertions.assertThrows(IndexOutOfBoundsException.class,
@@ -173,14 +173,14 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void atIndex_noMatching_throws() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.atIndex(1));
     }
 
     @Test
     void all_noMatching_getsEmptyList() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         List<ComponentWrap<TextField>> result = query.all();
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.isEmpty(),
@@ -196,7 +196,7 @@ class ComponentQueryTest extends UIUnitTest {
         expectedComponents
                 .forEach(text -> rootElement.appendChild(text.getElement()));
 
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         List<ComponentWrap<TextField>> result = query.all();
         Assertions.assertNotNull(result);
         List<TextField> foundComponents = result.stream()
@@ -206,14 +206,14 @@ class ComponentQueryTest extends UIUnitTest {
         Assertions.assertIterableEquals(
                 Collections
                         .singleton(getCurrentView().getElement().getChild(0)),
-                select(Text.class).allComponents().stream()
+                $(Text.class).allComponents().stream()
                         .map(Component::getElement)
                         .collect(Collectors.toList()));
     }
 
     @Test
     void allComponents_noMatching_getsEmptyList() {
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         List<TextField> result = query.allComponents();
         Assertions.assertNotNull(result);
         Assertions.assertEquals(0, result.size(),
@@ -229,14 +229,14 @@ class ComponentQueryTest extends UIUnitTest {
         expectedComponents
                 .forEach(text -> rootElement.appendChild(text.getElement()));
 
-        ComponentQuery<TextField> query = select(TextField.class);
+        ComponentQuery<TextField> query = $(TextField.class);
         List<TextField> result = query.allComponents();
         Assertions.assertIterableEquals(expectedComponents, result);
 
         Assertions.assertIterableEquals(
                 Collections
                         .singleton(getCurrentView().getElement().getChild(0)),
-                select(Text.class).allComponents().stream()
+                $(Text.class).allComponents().stream()
                         .map(Component::getElement)
                         .collect(Collectors.toList()));
     }
@@ -256,12 +256,12 @@ class ComponentQueryTest extends UIUnitTest {
                 new Div(context, textField3).getElement(),
                 textField4.getElement());
 
-        List<TextField> result = select(TextField.class).from(context)
+        List<TextField> result = $(TextField.class).from(context)
                 .allComponents();
         Assertions.assertIterableEquals(List.of(textField1, textField2),
                 result);
 
-        result = selectFromCurrentView(TextField.class).allComponents();
+        result = $view(TextField.class).allComponents();
         Assertions.assertIterableEquals(List.of(textField5, textField1,
                 textField2, textField3, textField4), result);
 
@@ -275,7 +275,7 @@ class ComponentQueryTest extends UIUnitTest {
                 new Div(context, new TextField()).getElement(),
                 new TextField().getElement());
 
-        List<TextField> result = select(TextField.class).from(context)
+        List<TextField> result = $(TextField.class).from(context)
                 .allComponents();
         Assertions.assertTrue(result.isEmpty());
     }
@@ -288,7 +288,7 @@ class ComponentQueryTest extends UIUnitTest {
         rootElement.appendChild(new Div(context, new TextField()).getElement(),
                 new TextField().getElement());
 
-        List<TextField> result = select(TextField.class).from(context)
+        List<TextField> result = $(TextField.class).from(context)
                 .allComponents();
         Assertions.assertTrue(result.isEmpty());
     }
@@ -306,12 +306,12 @@ class ComponentQueryTest extends UIUnitTest {
         Element rootElement = getCurrentView().getElement();
         rootElement.appendChild(context.getElement());
 
-        List<TextField> result = select(TextField.class).from(context)
+        List<TextField> result = $(TextField.class).from(context)
                 .allComponents();
         Assertions.assertIterableEquals(Collections.singleton(inViewTextField),
                 result);
 
-        ComponentWrap<TextField> foundTextField = select(TextField.class)
+        ComponentWrap<TextField> foundTextField = $(TextField.class)
                 .from(context).id("myId");
         Assertions.assertSame(inViewTextField, foundTextField.getComponent());
 
@@ -328,8 +328,7 @@ class ComponentQueryTest extends UIUnitTest {
                 }).peek(field -> rootElement.appendChild(field.getElement()))
                 .collect(Collectors.toList());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
 
         textFields.forEach(field -> Assertions.assertSame(field,
                 query.id(field.getId().orElse("")).getComponent()));
@@ -343,8 +342,7 @@ class ComponentQueryTest extends UIUnitTest {
         textField.setId("myId");
         rootElement.appendChild(textField.getElement());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.id("test"));
     }
@@ -357,8 +355,7 @@ class ComponentQueryTest extends UIUnitTest {
         button.setId("myId");
         rootElement.appendChild(button.getElement());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.id("myId"));
     }
@@ -374,8 +371,7 @@ class ComponentQueryTest extends UIUnitTest {
                 }).peek(field -> rootElement.appendChild(field.getElement()))
                 .collect(Collectors.toList());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
 
         for (TextField expected : textFields) {
             List<TextField> result = query.withId(expected.getId().orElse(""))
@@ -393,8 +389,7 @@ class ComponentQueryTest extends UIUnitTest {
         textField.setId("myId");
         rootElement.appendChild(textField.getElement());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
         Assertions
                 .assertTrue(query.withId("wrongId").allComponents().isEmpty());
     }
@@ -407,8 +402,7 @@ class ComponentQueryTest extends UIUnitTest {
         button.setId("myId");
         rootElement.appendChild(button.getElement());
 
-        ComponentQuery<TextField> query = selectFromCurrentView(
-                TextField.class);
+        ComponentQuery<TextField> query = $view(TextField.class);
         Assertions.assertTrue(query.withId("myId").allComponents().isEmpty());
     }
 
@@ -425,9 +419,8 @@ class ComponentQueryTest extends UIUnitTest {
         rootElement.appendChild(new TextField().getElement());
 
         Assertions.assertSame(textField,
-                select(TextField.class)
-                        .withPropertyValue(TextField::getLabel, label).first()
-                        .getComponent());
+                $(TextField.class).withPropertyValue(TextField::getLabel, label)
+                        .first().getComponent());
     }
 
     @Test
@@ -440,9 +433,8 @@ class ComponentQueryTest extends UIUnitTest {
         rootElement.appendChild(textField2.getElement());
 
         Assertions.assertSame(textField,
-                select(TextField.class)
-                        .withPropertyValue(TextField::getLabel, null).first()
-                        .getComponent());
+                $(TextField.class).withPropertyValue(TextField::getLabel, null)
+                        .first().getComponent());
     }
 
     @Test
@@ -454,7 +446,7 @@ class ComponentQueryTest extends UIUnitTest {
         textField2.setLabel("Another label");
         rootElement.appendChild(textField2.getElement());
 
-        Assertions.assertTrue(select(TextField.class)
+        Assertions.assertTrue($(TextField.class)
                 .withPropertyValue(TextField::getLabel, "The label").all()
                 .isEmpty());
     }
@@ -470,12 +462,12 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement());
 
-        List<Div> result = select(Div.class)
+        List<Div> result = $(Div.class)
                 .withCondition(div -> div.getChildren().findAny().isPresent())
                 .allComponents();
         Assertions.assertIterableEquals(Collections.singleton(div2), result);
 
-        result = select(Div.class).withCondition(div -> {
+        result = $(Div.class).withCondition(div -> {
             double value = div.getElement().getProperty("numeric-prop", 0.0);
             return value > 1 && value < 3;
         }).allComponents();
@@ -494,12 +486,12 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(
                 new Div(firstMatch).getElement(), new TextField().getElement());
 
-        List<TextField> result = select(Div.class).withId("myId")
+        List<TextField> result = $(Div.class).withId("myId")
                 .thenOnFirst(TextField.class).allComponents();
         Assertions.assertIterableEquals(List.of(deepNested, nested1, nested2),
                 result);
 
-        result = select(Div.class).withId("myId").thenOnFirst(Div.class)
+        result = $(Div.class).withId("myId").thenOnFirst(Div.class)
                 .withId("nestedDiv").thenOnFirst(TextField.class)
                 .allComponents();
         Assertions.assertIterableEquals(List.of(deepNested), result);
@@ -511,7 +503,7 @@ class ComponentQueryTest extends UIUnitTest {
         div.setVisible(false);
         UI.getCurrent().getElement().appendChild(div.getElement());
 
-        ComponentQuery<Div> query = select(Div.class);
+        ComponentQuery<Div> query = $(Div.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.thenOnFirst(TextField.class));
     }
@@ -526,7 +518,7 @@ class ComponentQueryTest extends UIUnitTest {
                 new Div(new TextField()).getElement(),
                 new Div(new TextField()).getElement());
 
-        List<TextField> result = select(Div.class).thenOn(3, TextField.class)
+        List<TextField> result = $(Div.class).thenOn(3, TextField.class)
                 .allComponents();
         Assertions.assertIterableEquals(List.of(nested), result);
     }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
@@ -34,7 +34,7 @@ public class ComponentWrapTest extends UIUnitTest {
 
     @Test
     public void canGetWrapperForView_viewIsUsable() {
-        final ComponentWrap<WelcomeView> home_ = $(home);
+        final ComponentWrap<WelcomeView> home_ = wrap(home);
         Assertions.assertTrue(home_.isUsable(),
                 "Home should be visible and interactable");
     }
@@ -43,7 +43,7 @@ public class ComponentWrapTest extends UIUnitTest {
     public void componentIsDisabled_isUsableReturnsFalse() {
         home.getElement().setEnabled(false);
 
-        final ComponentWrap<WelcomeView> home_ = $(home);
+        final ComponentWrap<WelcomeView> home_ = wrap(home);
         Assertions.assertFalse(home_.isUsable(),
                 "Home should be visible but not interactable");
     }
@@ -52,18 +52,18 @@ public class ComponentWrapTest extends UIUnitTest {
     public void componentIsHidden_isUsableReturnsFalse() {
         home.setVisible(false);
 
-        final ComponentWrap<WelcomeView> home_ = $(home);
+        final ComponentWrap<WelcomeView> home_ = wrap(home);
         Assertions.assertFalse(home_.isUsable(),
                 "Home should not be interactable when component is not visible");
     }
 
     @Test
     public void componentModality_componentIsUsableReturnsCorrectly() {
-        final ComponentWrap<WelcomeView> home_ = $(home);
+        final ComponentWrap<WelcomeView> home_ = wrap(home);
 
         final Span span = new Span();
         home.add(span);
-        final ComponentWrap<Span> span_ = $(span);
+        final ComponentWrap<Span> span_ = wrap(span);
 
         Assertions.assertTrue(span_.isUsable(),
                 "Span should be attached to the ui");
@@ -83,11 +83,11 @@ public class ComponentWrapTest extends UIUnitTest {
 
     @Test
     public void componentModality_modalityDropsOnComponentRemoval() {
-        final ComponentWrap<WelcomeView> home_ = $(home);
+        final ComponentWrap<WelcomeView> home_ = wrap(home);
 
         final Span span = new Span();
         home.add(span);
-        final ComponentWrap<Span> span_ = $(span);
+        final ComponentWrap<Span> span_ = wrap(span);
 
         Assertions.assertTrue(span_.isUsable(),
                 "Span should be attached to the ui");
@@ -112,7 +112,7 @@ public class ComponentWrapTest extends UIUnitTest {
     public void parentNotVisible_childIsNotInteractable() {
         final Span span = new Span();
         home.add(span);
-        final ComponentWrap<Span> span_ = $(span);
+        final ComponentWrap<Span> span_ = wrap(span);
 
         Assertions.assertTrue(span_.isUsable(),
                 "Span should be attached to the ui");
@@ -127,7 +127,7 @@ public class ComponentWrapTest extends UIUnitTest {
     public void nonAttachedComponent_isNotInteractable() {
         Span span = new Span();
 
-        ComponentWrap<Span> span_ = $(span);
+        ComponentWrap<Span> span_ = wrap(span);
 
         Assertions.assertFalse(span_.isUsable(),
                 "Span is not attached so it is not usable.");

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
@@ -27,20 +27,20 @@ public class WrapperResolutionTest extends UIUnitTest {
     public void wrapTest_returnsTestWrap() {
         TestComponent tc = new TestComponent();
 
-        Assertions.assertTrue($(tc) instanceof TestWrap);
+        Assertions.assertTrue(wrap(tc) instanceof TestWrap);
     }
 
     @Test
     public void wrapComponentExtendingTest_returnsTestWrap() {
         MyTest mt = new MyTest();
 
-        Assertions.assertTrue($(mt) instanceof TestWrap);
+        Assertions.assertTrue(wrap(mt) instanceof TestWrap);
     }
 
     @Test
     public void wrapOtherComponent_returnsGenericComponentWrap() {
         SpecialComponent sc = new SpecialComponent();
-        Assertions.assertTrue($(sc).getClass().equals(ComponentWrap.class));
+        Assertions.assertTrue(wrap(sc).getClass().equals(ComponentWrap.class));
     }
 
     public static class MyTest extends TestComponent {


### PR DESCRIPTION
To be consistent with TestBench, `select` is now `$`,
`selectFromCurrenView` is `$view` and current `$` becomes `wrap`.

Fixes #1378