### PR TITLE
fix: BasicGridView is not available in scan all

### DIFF
--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridView.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.router.Route;
 
 @Tag("div")
-@Route("basic-grid")
+@Route(value = "basic-grid", registerAtStartup = false)
 public class BasicGridView extends Component implements HasComponents {
 
     Grid<Person> basicGrid = new Grid<>();

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
 
 public class BasicGridWrapTest extends UIUnitTest {
@@ -29,6 +30,9 @@ public class BasicGridWrapTest extends UIUnitTest {
 
     @BeforeEach
     void init() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(BasicGridView.class);
+
         view = navigate(BasicGridView.class);
         grid_ = wrap(view.basicGrid);
     }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -76,7 +76,6 @@ public class UIUnit4BaseClassTest {
                     TestRoutes.INSTANCE.getViews());
             allViews.add(SingleParam.class);
             allViews.add(TemplatedParam.class);
-            allViews.add(BasicGridView.class); // TODO: should not be
             Assert.assertEquals(allViews.size(), routes.size());
             Assert.assertTrue(routes.containsAll(allViews));
         }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -69,7 +69,6 @@ class UIUnitBaseClassTest {
                     TestRoutes.INSTANCE.getViews());
             allViews.add(SingleParam.class);
             allViews.add(TemplatedParam.class);
-            allViews.add(BasicGridView.class); // TODO: should not be
             Assertions.assertEquals(allViews.size(), routes.size());
             Assertions.assertTrue(routes.containsAll(allViews));
         }


### PR DESCRIPTION
Make component view not register at
startup so it will not break scan all.

