### PR TITLE
feat: Allow providing custom service implementations for Lookup

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -94,8 +95,9 @@ class BaseUIUnitTest {
                 pn -> new Routes().autoDiscoverViews(pn));
     }
 
-    protected void initVaadinEnvironment() {
-        MockVaadin.setup(discoverRoutes(scanPackage()), UI::new);
+    protected void initVaadinEnvironment(Class<?>... lookupService) {
+        MockVaadin.setup(discoverRoutes(scanPackage()), UI::new,
+                Set.of(lookupService));
     }
 
     protected void cleanVaadinEnvironment() {

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -19,16 +19,28 @@ import org.junit.Before;
  * for faster bootstrap by overriding {@link #scanPackage()} method.
  *
  * Set up of Vaadin environment is performed before each test by
- * {@link #initVaadinEnvironment()} method, and will be executed before
+ * {@link #initVaadinEnvironment()}} method, and will be executed before
  * {@code @Before} methods defined in subclasses. At the same way, cleanup tasks
  * operated by {@link #cleanVaadinEnvironment()} are executed after each test,
  * and after all {@code @After} annotated methods in subclasses.
  *
+ * Custom Flow service implementations supported by
+ * {@link com.vaadin.flow.di.Lookup} SPI can be provided overriding
+ * {@link #initVaadinEnvironment()} and passing to super implementation the
+ * service classes that should be initialized during setup.
+ *
+ * <pre>
+ * {@code
+ * &#64;Override
+ * public void initVaadinEnvironment() {
+ *     super.initVaadinEnvironment(CustomInstantiatorFactory.class);
+ * }
+ * }
+ * </pre>
  */
 public abstract class UIUnit4Test extends BaseUIUnitTest {
 
     @Before
-    @Override
     public void initVaadinEnvironment() {
         super.initVaadinEnvironment();
     }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -19,7 +19,7 @@ import org.junit.Before;
  * for faster bootstrap by overriding {@link #scanPackage()} method.
  *
  * Set up of Vaadin environment is performed before each test by
- * {@link #initVaadinEnvironment()}} method, and will be executed before
+ * {@link #initVaadinEnvironment()} method, and will be executed before
  * {@code @Before} methods defined in subclasses. At the same way, cleanup tasks
  * operated by {@link #cleanVaadinEnvironment()} are executed after each test,
  * and after all {@code @After} annotated methods in subclasses.

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -29,11 +29,25 @@ import org.junit.jupiter.api.BeforeEach;
  * mandatory to add the {@code @BeforeEach} and {@code @AfterEach} annotations
  * in the subclass, in order to have hooks handled by testing framework.
  *
+ * A use case for overriding {@link #initVaadinEnvironment()} is to provide
+ * custom Flow service implementations supported by
+ * {@link com.vaadin.flow.di.Lookup} SPI. Implementations can be provided
+ * overriding {@link #initVaadinEnvironment()} and passing to super
+ * implementation the service classes that should be initialized during setup.
+ *
+ * <pre>
+ * {@code
+ * &#64;BeforeEach
+ * &#64;Override
+ * void initVaadinEnvironment() {
+ *     super.initVaadinEnvironment(CustomInstantiatorFactory.class);
+ * }
+ * }
+ * </pre>
  */
 public abstract class UIUnitTest extends BaseUIUnitTest {
 
     @BeforeEach
-    @Override
     protected void initVaadinEnvironment() {
         super.initVaadinEnvironment();
     }

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/MockVaadin.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/MockVaadin.kt
@@ -77,14 +77,16 @@ object MockVaadin {
      * provide all necessary mocking code.
      * @param routes all classes annotated with [com.vaadin.flow.router.Route]; use [Routes.autoDiscoverViews] to auto-discover all such classes.
      * @param uiFactory produces [UI] instances and sets them as current, by default simply instantiates [MockedUI] class.
+     * @param lookupServices service classes to be provided to the lookup initializer
      */
     @JvmStatic
     @JvmOverloads
     fun setup(routes: Routes = Routes(),
-              uiFactory: () -> UI = { MockedUI() }) {
+              uiFactory: () -> UI = { MockedUI() },
+              lookupServices: Set<Class<*>> = emptySet()) {
         // init servlet
         val servlet = MockVaadinServlet(routes)
-        setup(uiFactory, servlet)
+        setup(uiFactory, servlet, lookupServices)
     }
 
     /**
@@ -102,11 +104,14 @@ object MockVaadin {
      * and construct a custom service which overrides important methods.
      * Please consult [com.vaadin.testbench.unit.mocks.MockService]
      * on what methods you must override in your custom service.
+     * @param lookupServices service classes to be provided to the lookup initializer
      */
     @JvmStatic
-    fun setup(uiFactory: () -> UI = { MockedUI() }, servlet: VaadinServlet) {
+    fun setup(uiFactory: () -> UI = { MockedUI() }, servlet: VaadinServlet,
+              lookupServices: Set<Class<*>> = emptySet()
+              ) {
         if (!servlet.isInitialized) {
-            val ctx: ServletContext = MockVaadinHelper.createMockContext()
+            val ctx: ServletContext = MockVaadinHelper.createMockContext(lookupServices)
             servlet.init(MockServletConfig(ctx))
         }
         val service: VaadinServletService = checkNotNull(servlet.serviceSafe)

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockVaadinHelper.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockVaadinHelper.kt
@@ -41,9 +41,9 @@ object MockVaadinHelper {
         servlet.servletContext.setInitParameter("compatibilityMode", "false")
     }
 
-    fun createMockContext(): ServletContext {
+    fun createMockContext(lookupServices: Set<Class<*>> = emptySet()): ServletContext {
         val ctx = MockContext()
-        init(ctx)
+        init(ctx, lookupServices)
         return ctx
     }
 
@@ -90,11 +90,12 @@ object MockVaadinHelper {
     private fun verifyHasLookup(ctx: VaadinContext): Lookup =
             verifyHasLookup((ctx as VaadinServletContext).context)
 
-    private fun init(ctx: ServletContext) {
+    private fun init(ctx: ServletContext, lookupServices: Set<Class<*>> = emptySet()) {
 
         val loaderInitializer = LookupServletContainerInitializer()
 
         val loaders = mutableSetOf<Class<*>>(
+                *lookupServices.toTypedArray(),
                 LookupInitializer::class.java,
                 Class.forName("com.vaadin.flow.di.LookupInitializer${'$'}ResourceProviderImpl")
         )

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/TestCustomInstantiatorFactory.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/TestCustomInstantiatorFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit;
+
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * A custom {@link InstantiatorFactory} to test
+ * {@link com.vaadin.flow.di.Lookup} initialization.
+ */
+public class TestCustomInstantiatorFactory implements InstantiatorFactory {
+
+    @Override
+    public Instantiator createInstantitor(VaadinService vaadinService) {
+        return new DefaultInstantiator(vaadinService);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -18,13 +18,19 @@ import com.example.TemplatedParam;
 import com.example.base.WelcomeView;
 import com.example.base.child.ChildView;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.runner.RunWith;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.BasicGridView;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -96,6 +102,33 @@ public class UIUnit4BaseClassTest {
                     .collect(Collectors.toSet());
             Assert.assertEquals(1, routes.size());
             Assert.assertTrue(routes.contains(ChildView.class));
+        }
+    }
+
+    public static class CustomLookupServicesTest extends UIUnit4Test {
+
+        @Override
+        public void initVaadinEnvironment() {
+            super.initVaadinEnvironment(TestCustomInstantiatorFactory.class);
+        }
+
+        @Test
+        public void customService_availableInLookup() {
+            Lookup lookup = VaadinService.getCurrent().getContext()
+                    .getAttribute(Lookup.class);
+            Assert.assertNotNull("Expecting Lookup to be initialized", lookup);
+
+            InstantiatorFactory service = lookup
+                    .lookup(InstantiatorFactory.class);
+            Assert.assertNotNull(
+                    "Expecting service to be available through Lookup",
+                    service);
+            Assert.assertTrue(
+                    "Expecting service to "
+                            + TestCustomInstantiatorFactory.class
+                                    .getSimpleName()
+                            + " but was " + service.getClass().getSimpleName(),
+                    service instanceof TestCustomInstantiatorFactory);
         }
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -124,7 +124,7 @@ public class UIUnit4BaseClassTest {
                     "Expecting service to be available through Lookup",
                     service);
             Assert.assertTrue(
-                    "Expecting service to "
+                    "Expecting service to be "
                             + TestCustomInstantiatorFactory.class
                                     .getSimpleName()
                             + " but was " + service.getClass().getSimpleName(),

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -118,7 +118,7 @@ class UIUnitBaseClassTest {
                     "Expecting service to be available through Lookup");
             Assertions.assertInstanceOf(TestCustomInstantiatorFactory.class,
                     service,
-                    "Expecting service to "
+                    "Expecting service to be "
                             + TestCustomInstantiatorFactory.class
                                     .getSimpleName()
                             + " but was " + service.getClass().getSimpleName());

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -18,12 +18,15 @@ import com.example.TemplatedParam;
 import com.example.base.WelcomeView;
 import com.example.base.child.ChildView;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.grid.BasicGridView;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -90,6 +93,35 @@ class UIUnitBaseClassTest {
                     .collect(Collectors.toSet());
             Assertions.assertEquals(1, routes.size());
             Assertions.assertTrue(routes.contains(ChildView.class));
+        }
+    }
+
+    @Nested
+    class CustomLookupServicesTest extends UIUnitTest {
+
+        @BeforeEach
+        @Override
+        protected void initVaadinEnvironment() {
+            super.initVaadinEnvironment(TestCustomInstantiatorFactory.class);
+        }
+
+        @Test
+        void customService_availableInLookup() {
+            Lookup lookup = VaadinService.getCurrent().getContext()
+                    .getAttribute(Lookup.class);
+            Assertions.assertNotNull(lookup,
+                    "Expecting Lookup to be initialized");
+
+            InstantiatorFactory service = lookup
+                    .lookup(InstantiatorFactory.class);
+            Assertions.assertNotNull(service,
+                    "Expecting service to be available through Lookup");
+            Assertions.assertInstanceOf(TestCustomInstantiatorFactory.class,
+                    service,
+                    "Expecting service to "
+                            + TestCustomInstantiatorFactory.class
+                                    .getSimpleName()
+                            + " but was " + service.getClass().getSimpleName());
         }
     }
 


### PR DESCRIPTION
Unit tests may need to provide custom implementations for Flow services
discovered through Lookup, such as a custom InstantiatorFactory.
This changes allows to provide custom services overriding base test
initVaadinEnvironment method and calling super implementation with
classes to be initialized during setup.