### PR TITLE
feat: enable using FQN in wraps

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
@@ -31,7 +31,7 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
  * @param <Y>
  *            item type
  */
-//@Wraps(Grid.class) // TODO: Having Grid in the annotation fails dokka:javadoc
+@Wraps(fqn = { "com.vaadin.flow.component.grid.Grid" })
 public class GridWrap<T extends Grid<Y>, Y> extends ComponentWrap<T> {
     /**
      * Wrap grid for testing.

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.testbench.unit;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,6 +66,19 @@ class BaseUIUnitTest {
                                 wrapperMap.put(component,
                                         (Class<? extends ComponentWrap>) wrapper);
                             }
+                            // -- Enable annotation with fqn for components with
+                            // generics
+                            final String[] classes = wrapper
+                                    .getAnnotation(Wraps.class).fqn();
+
+                            Arrays.stream(classes).map(clazz -> {
+                                try {
+                                    return Class.forName(clazz);
+                                } catch (ClassNotFoundException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }).forEach(clazz -> wrapperMap.put(clazz,
+                                    (Class<? extends ComponentWrap>) wrapper));
 
                         } catch (ClassNotFoundException e) {
                             throw new RuntimeException(e);

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/Wraps.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/Wraps.java
@@ -33,5 +33,7 @@ public @interface Wraps {
      *
      * @return {@link Component} classes that can be wrapped
      */
-    Class<? extends Component>[] value();
+    Class<? extends Component>[] value() default {};
+
+    String[] fqn() default {};
 }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
@@ -30,7 +30,7 @@ public class BasicGridWrapTest extends UIUnitTest {
     @BeforeEach
     void init() {
         view = navigate(BasicGridView.class);
-        grid_ = wrap(GridWrap.class, view.basicGrid);
+        grid_ = wrap(view.basicGrid);
     }
 
     @Test
@@ -149,15 +149,18 @@ public class BasicGridWrapTest extends UIUnitTest {
     @Test
     void basicGrid_doubleClick() {
         AtomicInteger doubleClicks = new AtomicInteger(0);
-        view.basicGrid.addItemDoubleClickListener(event -> doubleClicks.incrementAndGet());
+        view.basicGrid.addItemDoubleClickListener(
+                event -> doubleClicks.incrementAndGet());
 
         grid_.clickRow(0);
 
-        Assertions.assertEquals(0, doubleClicks.get(), "Click should not generate a double click event");
+        Assertions.assertEquals(0, doubleClicks.get(),
+                "Click should not generate a double click event");
 
         grid_.doubleClickRow(0);
 
-        Assertions.assertEquals(1, doubleClicks.get(), "Double click event should have fired");
+        Assertions.assertEquals(1, doubleClicks.get(),
+                "Double click event should have fired");
 
     }
 }


### PR DESCRIPTION
Using the fully qualified name in wraps
bypasses the dokka problem with
Components having generics.
