### PR TITLE
feat: added mixin interfaces for wrappers

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/WithAllWrappers.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/unit/WithAllWrappers.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit;
+
+import com.vaadin.flow.component.button.ButtonWrap;
+import com.vaadin.flow.component.notification.NotificationWrap;
+import com.vaadin.flow.component.textfield.TextFieldWrap;
+
+/**
+ * A mixin interface that brings in all known specific wrapper creation
+ * functions.
+ *
+ * To be used with {@link UIUnitTest} to reduce the need for explicit casts when
+ * getting test wrapper for component instances.
+ */
+public interface WithAllWrappers
+        extends TextFieldWrap.Mixin, ButtonWrap.Mixin, NotificationWrap.Mixin {
+}

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
@@ -12,8 +12,6 @@ package com.vaadin.flow.component.button;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
-import com.vaadin.flow.component.textfield.TextFieldWrap;
 import com.vaadin.testbench.unit.ComponentQuery;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.MetaKeys;
@@ -132,8 +130,8 @@ public class ButtonWrap<T extends Button> extends ComponentWrap<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public interface Mixin extends Mixable {
 
-        Kind<Button, ButtonWrap<Button>> BUTTON = new Kind<>(Button.class,
-                (Class) ButtonWrap.class);
+        GenericKind<Button, ButtonWrap<Button>> BUTTON = new GenericKind<>(
+                Button.class, (Class) ButtonWrap.class);
 
         default <T extends Button> ButtonWrap<T> wrap(T textField) {
             return wrap(ButtonWrap.class, textField);

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
@@ -10,6 +10,7 @@
 package com.vaadin.flow.component.button;
 
 import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.MetaKeys;
@@ -90,4 +91,48 @@ public class ButtonWrap<T extends Button> extends ComponentWrap<T> {
                         metaKeys.isCtrl(), metaKeys.isShift(), metaKeys.isAlt(),
                         metaKeys.isMeta()));
     }
+
+    /**
+     * Mixin interface to simplify creation of {@link ButtonWrap} wrappers for
+     * component instances, avoiding explicit casts.
+     *
+     * Wrapper creation is based on {@link ComponentWrap.Discover}
+     * functionality, so this mixin requires to be applied on a class already
+     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
+     * method.
+     *
+     * Usually used with test classes extending
+     * {@link com.vaadin.testbench.unit.UIUnitTest}.
+     *
+     *
+     * <pre>
+     * {@code
+     * class ViewTest extends UIUnitTest implements ButtonWrap.Mapper {
+     *
+     *     &#64;Test
+     *     void useCaseTest() {
+     *         ...
+     *         // given view.save is a Button
+     *         TheView view = navigate(TheView.class);
+     *
+     *         // without mapper mixin
+     *         ButtonWrap button_ = wrap(ButtonWrap.class, view.save);
+     *         button_.click();
+     *
+     *         // with mixin
+     *         wrap(view.save).click();
+     *         ...
+     *     }
+     * }
+     * }
+     * </pre>
+     */
+    public interface Mixin extends ComponentWrap.Discover {
+
+        @SuppressWarnings("unchecked")
+        default <T extends Button> ButtonWrap<T> wrap(T textField) {
+            return wrap(ButtonWrap.class, textField);
+        }
+    }
+
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/button/ButtonWrap.java
@@ -12,6 +12,9 @@ package com.vaadin.flow.component.button;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
+import com.vaadin.flow.component.textfield.TextFieldWrap;
+import com.vaadin.testbench.unit.ComponentQuery;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.Wraps;
@@ -96,10 +99,9 @@ public class ButtonWrap<T extends Button> extends ComponentWrap<T> {
      * Mixin interface to simplify creation of {@link ButtonWrap} wrappers for
      * component instances, avoiding explicit casts.
      *
-     * Wrapper creation is based on {@link ComponentWrap.Discover}
-     * functionality, so this mixin requires to be applied on a class already
-     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
-     * method.
+     * Wrapper creation is based on {@link Mixable} functionality, so this mixin
+     * requires to be applied on a class already implementing the
+     * {@link Mixable#wrap(Class, Component)} method.
      *
      * Usually used with test classes extending
      * {@link com.vaadin.testbench.unit.UIUnitTest}.
@@ -127,11 +129,23 @@ public class ButtonWrap<T extends Button> extends ComponentWrap<T> {
      * }
      * </pre>
      */
-    public interface Mixin extends ComponentWrap.Discover {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public interface Mixin extends Mixable {
 
-        @SuppressWarnings("unchecked")
+        Kind<Button, ButtonWrap<Button>> BUTTON = new Kind<>(Button.class,
+                (Class) ButtonWrap.class);
+
         default <T extends Button> ButtonWrap<T> wrap(T textField) {
             return wrap(ButtonWrap.class, textField);
+        }
+
+        default ComponentQuery<Button, ButtonWrap<Button>> $button() {
+            return $(Button.class);
+        }
+
+        default <T extends Button> ComponentQuery<T, ButtonWrap<T>> $button(
+                Class<T> componentType) {
+            return $(componentType);
         }
     }
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
@@ -13,8 +13,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 
+import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.textfield.TextFieldWrap;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.testbench.unit.ComponentQuery;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.MouseButton;
@@ -320,6 +324,35 @@ public class GridWrap<T extends Grid<Y>, Y> extends ComponentWrap<T> {
             throw new RuntimeException("Failed to get internal id for column",
                     e);
         }
+    }
+
+    public interface Mixin extends Mixable {
+
+        GridKind<Object, Grid<Object>> GRID = new GridKind<>(
+                (Class) Grid.class);
+
+        default <T extends Grid<V>, V> GridWrap<T, V> wrap(T grid) {
+            return wrap(GridWrap.class, grid);
+        }
+
+        default <V, T extends Grid<V>, W extends GridWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
+                GridKind<V, T> kind) {
+            return $(kind.componentType);
+        }
+
+        default <V, T extends Grid<V>, W extends GridWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
+                GridKind kind, Class<V> valueType) {
+            return (Q) $(kind.componentType);
+        }
+    }
+
+    public static class GridKind<V, C extends Grid<V>>
+            extends Mixable.TypedKind<V, C, GridWrap<C, V>> {
+
+        private GridKind(Class<C> componentType) {
+            super(componentType, (Class) GridWrap.class);
+        }
+
     }
 
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/notification/NotificationWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/notification/NotificationWrap.java
@@ -92,10 +92,9 @@ public class NotificationWrap<T extends Notification> extends ComponentWrap<T> {
      * Mixin interface to simplify creation of {@link TextFieldWrap} wrappers
      * for component instances, avoiding explicit casts.
      *
-     * Wrapper creation is based on {@link ComponentWrap.Discover}
-     * functionality, so this mixin requires to be applied on a class already
-     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
-     * method.
+     * Wrapper creation is based on {@link Mixable} functionality, so this mixin
+     * requires to be applied on a class already implementing the
+     * {@link Mixable#wrap(Class, Component)} method.
      *
      * Usually used with test classes extending
      * {@link com.vaadin.testbench.unit.UIUnitTest}.
@@ -122,7 +121,7 @@ public class NotificationWrap<T extends Notification> extends ComponentWrap<T> {
      * }
      * </pre>
      */
-    public interface Mixin extends ComponentWrap.Discover {
+    public interface Mixin extends Mixable {
 
         @SuppressWarnings("unchecked")
         default <T extends Notification> NotificationWrap<T> wrap(

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/notification/NotificationWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/notification/NotificationWrap.java
@@ -9,6 +9,8 @@
  */
 package com.vaadin.flow.component.notification;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.textfield.TextFieldWrap;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
@@ -85,4 +87,48 @@ public class NotificationWrap<T extends Notification> extends ComponentWrap<T> {
         element.getNode().getFeature(ElementListenerMap.class).fireEvent(
                 new DomEvent(element, "open-changed", Json.createObject()));
     }
+
+    /**
+     * Mixin interface to simplify creation of {@link TextFieldWrap} wrappers
+     * for component instances, avoiding explicit casts.
+     *
+     * Wrapper creation is based on {@link ComponentWrap.Discover}
+     * functionality, so this mixin requires to be applied on a class already
+     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
+     * method.
+     *
+     * Usually used with test classes extending
+     * {@link com.vaadin.testbench.unit.UIUnitTest}.
+     *
+     *
+     * <pre>
+     * {@code
+     * class ViewTest extends UIUnitTest implements TextFieldWrap.Mapper {
+     *
+     *     &#64;Test
+     *     void useCaseTest() {
+     *         ...
+     *         TheView view = navigate(TheView.class);
+     *         Notification notification = getNotifications().get(0);
+     *
+     *         NotificationWrap notification_ = wrap(NotificationWrap.class, notification);
+     *         Assertions.assertEquals("Job completed", notification_.getText());
+     *
+     *         // with mixin
+     *         Assertions.assertEquals("Job completed", wrap(view.notification).getText());
+     *         ...
+     *     }
+     * }
+     * }
+     * </pre>
+     */
+    public interface Mixin extends ComponentWrap.Discover {
+
+        @SuppressWarnings("unchecked")
+        default <T extends Notification> NotificationWrap<T> wrap(
+                T notification) {
+            return wrap(NotificationWrap.class, notification);
+        }
+    }
+
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
@@ -12,6 +12,9 @@ package com.vaadin.flow.component.textfield;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonWrap;
+import com.vaadin.testbench.unit.ComponentQuery;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.Wraps;
 
@@ -93,10 +96,9 @@ public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
      * Mixin interface to simplify creation of {@link TextFieldWrap} wrappers
      * for component instances, avoiding explicit casts.
      *
-     * Wrapper creation is based on {@link ComponentWrap.Discover}
-     * functionality, so this mixin requires to be applied on a class already
-     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
-     * method.
+     * Wrapper creation is based on {@link Mixable} functionality, so this mixin
+     * requires to be applied on a class already implementing the
+     * {@link Mixable#wrap(Class, Component)} method.
      *
      * Usually used with test classes extending
      * {@link com.vaadin.testbench.unit.UIUnitTest}.
@@ -124,13 +126,49 @@ public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
      * }
      * </pre>
      */
-    public interface Mixin extends ComponentWrap.Discover {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public interface Mixin extends Mixable {
 
-        @SuppressWarnings("unchecked")
+        TextFieldKind<String, TextField> TEXTFIELD = new TextFieldKind<>(
+                TextField.class);
+
         default <T extends GeneratedVaadinTextField<T, V>, V> TextFieldWrap<T, V> wrap(
                 T textField) {
             return wrap(TextFieldWrap.class, textField);
         }
+
+        default ComponentQuery<TextField, TextFieldWrap<TextField, String>> $textField() {
+            return $(TextField.class);
+        }
+
+        default <V, T extends GeneratedVaadinTextField<T, V>> ComponentQuery<T, TextFieldWrap<T, V>> $textField(
+                Class<T> componentType) {
+            return $(componentType);
+        }
+
+        default <V, T extends GeneratedVaadinTextField<T, V>, W extends TextFieldWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
+                TextFieldKind<V, T> kind) {
+            return $(kind.componentType);
+        }
+
+        default <V, T extends GeneratedVaadinTextField<T, V>, W extends TextFieldWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
+                TextFieldKind kind, Class<V> valueType) {
+            return (Q) $(kind.componentType);
+        }
+    }
+
+    public static class TextFieldKind<V, C extends GeneratedVaadinTextField<C, V>>
+            extends Mixable.TypedKind<V, C, TextFieldWrap<C, V>> {
+
+        private TextFieldKind(Class<C> componentType) {
+            super(componentType, (Class) TextFieldWrap.class);
+        }
+
+        public <X, Y extends GeneratedVaadinTextField<Y, X>> TextFieldKind<X, Y> as(
+                Class<Y> ct) {
+            return new TextFieldKind<>(ct);
+        }
+
     }
 
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
@@ -27,7 +27,7 @@ import com.vaadin.testbench.unit.Wraps;
  *            value type
  */
 @Wraps({ TextField.class, PasswordField.class, EmailField.class,
-        BigDecimalField.class })
+        BigDecimalField.class, IntegerField.class })
 public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
         extends ComponentWrap<T> {
 
@@ -147,14 +147,15 @@ public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
         }
 
         default <V, T extends GeneratedVaadinTextField<T, V>, W extends TextFieldWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
-                TextFieldKind<V, T> kind) {
-            return $(kind.componentType);
+                TextFieldKind kind) {
+            return (Q) $(kind.componentType);
         }
 
         default <V, T extends GeneratedVaadinTextField<T, V>, W extends TextFieldWrap<? extends T, V>, Q extends ComponentQuery<T, W>> Q $(
                 TextFieldKind kind, Class<V> valueType) {
             return (Q) $(kind.componentType);
         }
+
     }
 
     public static class TextFieldKind<V, C extends GeneratedVaadinTextField<C, V>>

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.textfield;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.Wraps;
 
@@ -87,4 +88,49 @@ public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
         // TextFields can be read only so the usable check needs extending
         return super.isUsable() && !getComponent().isReadOnly();
     }
+
+    /**
+     * Mixin interface to simplify creation of {@link TextFieldWrap} wrappers
+     * for component instances, avoiding explicit casts.
+     *
+     * Wrapper creation is based on {@link ComponentWrap.Discover}
+     * functionality, so this mixin requires to be applied on a class already
+     * implementing the {@link ComponentWrap.Discover#wrap(Class, Component)}
+     * method.
+     *
+     * Usually used with test classes extending
+     * {@link com.vaadin.testbench.unit.UIUnitTest}.
+     *
+     *
+     * <pre>
+     * {@code
+     * class ViewTest extends UIUnitTest implements TextFieldWrap.Mapper {
+     *
+     *     &#64;Test
+     *     void useCaseTest() {
+     *         ...
+     *         // given view.firstName is a TextField
+     *         TheView view = navigate(TheView.class);
+     *
+     *         // without mapper mixin
+     *         TextFieldWrap tf_ = wrap(TextFieldWrapper.class, view.firstName);
+     *         tf_.setValue("John");
+     *
+     *         // with mixin
+     *         wrap(view.firstName).setValue("John");
+     *         ...
+     *     }
+     * }
+     * }
+     * </pre>
+     */
+    public interface Mixin extends ComponentWrap.Discover {
+
+        @SuppressWarnings("unchecked")
+        default <T extends GeneratedVaadinTextField<T, V>, V> TextFieldWrap<T, V> wrap(
+                T textField) {
+            return wrap(TextFieldWrap.class, textField);
+        }
+    }
+
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -48,7 +48,7 @@ import com.vaadin.testbench.unit.mocks.MockedUI;
  *
  * For internal use only. May be renamed or removed in a future release.
  */
-class BaseUIUnitTest {
+class BaseUIUnitTest implements ComponentWrap.Discover {
 
     private static final ConcurrentHashMap<String, Routes> routesCache = new ConcurrentHashMap<>();
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -287,7 +287,14 @@ class BaseUIUnitTest implements ComponentWrap.Discover {
      */
     public <T extends ComponentWrap<Y>, Y extends Component> T wrap(
             Class<T> wrap, Y component) {
-        return (T) initialize(wrap, component);
+        Class<? extends ComponentWrap> bestMatch = getWrapper(
+                component.getClass());
+        // Always use the best wrapper candidate, unless required wrapper type
+        // is completely unrelated to the one discovered
+        if (!wrap.isAssignableFrom(bestMatch)) {
+            bestMatch = wrap;
+        }
+        return (T) initialize(bestMatch, component);
     }
 
     private <Y extends Component> Class<? extends ComponentWrap> getWrapper(

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -44,9 +44,11 @@ import com.vaadin.testbench.unit.internal.SearchSpec;
  *
  * @param <T>
  *            the type of the component(s) to search for
+ * @param <W>
+ *            the type of the wrapper for the target component
  * @see ComponentWrap
  */
-public class ComponentQuery<T extends Component> {
+public class ComponentQuery<T extends Component, W extends ComponentWrap<? extends T>> {
 
     private final Class<T> componentType;
     private final Function<Component, ? extends ComponentWrap<?>> wrapperFactory;
@@ -83,7 +85,7 @@ public class ComponentQuery<T extends Component> {
      *            getter function to a component instance
      * @return this element query instance for chaining
      */
-    public <V> ComponentQuery<T> withPropertyValue(Function<T, V> getter,
+    public <V> ComponentQuery<T, W> withPropertyValue(Function<T, V> getter,
             V expectedValue) {
         Objects.requireNonNull(getter, "getter function must not be null");
         locatorSpec.predicates
@@ -105,7 +107,7 @@ public class ComponentQuery<T extends Component> {
      * @return this element query instance for chaining
      * @see com.vaadin.flow.component.HasValue#getValue()
      */
-    public <V> ComponentQuery<T> withValue(V expectedValue) {
+    public <V> ComponentQuery<T, W> withValue(V expectedValue) {
         locatorSpec.value = expectedValue;
         return this;
     }
@@ -117,7 +119,7 @@ public class ComponentQuery<T extends Component> {
      *            the id to look up
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withId(String id) {
+    public ComponentQuery<T, W> withId(String id) {
         locatorSpec.id = id;
         // At most one element with given id is expected
         locatorSpec.count = new IntRange(0, 1);
@@ -131,7 +133,7 @@ public class ComponentQuery<T extends Component> {
      *            the condition to check against the components.
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withCondition(Predicate<T> condition) {
+    public ComponentQuery<T, W> withCondition(Predicate<T> condition) {
         Objects.requireNonNull(condition, "condition must not be null");
         locatorSpec.predicates.add(condition);
         return this;
@@ -147,7 +149,8 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withClassName(String className, String... other) {
+    public ComponentQuery<T, W> withClassName(String className,
+            String... other) {
         if (className == null) {
             throw new IllegalArgumentException("className must not be null");
         }
@@ -172,7 +175,7 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withoutClassName(String className,
+    public ComponentQuery<T, W> withoutClassName(String className,
             String... other) {
         if (className == null) {
             throw new IllegalArgumentException("className must not be null");
@@ -194,7 +197,7 @@ public class ComponentQuery<T extends Component> {
      *            theme that should exist on the component.
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withTheme(String theme) {
+    public ComponentQuery<T, W> withTheme(String theme) {
         if (locatorSpec.themes == null || locatorSpec.themes.isEmpty()) {
             locatorSpec.themes = theme;
         } else {
@@ -210,7 +213,7 @@ public class ComponentQuery<T extends Component> {
      *            theme that should not exist on the component.
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withoutTheme(String theme) {
+    public ComponentQuery<T, W> withoutTheme(String theme) {
         if (locatorSpec.withoutThemes == null
                 || locatorSpec.withoutThemes.isEmpty()) {
             locatorSpec.withoutThemes = theme;
@@ -232,7 +235,7 @@ public class ComponentQuery<T extends Component> {
      *            the text the component is expected to have as its caption
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withCaption(String caption) {
+    public ComponentQuery<T, W> withCaption(String caption) {
         locatorSpec.caption = caption;
         locatorSpec.captionExactMatch = true;
         return this;
@@ -250,7 +253,7 @@ public class ComponentQuery<T extends Component> {
      *            the text the component is expected to have as its caption
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withCaptionContaining(String text) {
+    public ComponentQuery<T, W> withCaptionContaining(String text) {
         if (text == null) {
             throw new IllegalArgumentException("text must not be null");
         }
@@ -267,7 +270,7 @@ public class ComponentQuery<T extends Component> {
      * @return this element query instance for chaining
      * @see Element#getText()
      */
-    public ComponentQuery<T> withText(String text) {
+    public ComponentQuery<T, W> withText(String text) {
         locatorSpec.text = text;
         locatorSpec.textExactMatch = true;
         return this;
@@ -281,7 +284,7 @@ public class ComponentQuery<T extends Component> {
      * @return this element query instance for chaining
      * @see Element#getText()
      */
-    public ComponentQuery<T> withTextContaining(String text) {
+    public ComponentQuery<T, W> withTextContaining(String text) {
         if (text == null) {
             throw new IllegalArgumentException("text must not be null");
         }
@@ -300,7 +303,7 @@ public class ComponentQuery<T extends Component> {
      * @throws IllegalArgumentException
      *             if {@code count} is negative
      */
-    public ComponentQuery<T> withResultsSize(int count) {
+    public ComponentQuery<T, W> withResultsSize(int count) {
         if (count < 0) {
             throw new IllegalArgumentException(
                     "count must be greater or equal than zero, but was "
@@ -323,7 +326,7 @@ public class ComponentQuery<T extends Component> {
      *             if {@code min} or {@code max} are negative, or if {@code min}
      *             is greater than {@code max}
      */
-    public ComponentQuery<T> withResultsSize(int min, int max) {
+    public ComponentQuery<T, W> withResultsSize(int min, int max) {
         if (min < 0) {
             throw new IllegalArgumentException(
                     "min must be greater or equal than zero, but was " + min);
@@ -352,7 +355,7 @@ public class ComponentQuery<T extends Component> {
      *             if {@code min} or {@code max} are negative, or if {@code min}
      *             is greater than {@code max}
      */
-    public ComponentQuery<T> withMinResults(int min) {
+    public ComponentQuery<T, W> withMinResults(int min) {
         return withResultsSize(min, locatorSpec.count.getEndInclusive());
     }
 
@@ -367,7 +370,7 @@ public class ComponentQuery<T extends Component> {
      *             if {@code min} or {@code max} are negative, or if {@code min}
      *             is greater than {@code max}
      */
-    public ComponentQuery<T> withMaxResults(int max) {
+    public ComponentQuery<T, W> withMaxResults(int max) {
         return withResultsSize(locatorSpec.count.getStart(), max);
     }
 
@@ -380,7 +383,7 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withAttribute(String attribute) {
+    public ComponentQuery<T, W> withAttribute(String attribute) {
         locatorSpec.predicates.add(ElementConditions.hasAttribute(attribute));
         return this;
     }
@@ -396,7 +399,7 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withAttribute(String attribute, String value) {
+    public ComponentQuery<T, W> withAttribute(String attribute, String value) {
         locatorSpec.predicates
                 .add(ElementConditions.hasAttribute(attribute, value));
         return this;
@@ -410,7 +413,7 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withoutAttribute(String attribute) {
+    public ComponentQuery<T, W> withoutAttribute(String attribute) {
         locatorSpec.predicates
                 .add(ElementConditions.hasNotAttribute(attribute));
         return this;
@@ -427,7 +430,8 @@ public class ComponentQuery<T extends Component> {
      *
      * @return this element query instance for chaining
      */
-    public ComponentQuery<T> withoutAttribute(String attribute, String value) {
+    public ComponentQuery<T, W> withoutAttribute(String attribute,
+            String value) {
         locatorSpec.predicates
                 .add(ElementConditions.hasNotAttribute(attribute, value));
         return this;
@@ -445,7 +449,7 @@ public class ComponentQuery<T extends Component> {
      * @throws java.util.NoSuchElementException
      *             if first component is found
      */
-    public <E extends Component> ComponentQuery<E> thenOnFirst(
+    public <E extends Component, F extends ComponentWrap<E>> ComponentQuery<E, F> thenOnFirst(
             Class<E> componentType) {
         return thenOn(1, componentType);
     }
@@ -471,9 +475,9 @@ public class ComponentQuery<T extends Component> {
      * @throws java.util.NoSuchElementException
      *             if current query does not produce results
      */
-    public <E extends Component> ComponentQuery<E> thenOn(int index,
-            Class<E> componentType) {
-        return new ComponentQuery<>(componentType, wrapperFactory)
+    public <E extends Component, F extends ComponentWrap<? extends E>> ComponentQuery<E, F> thenOn(
+            int index, Class<E> componentType) {
+        return new ComponentQuery<E, F>(componentType, wrapperFactory)
                 .from(atIndex(index).getComponent());
     }
 
@@ -504,7 +508,7 @@ public class ComponentQuery<T extends Component> {
      *             if no component is found
      */
     @SuppressWarnings("unchecked")
-    public <X extends ComponentWrap<? extends T>> X first() {
+    public <X extends W> X first() {
         return (X) allComponents().stream().findFirst().map(wrapperFactory)
                 .orElseThrow(() -> new NoSuchElementException(
                         "Cannot find component for current query"));
@@ -631,7 +635,7 @@ public class ComponentQuery<T extends Component> {
      *            a component used as starting element for search.
      * @return this component query instance for chaining.
      */
-    public ComponentQuery<T> from(Component context) {
+    public ComponentQuery<T, W> from(Component context) {
         this.context = context;
         return this;
     }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
 
 /**
@@ -195,13 +194,20 @@ public class ComponentWrap<T extends Component> {
      */
     public interface Mixable {
 
-        class Kind<C extends Component, W extends ComponentWrap<? extends C>> {
+        abstract class Kind<C extends Component, W extends ComponentWrap<? extends C>> {
             public final Class<W> wrapperType;
             public final Class<C> componentType;
 
-            public Kind(Class<C> componentType, Class<W> wrapperType) {
+            protected Kind(Class<C> componentType, Class<W> wrapperType) {
                 this.wrapperType = wrapperType;
                 this.componentType = componentType;
+            }
+        }
+
+        class GenericKind<C extends Component, W extends ComponentWrap<? extends C>>
+                extends Kind<C, W> {
+            public GenericKind(Class<C> componentType, Class<W> wrapperType) {
+                super(componentType, wrapperType);
             }
 
             public <V> TypedKind<V, C, W> typed(Class<V> type) {
@@ -235,7 +241,7 @@ public class ComponentWrap<T extends Component> {
                 Class<T> componentType);
 
         default <T extends Component, W extends ComponentWrap<? extends T>, Q extends ComponentQuery<T, W>> Q $(
-                Kind<T, W> kind) {
+                GenericKind<T, W> kind) {
             return $(kind.componentType);
         }
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
@@ -188,11 +188,35 @@ public class ComponentWrap<T extends Component> {
             throw new RuntimeException(e);
         }
     }
+
     /**
      * Discovers and instantiates the best matching test wrapper for a specific
      * component type.
      */
-    public interface Discover {
+    public interface Mixable {
+
+        class Kind<C extends Component, W extends ComponentWrap<? extends C>> {
+            public final Class<W> wrapperType;
+            public final Class<C> componentType;
+
+            public Kind(Class<C> componentType, Class<W> wrapperType) {
+                this.wrapperType = wrapperType;
+                this.componentType = componentType;
+            }
+
+            public <V> TypedKind<V, C, W> typed(Class<V> type) {
+                return new TypedKind<>(componentType, wrapperType);
+            }
+        }
+
+        class TypedKind<V, C extends Component, W extends ComponentWrap<? extends C>>
+                extends Kind<C, W> {
+            public TypedKind(Class<C> componentType, Class<W> wrapperType) {
+                super(componentType, wrapperType);
+            }
+
+        }
+
         /**
          * Wrap component with wrapper best matching component type.
          *
@@ -206,5 +230,14 @@ public class ComponentWrap<T extends Component> {
          */
         <T extends ComponentWrap<Y>, Y extends Component> T wrap(Class<T> wrap,
                 Y component);
+
+        <T extends Component, W extends ComponentWrap<? extends T>, Q extends ComponentQuery<T, W>> Q $(
+                Class<T> componentType);
+
+        default <T extends Component, W extends ComponentWrap<? extends T>, Q extends ComponentQuery<T, W>> Q $(
+                Kind<T, W> kind) {
+            return $(kind.componentType);
+        }
+
     }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
@@ -188,4 +188,23 @@ public class ComponentWrap<T extends Component> {
             throw new RuntimeException(e);
         }
     }
+    /**
+     * Discovers and instantiates the best matching test wrapper for a specific
+     * component type.
+     */
+    public interface Discover {
+        /**
+         * Wrap component with wrapper best matching component type.
+         *
+         * @param component
+         *            component to get test wrapper for
+         * @param <T>
+         *            wrapper type
+         * @param <Y>
+         *            component type
+         * @return component in wrapper with test helpers
+         */
+        <T extends ComponentWrap<Y>, Y extends Component> T wrap(Class<T> wrap,
+                Y component);
+    }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/WithAllWrappers.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/WithAllWrappers.java
@@ -11,6 +11,7 @@
 package com.vaadin.testbench.unit;
 
 import com.vaadin.flow.component.button.ButtonWrap;
+import com.vaadin.flow.component.grid.GridWrap;
 import com.vaadin.flow.component.notification.NotificationWrap;
 import com.vaadin.flow.component.textfield.TextFieldWrap;
 
@@ -21,6 +22,6 @@ import com.vaadin.flow.component.textfield.TextFieldWrap;
  * To be used with {@link UIUnitTest} to reduce the need for explicit casts when
  * getting test wrapper for component instances.
  */
-public interface WithAllWrappers
-        extends TextFieldWrap.Mixin, ButtonWrap.Mixin, NotificationWrap.Mixin {
+public interface WithAllWrappers extends TextFieldWrap.Mixin, ButtonWrap.Mixin,
+        NotificationWrap.Mixin, GridWrap.Mixin {
 }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
@@ -19,7 +19,7 @@ import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.UIUnitTest;
 
-public class ButtonWrapTest extends UIUnitTest {
+public class ButtonWrapTest extends UIUnitTest implements ButtonWrap.Mixin {
 
     @Override
     protected String scanPackage() {
@@ -32,7 +32,7 @@ public class ButtonWrapTest extends UIUnitTest {
         button.setDisableOnClick(true);
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
+        final ButtonWrap button_ = wrap(button);
 
         Assertions.assertTrue(button_.isUsable(),
                 "Button should be usable before click");
@@ -55,8 +55,7 @@ public class ButtonWrapTest extends UIUnitTest {
 
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
-        button_.middleClick();
+        wrap(button).middleClick();
 
         Assertions.assertEquals(1, mouseButton.get(),
                 "Click event should have sent with middle click");
@@ -70,8 +69,7 @@ public class ButtonWrapTest extends UIUnitTest {
 
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
-        button_.rightClick();
+        wrap(button).rightClick();
 
         Assertions.assertEquals(2, mouseButton.get(),
                 "Click event should have sent with right click");
@@ -85,8 +83,7 @@ public class ButtonWrapTest extends UIUnitTest {
                 clickEvent -> event.compareAndSet(null, clickEvent));
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
-        button_.click();
+        wrap(button).click();
 
         Assertions.assertNotNull(event.get(),
                 "event should have fired and recorded");
@@ -107,7 +104,7 @@ public class ButtonWrapTest extends UIUnitTest {
         button.addClickListener(clickEvent -> event.set(clickEvent));
         getCurrentView().getElement().appendChild(button.getElement());
 
-        final ButtonWrap button_ = wrap(ButtonWrap.class, button);
+        ButtonWrap<Button> button_ = wrap(button);
         button_.click(new MetaKeys(true, true, true, true));
 
         Assertions.assertNotNull(event.get(),

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
@@ -128,4 +128,5 @@ public class ButtonWrapTest extends UIUnitTest implements ButtonWrap.Mixin {
         Assertions.assertFalse(event.get().isMetaKey(),
                 "Meta should not have been used");
     }
+
 }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
@@ -14,7 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.testbench.unit.UIUnitTest;
 
-class NotificationWrapTest extends UIUnitTest {
+class NotificationWrapTest extends UIUnitTest
+        implements NotificationWrap.Mixin {
 
     @Override
     protected String scanPackage() {
@@ -25,8 +26,7 @@ class NotificationWrapTest extends UIUnitTest {
     void notOpenedNotification_isNotUsable() {
         Notification notification = new Notification("Not Opened");
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
 
         Assertions.assertFalse(notification_.isUsable(),
                 "Not opened Notification shouldn't be usable");
@@ -38,8 +38,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show(notificationText);
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         Assertions.assertTrue(notification_.isUsable(),
                 "Opened Notification should be usable");
     }
@@ -51,8 +50,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setEnabled(false);
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         Assertions.assertTrue(notification_.isUsable(),
                 "Disabled Notification should be usable");
     }
@@ -64,8 +62,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setVisible(false);
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         Assertions.assertFalse(notification_.isUsable(),
                 "Hidden Notification should not be usable");
     }
@@ -77,8 +74,7 @@ class NotificationWrapTest extends UIUnitTest {
         roundTrip();
         notification.close();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         Assertions.assertFalse(notification_.isUsable(),
                 "Closed Notification should not be usable");
     }
@@ -88,8 +84,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show("Some text");
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         notification_.autoClose();
 
         Assertions.assertFalse(notification_.isUsable(),
@@ -99,8 +94,7 @@ class NotificationWrapTest extends UIUnitTest {
     @Test
     void autoClose_notOpenedNotification_throws() {
         Notification notification = new Notification("Some text");
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
 
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::autoClose,
@@ -112,8 +106,7 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show("Some text");
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         notification_.autoClose();
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::autoClose,
@@ -126,8 +119,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.setDuration(0);
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::autoClose,
                 "Auto-close notification with auto-close disabled should fail");
@@ -139,18 +131,14 @@ class NotificationWrapTest extends UIUnitTest {
         Notification notification = Notification.show(notificationText);
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
-
-        Assertions.assertEquals(notificationText, notification_.getText());
+        Assertions.assertEquals(notificationText, wrap(notification).getText());
     }
 
     @Test
     void getText_notOpenedNotification_throws() {
         Notification notification = new Notification("Some text");
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
 
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::getText,
@@ -163,8 +151,7 @@ class NotificationWrapTest extends UIUnitTest {
         notification.close();
         roundTrip();
 
-        NotificationWrap<?> notification_ = wrap(NotificationWrap.class,
-                notification);
+        NotificationWrap<?> notification_ = wrap(notification);
 
         Assertions.assertThrows(IllegalStateException.class,
                 notification_::getText,

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -16,10 +16,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue.ValueChangeListener;
 import com.vaadin.testbench.unit.UIUnitTest;
 
-public class TextFieldWrapTest extends UIUnitTest {
+public class TextFieldWrapTest extends UIUnitTest
+        implements TextFieldWrap.Mixin {
 
     @Override
     protected String scanPackage() {
@@ -32,9 +34,7 @@ public class TextFieldWrapTest extends UIUnitTest {
         tf.setReadOnly(true);
         getCurrentView().getElement().appendChild(tf.getElement());
 
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
-
-        Assertions.assertFalse(tf_.isUsable(),
+        Assertions.assertFalse(wrap(tf).isUsable(),
                 "Read only TextField shouldn't be usable");
     }
 
@@ -44,7 +44,9 @@ public class TextFieldWrapTest extends UIUnitTest {
         tf.setReadOnly(true);
         getCurrentView().getElement().appendChild(tf.getElement());
 
-        Assertions.assertFalse(wrap(tf).isUsable(),
+        // Force cast to Component to bypass specific wrapper and test automatic
+        // wrapper discovery
+        Assertions.assertFalse(wrap((Component) tf).isUsable(),
                 "Read only TextField shouldn't be usable");
     }
 
@@ -60,9 +62,8 @@ public class TextFieldWrapTest extends UIUnitTest {
                     value.compareAndSet(null, event.getValue());
                 });
 
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
         final String newValue = "Test";
-        tf_.setValue(newValue);
+        wrap(tf).setValue(newValue);
 
         Assertions.assertEquals(newValue, value.get());
     }
@@ -73,7 +74,7 @@ public class TextFieldWrapTest extends UIUnitTest {
         getCurrentView().getElement().appendChild(tf.getElement());
 
         tf.getElement().setEnabled(false);
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
+        final TextFieldWrap tf_ = wrap(tf);
 
         Assertions.assertThrows(IllegalStateException.class,
                 () -> tf_.setValue("fail"),

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -56,11 +56,11 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
+        var textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField, textFieldQuery.first().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = $(Button.class);
+        var buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.first().getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -74,14 +74,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 new TextField().getElement());
 
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertSame(first, query.first().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void first_noMatching_throws() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class, query::first);
     }
 
@@ -94,11 +94,11 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
+        var textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField, textFieldQuery.last().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = $(Button.class);
+        var buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.last().getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -112,14 +112,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 last.getElement());
 
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertSame(last, query.last().getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void last_noMatching_throws() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class, query::last);
     }
 
@@ -132,12 +132,12 @@ class ComponentQueryTest extends UIUnitTest {
         Button button = new Button();
         root.appendChild(button.getElement());
 
-        ComponentQuery<TextField> textFieldQuery = $(TextField.class);
+        var textFieldQuery = $(TextField.class);
         Assertions.assertSame(textField,
                 textFieldQuery.atIndex(1).getComponent(),
                 "Expecting query to find TextField component, but got different instance");
 
-        ComponentQuery<Button> buttonQuery = $(Button.class);
+        var buttonQuery = $(Button.class);
         Assertions.assertSame(button, buttonQuery.atIndex(1).getComponent(),
                 "Expecting query to find Button component, but got different instance");
 
@@ -151,14 +151,14 @@ class ComponentQueryTest extends UIUnitTest {
                 new TextField().getElement(), new TextField().getElement(),
                 last.getElement());
 
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertSame(last, query.atIndex(4).getComponent(),
                 "Expecting query to find TextField component, but got different instance");
     }
 
     @Test
     void atIndex_negativeOrZeroIndex_throws() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.atIndex(-10));
         Assertions.assertThrows(IllegalArgumentException.class,
@@ -170,7 +170,7 @@ class ComponentQueryTest extends UIUnitTest {
         Element rootElement = getCurrentView().getElement();
         rootElement.appendChild(new TextField().getElement(),
                 new TextField().getElement(), new TextField().getElement());
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertThrows(IndexOutOfBoundsException.class,
                 () -> query.atIndex(4));
         Assertions.assertThrows(IndexOutOfBoundsException.class,
@@ -179,14 +179,14 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void atIndex_noMatching_throws() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.atIndex(1));
     }
 
     @Test
     void all_noMatching_getsEmptyList() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         List<ComponentWrap<TextField>> result = query.all();
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.isEmpty(),
@@ -202,7 +202,7 @@ class ComponentQueryTest extends UIUnitTest {
         expectedComponents
                 .forEach(text -> rootElement.appendChild(text.getElement()));
 
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         List<ComponentWrap<TextField>> result = query.all();
         Assertions.assertNotNull(result);
         List<TextField> foundComponents = result.stream()
@@ -219,7 +219,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void allComponents_noMatching_getsEmptyList() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         List<TextField> result = query.allComponents();
         Assertions.assertNotNull(result);
         Assertions.assertEquals(0, result.size(),
@@ -235,7 +235,7 @@ class ComponentQueryTest extends UIUnitTest {
         expectedComponents
                 .forEach(text -> rootElement.appendChild(text.getElement()));
 
-        ComponentQuery<TextField> query = $(TextField.class);
+        var query = $(TextField.class);
         List<TextField> result = query.allComponents();
         Assertions.assertIterableEquals(expectedComponents, result);
 
@@ -334,7 +334,7 @@ class ComponentQueryTest extends UIUnitTest {
                 }).peek(field -> rootElement.appendChild(field.getElement()))
                 .collect(Collectors.toList());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
 
         textFields.forEach(field -> Assertions.assertSame(field,
                 query.id(field.getId().orElse("")).getComponent()));
@@ -348,7 +348,7 @@ class ComponentQueryTest extends UIUnitTest {
         textField.setId("myId");
         rootElement.appendChild(textField.getElement());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.id("test"));
     }
@@ -361,7 +361,7 @@ class ComponentQueryTest extends UIUnitTest {
         button.setId("myId");
         rootElement.appendChild(button.getElement());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.id("myId"));
     }
@@ -377,7 +377,7 @@ class ComponentQueryTest extends UIUnitTest {
                 }).peek(field -> rootElement.appendChild(field.getElement()))
                 .collect(Collectors.toList());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
 
         for (TextField expected : textFields) {
             List<TextField> result = query.withId(expected.getId().orElse(""))
@@ -395,7 +395,7 @@ class ComponentQueryTest extends UIUnitTest {
         textField.setId("myId");
         rootElement.appendChild(textField.getElement());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
         Assertions
                 .assertTrue(query.withId("wrongId").allComponents().isEmpty());
     }
@@ -408,7 +408,7 @@ class ComponentQueryTest extends UIUnitTest {
         button.setId("myId");
         rootElement.appendChild(button.getElement());
 
-        ComponentQuery<TextField> query = $view(TextField.class);
+        var query = $view(TextField.class);
         Assertions.assertTrue(query.withId("myId").allComponents().isEmpty());
     }
 
@@ -605,7 +605,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withCaptionContaining_null_throws() {
-        ComponentQuery<TestComponent> query = $(TestComponent.class);
+        var query = $(TestComponent.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withCaptionContaining(null));
     }
@@ -660,7 +660,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withTextContaining_null_throws() {
-        ComponentQuery<Span> query = $(Span.class);
+        var query = $(Span.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withTextContaining(null));
     }
@@ -702,14 +702,14 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement(), div3.getElement(), div4.getElement());
 
         IntStream.rangeClosed(0, 10).filter(i -> i != 4).forEach(i -> {
-            ComponentQuery<Div> query = $(Div.class).withResultsSize(i);
+            var query = $(Div.class).withResultsSize(i);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withResultsSize_negative_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1));
     }
@@ -786,21 +786,21 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement(), div3.getElement(), div4.getElement());
 
         IntStream.rangeClosed(1, 3).forEach(count -> {
-            ComponentQuery<Div> query = $(Div.class).withMaxResults(count);
+            var query = $(Div.class).withMaxResults(count);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withMaxResults_negative_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMaxResults(-1));
     }
 
     @Test
     void withMaxResults_lowerThanMin_throws() {
-        ComponentQuery<Div> query = $(Div.class).withMinResults(4);
+        var query = $(Div.class).withMinResults(4);
         query.withMaxResults(4); // same as min is OK, must not throw
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMaxResults(2));
@@ -845,21 +845,21 @@ class ComponentQueryTest extends UIUnitTest {
                 div2.getElement());
 
         IntStream.rangeClosed(3, 10).forEach(count -> {
-            ComponentQuery<Div> query = $(Div.class).withMinResults(count);
+            var query = $(Div.class).withMinResults(count);
             Assertions.assertThrows(AssertionError.class, query::allComponents);
         });
     }
 
     @Test
     void withMinResults_negative_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMinResults(-1));
     }
 
     @Test
     void withMinResults_greaterThanMax_throws() {
-        ComponentQuery<Div> query = $(Div.class).withMaxResults(2);
+        var query = $(Div.class).withMaxResults(2);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withMinResults(10));
     }
@@ -886,7 +886,7 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        ComponentQuery<Div> query = $(Div.class).withResultsSize(5, 10);
+        var query = $(Div.class).withResultsSize(5, 10);
         Assertions.assertThrows(AssertionError.class, query::allComponents);
 
         query = $(Div.class).withResultsSize(1, 3);
@@ -896,21 +896,21 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withResultsSize_minNegative_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(-1, 10));
     }
 
     @Test
     void withResultsSize_maxNegative_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(2, -1));
     }
 
     @Test
     void withResultsSize_maxLowerThanMin_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withResultsSize(5, 2));
     }
@@ -958,7 +958,7 @@ class ComponentQueryTest extends UIUnitTest {
         div.setVisible(false);
         UI.getCurrent().getElement().appendChild(div.getElement());
 
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 () -> query.thenOnFirst(TextField.class));
     }
@@ -1139,7 +1139,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withClass_nullClassNames_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withClassName(null));
         Assertions.assertThrows(IllegalArgumentException.class,
@@ -1254,7 +1254,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void withoutClass_nullClassNames_throws() {
-        ComponentQuery<Div> query = $(Div.class);
+        var query = $(Div.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withoutClassName(null));
         Assertions.assertThrows(IllegalArgumentException.class,

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.textfield.TextFieldWrap;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.testbench.unit.ComponentWrapTest.Span;
 import com.vaadin.testbench.unit.ElementConditionsTest.TextComponent;
@@ -1394,7 +1395,7 @@ class ComponentQueryTest extends UIUnitTest {
 
     @Test
     void exists_noMatching_false() {
-        ComponentQuery<TextField> query = $(TextField.class);
+        ComponentQuery<?, ?> query = $(TextField.class);
         Assertions.assertFalse(query.exists(),
                 "Expecting no components to be found, but exists is true");
     }
@@ -1425,11 +1426,11 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        ComponentQuery<Span> queryNonExistent = $(Span.class);
+        ComponentQuery<?, ?> queryNonExistent = $(Span.class);
         Assertions.assertThrows(NoSuchElementException.class,
                 queryNonExistent::single);
 
-        ComponentQuery<Div> query = $(Div.class).withClassName("my-test");
+        ComponentQuery<?, ?> query = $(Div.class).withClassName("my-test");
         Assertions.assertThrows(NoSuchElementException.class, query::single);
     }
 
@@ -1442,7 +1443,7 @@ class ComponentQueryTest extends UIUnitTest {
         UI.getCurrent().getElement().appendChild(div1.getElement(),
                 div2.getElement(), div3.getElement(), div4.getElement());
 
-        ComponentQuery<Div> query = $(Div.class);
+        ComponentQuery<?, ?> query = $(Div.class);
         Assertions.assertThrows(NoSuchElementException.class, query::single);
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/MixinWrapperTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/MixinWrapperTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.textfield.IntegerField;
+
+public class MixinWrapperTest extends UIUnitTest implements WithAllWrappers {
+
+    @Test
+    void kind_getsCorrectWrapper() {
+        $(BUTTON).first().click();
+        $(TEXTFIELD).first().setValue("xx");
+        $(TEXTFIELD.as(IntegerField.class)).first().setValue(12);
+        $(TEXTFIELD, BigDecimal.class).first().setValue(new BigDecimal(10));
+        $(GRID).first().select(1);
+        $(GRID, Address.class).first().getSelected().iterator().next().city();
+    }
+
+    static class Address {
+        String city() {
+            return null;
+        }
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/MixinWrapperTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/MixinWrapperTest.java
@@ -14,23 +14,42 @@ import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.TextField;
 
-public class MixinWrapperTest extends UIUnitTest implements WithAllWrappers {
+class MixinWrapperTest extends UIUnitTest implements WithAllWrappers {
 
     @Test
     void kind_getsCorrectWrapper() {
+
+        Grid<Address> grid = new Grid<>(Address.class);
+        grid.setItems(new Address("Udine"), new Address("Vicenza"));
+        getCurrentView().getElement().appendChild(new Button().getElement(),
+                new TextField().getElement(), new IntegerField().getElement(),
+                new BigDecimalField().getElement(), grid.getElement());
+
         $(BUTTON).first().click();
         $(TEXTFIELD).first().setValue("xx");
         $(TEXTFIELD.as(IntegerField.class)).first().setValue(12);
-        $(TEXTFIELD, BigDecimal.class).first().setValue(new BigDecimal(10));
+        $(TEXTFIELD.as(BigDecimalField.class)).first()
+                .setValue(new BigDecimal(10));
         $(GRID).first().select(1);
-        $(GRID, Address.class).first().getSelected().iterator().next().city();
+        $(GRID, Address.class).first().getSelected().iterator().next()
+                .getCity();
     }
 
     static class Address {
-        String city() {
-            return null;
+        private String city;
+
+        public Address(String city) {
+            this.city = city;
+        }
+
+        String getCity() {
+            return city;
         }
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
@@ -62,11 +62,32 @@ public class WrapperResolutionTest extends UIUnitTest {
                 detectComponentType(NonGenericTestWrap.class));
     }
 
+    @Test
+    public void wrapTest_requireExtendedWrapper_returnsExtendedTestWrap() {
+        TestComponent tc = new TestComponent();
+        Assertions.assertInstanceOf(ExtendedTestWrap.class,
+                wrap(ExtendedTestWrap.class, tc));
+    }
+
+    @Test
+    public void wrapTest_requireLessSpecificWrapper_returnsTestWrap() {
+        TestComponent tc = new TestComponent();
+        Assertions.assertInstanceOf(TestWrap.class,
+                wrap(ComponentWrap.class, tc));
+    }
+
     public static class MyTest extends TestComponent {
     }
 
     @Tag("div")
     public static class SpecialComponent extends Component {
+    }
+
+    public static class ExtendedTestWrap<T extends TestComponent>
+            extends TestWrap<TestComponent> {
+        public ExtendedTestWrap(TestComponent component) {
+            super(component);
+        }
     }
 
     static class MyWrap<Y, Z extends TestComponent> extends ComponentWrap<Z> {


### PR DESCRIPTION
Wrapper mixin interfaces provides specific overloads of method in order
to reduce the number of explicit casts of wrapper references in unit tests.

Closes #1379