### PR TITLE
feat: add pretty print on assert fail

### DIFF
--- a/vaadin-testbench-unit/pom.xml
+++ b/vaadin-testbench-unit/pom.xml
@@ -349,6 +349,11 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
             <version>4.8.146</version>

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
@@ -20,8 +20,8 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
  * JUnit5 extension that will collect and output the component tree for the
  * failing test UI.
  * <p>
- * This can help with identifying a problem that has happened
- * in the test where a component is missing or has faulty data.
+ * This can help with identifying a problem that has happened in the test where
+ * a component is missing or has faulty data.
  */
 public class TreeOnFailureExtension implements AfterTestExecutionCallback {
 
@@ -30,14 +30,12 @@ public class TreeOnFailureExtension implements AfterTestExecutionCallback {
         boolean testFailed = extensionContext.getExecutionException()
                 .isPresent();
         if (testFailed) {
-            final String prettyPrintTree = PrettyPrintTree.Companion.ofVaadin(
-                    UI.getCurrent()).print();
-            LoggerFactory.getLogger(TreeOnFailureExtension.class)
-                    .error("Test {}::{} failed with the tree:\n{}",
-                            extensionContext.getTestClass().get()
-                                    .getSimpleName(),
-                            extensionContext.getTestMethod().get().getName(),
-                            prettyPrintTree);
+            final String prettyPrintTree = PrettyPrintTree.Companion
+                    .ofVaadin(UI.getCurrent()).print();
+            extensionContext.publishReportEntry("Test "
+                    + extensionContext.getTestClass().get().getSimpleName()
+                    + "::" + extensionContext.getTestMethod().get().getName()
+                    + " failed with the tree:\n" + prettyPrintTree);
         }
     }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.testbench.unit;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.testbench.unit.internal.PrettyPrintTree;
+
+/**
+ * JUnit5 extension that will collect and output the component tree for the
+ * failing test UI.
+ * <p>
+ * This can help with identifying a problem that has happened
+ * in the test where a component is missing or has faulty data.
+ */
+public class TreeOnFailureExtension implements AfterTestExecutionCallback {
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        boolean testFailed = extensionContext.getExecutionException()
+                .isPresent();
+        if (testFailed) {
+            final String prettyPrintTree = PrettyPrintTree.Companion.ofVaadin(
+                    UI.getCurrent()).print();
+            LoggerFactory.getLogger(TreeOnFailureExtension.class)
+                    .error("Test {}::{} failed with the tree:\n{}",
+                            extensionContext.getTestClass().get()
+                                    .getSimpleName(),
+                            extensionContext.getTestMethod().get().getName(),
+                            prettyPrintTree);
+        }
+    }
+}

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -45,12 +45,15 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
  * }
  * }
  * </pre>
+ * <p/>
+ * To get a graphical ascii representation of the UI tree on failure override
+ * the {@link #printTree()} method to return true.
  */
 public abstract class UIUnit4Test extends BaseUIUnitTest {
 
     /**
-     * Override to return true to get component tree output into log
-     * on test failure.
+     * Override to return true to get component tree output into log on test
+     * failure.
      *
      * @return {@code true} to print component tree
      */
@@ -63,19 +66,16 @@ public abstract class UIUnit4Test extends BaseUIUnitTest {
         super.initVaadinEnvironment();
     }
 
-
     @Rule
     public TestRule treeOnFailure = new TestWatcher() {
         @Override
         protected void failed(Throwable e, Description description) {
             if (printTree()) {
-                            final String prettyPrintTree = PrettyPrintTree.Companion.ofVaadin(
-                                    UI.getCurrent()).print();
-//                String prettyPrintTree = new UITree(UI.getCurrent()).print();
-                LoggerFactory.getLogger("UIUnitTest")
-                        .error("Test {}::{} failed with the tree:\n{}",
-                                description.getTestClass(),
-                                description.getMethodName(), prettyPrintTree);
+                final String prettyPrintTree = PrettyPrintTree.Companion
+                        .ofVaadin(UI.getCurrent()).print();
+                System.out.println("Test " + description.getTestClass() + "::"
+                        + description.getMethodName()
+                        + " failed with the tree:\n" + prettyPrintTree);
             }
         }
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -11,6 +11,14 @@ package com.vaadin.testbench.unit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.testbench.unit.internal.PrettyPrintTree;
 
 /**
  * Base JUnit 4 class for UI unit tests.
@@ -40,14 +48,42 @@ import org.junit.Before;
  */
 public abstract class UIUnit4Test extends BaseUIUnitTest {
 
+    /**
+     * Override to return true to get component tree output into log
+     * on test failure.
+     *
+     * @return {@code true} to print component tree
+     */
+    public boolean printTree() {
+        return false;
+    }
+
     @Before
     public void initVaadinEnvironment() {
         super.initVaadinEnvironment();
     }
 
-    @After
-    @Override
-    public void cleanVaadinEnvironment() {
-        super.cleanVaadinEnvironment();
-    }
+
+    @Rule
+    public TestRule treeOnFailure = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            if (printTree()) {
+                            final String prettyPrintTree = PrettyPrintTree.Companion.ofVaadin(
+                                    UI.getCurrent()).print();
+//                String prettyPrintTree = new UITree(UI.getCurrent()).print();
+                LoggerFactory.getLogger("UIUnitTest")
+                        .error("Test {}::{} failed with the tree:\n{}",
+                                description.getTestClass(),
+                                description.getMethodName(), prettyPrintTree);
+            }
+        }
+
+        @Override
+        protected void finished(Description description) {
+            // Watcher handles cleaning of environment instead of After.
+            // Else the UI has been cleared, and we can not build the tree.
+            cleanVaadinEnvironment();
+        }
+    };
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -44,6 +44,10 @@ import org.junit.jupiter.api.BeforeEach;
  * }
  * }
  * </pre>
+ * <p>
+ * To get a graphical ascii representation of the ui tree on failure add the
+ * annotation {@code @ExtendWith(TreeOnFailureExtension.class)} to the test
+ * class.
  */
 public abstract class UIUnitTest extends BaseUIUnitTest {
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -44,8 +44,8 @@ import org.junit.jupiter.api.BeforeEach;
  * }
  * }
  * </pre>
- * <p>
- * To get a graphical ascii representation of the ui tree on failure add the
+ * <p/>
+ * To get a graphical ascii representation of the UI tree on failure add the
  * annotation {@code @ExtendWith(TreeOnFailureExtension.class)} to the test
  * class.
  */

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/BasicUtils.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/BasicUtils.kt
@@ -74,7 +74,6 @@ val Component._isVisible: Boolean
 val Component._text: String?
     get() = when (this) {
         is HasText -> text
-        is Text -> text   // workaround for https://github.com/vaadin/flow/issues/3606
         else -> null
     }
 

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTree.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTree.kt
@@ -102,7 +102,7 @@ fun Component.toPrettyString(): String {
     if (label != caption && caption.isNotBlank()) {
         list.add("caption='$caption'")
     }
-    if (!_text.isNullOrBlank()) {
+    if (!_text.isNullOrBlank() && _text != caption) {
         list.add("text='$_text'")
     }
     if (this is HasValue<*, *>) {
@@ -135,10 +135,13 @@ fun Component.toPrettyString(): String {
     // Any component with href should output it not only Anchor
     if (this.javaClass.kotlin.members.any { it.name == "href"}) {
         val f = this.javaClass.kotlin.members.find { it.name == "href" }
-        list.add("href='${f?.let {
+        val href = f?.let {
             it.isAccessible = true
             it.call(this)
-        }}'")
+        }
+        if (href != null) {
+            list.add("href='$href'")
+        }
     }
     if (this is Button && icon is Icon) {
         list.add("icon='${(icon as Icon).element.getAttribute("icon")}'")

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTree.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTree.kt
@@ -20,6 +20,8 @@ import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.html.Anchor
 import com.vaadin.flow.component.icon.Icon
 import com.vaadin.testbench.unit.internal.PrettyPrintTree.Companion.ofVaadin
+import kotlin.reflect.jvm.isAccessible
+
 
 /**
  * If true, [PrettyPrintTree] will use `\--` instead of `└──` which tend to render on some terminals as `???`.
@@ -100,7 +102,7 @@ fun Component.toPrettyString(): String {
     if (label != caption && caption.isNotBlank()) {
         list.add("caption='$caption'")
     }
-    if (!_text.isNullOrBlank() && this !is Button) {
+    if (!_text.isNullOrBlank()) {
         list.add("text='$_text'")
     }
     if (this is HasValue<*, *>) {
@@ -124,17 +126,21 @@ fun Component.toPrettyString(): String {
         }
     }
      */
-    if (!placeholder.isNullOrBlank()) {
-        list.add("placeholder='$placeholder'")
+    val ignoredAttr = mutableListOf("value", "invalid", "openOn", "label", "errorMessage", "innerHTML")
+    this.element.propertyNames.forEach {
+        if(!ignoredAttr.contains(it) && this.element.getProperty(it).isNotEmpty()) {
+            list.add("${it}='${this.element.getProperty(it)}'")
+        }
     }
-    if (this is Anchor) {
-        // TODO: FIX after importing Anchors
-        // list.add("href='$_href'")
-        list.add("href='${this.href}'")
+    // Any component with href should output it not only Anchor
+    if (this.javaClass.kotlin.members.any { it.name == "href"}) {
+        val f = this.javaClass.kotlin.members.find { it.name == "href" }
+        list.add("href='${f?.let {
+            it.isAccessible = true
+            it.call(this)
+        }}'")
     }
     if (this is Button && icon is Icon) {
-        // TODO: FIX after importing IconUtils
-        //list.add("icon='${(icon as Icon).iconName}'")
         list.add("icon='${(icon as Icon).element.getAttribute("icon")}'")
     }
     if (this is Html) {

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
@@ -40,9 +40,9 @@ internal fun DynaNodeGroup.locatorTest2() {
         val dlg = Dialog()
         dlg.open()
         expectThrows(AssertionError::class,
-            """Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0: [Dialog[]]. Component tree:
+            """Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0: [Dialog[opened='true']]. Component tree:
 └── MockedUI[]
-    └── Dialog[]
+    └── Dialog[opened='true']
 """) {
             _expectNoDialogs()
         }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
@@ -50,15 +50,42 @@ internal fun DynaNodeGroup.prettyPrintTreeTest() {
 """.trim()) { div.toPrettyTree().trim() }
     }
 
-    test("toPrettyString()") {
+    test("toPrettyStringHtmlComponent()") {
         expect("Text[text='foo']") { Text("foo").toPrettyString() }
         expect("Div[INVIS]") { Div().apply { isVisible = false }.toPrettyString() }
+        expect("Html[<b>foo bar baz <i>foobar</i></b>]") {
+            Html("\n    <b>foo\nbar\n    baz\n<i>foobar</i></b>").toPrettyString()
+        }
+        expect("HtmlSpan[innerHTML='aaa<b>bbbb</b>ccc']") {
+            HtmlSpan("aaa<b>bbbb</b>ccc").toPrettyString()
+        }
+        expect("Div[@title='foobar']") {
+            Div().apply { tooltip = "foobar" }.toPrettyString()
+        }
+        expect("Span[text='hi', @slot='prefix']") {
+            val testSpan = Span("hi")
+            TextField().prefixComponent = testSpan
+            testSpan.toPrettyString()
+        }
+    }
+    test("toPrettyStringTextField()") {
         expect("TextField[#25, value='']") {
             TextField().apply { id_ = "25" }.toPrettyString()
         }
-        expect("Button[caption='click me']") { Button("click me").toPrettyString() }
         expect("TextArea[label='label', value='some text']") { TextArea("label").apply { value = "some text" }.toPrettyString() }
+        expect("TextField[#25, value='', errorMessage='failed validation']") {
+            TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString()
+        }
+        expect("TextField[label='foobar', value='']") {
+            TextField("foobar").toPrettyString()
+        }
+    }
+    test("toPrettyStringButton()") {
+        expect("Button[caption='click me']") { Button("click me").toPrettyString() }
+        expect("Button[icon='vaadin:abacus', @theme='icon']") { Button(VaadinIcon.ABACUS.create()).toPrettyString() }
 
+    }
+//    test("toPrettyStringGrid()") {
         /* TODO: uncomment when importing Grid stuff
         expect("Grid[<String>, dataprovider='ListDataProvider2{0 items}']") { Grid<String>(String::class.java).apply { setItems2(listOf()) }.toPrettyString() }
         expect("Column[header='My Header']") {
@@ -68,35 +95,24 @@ internal fun DynaNodeGroup.prettyPrintTreeTest() {
             Grid<Any>().run { addColumn { it }.apply { header2 = "My Header"; key = "foo" } }.toPrettyString()
         }
          */
-        expect("Anchor[href='']") { Anchor().toPrettyString() }
+//    }
+    test("toPrettyStringAnchor()") {
+        expect("Anchor[]") { Anchor().toPrettyString() }
         expect("Anchor[href='vaadin.com']") { Anchor("vaadin.com").toPrettyString() }
+    }
+    test("toPrettyStringImage()") {
         expect("Image[]") { Image().toPrettyString() }
         expect("Image[@src='vaadin.com']") { Image("vaadin.com", "").toPrettyString() }
-        expect("TextField[#25, value='', errorMessage='failed validation']") {
-            TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString()
-        }
-        expect("TextField[label='foobar', value='']") {
-            TextField("foobar").toPrettyString()
-        }
+    }
+    test("toPrettyStringIcon()") {
         expect("Icon[@icon='vaadin:abacus']") { VaadinIcon.ABACUS.create().toPrettyString() }
-        expect("Button[icon='vaadin:abacus', @theme='icon']") { Button(VaadinIcon.ABACUS.create()).toPrettyString() }
+    }
+    test("toPrettyStringForm()") {
         expect("FormItem[label='foo']") { FormLayout().addFormItem(TextField(), "foo").toPrettyString() }
-        expect("Html[<b>foo bar baz <i>foobar</i></b>]") {
-            Html("\n    <b>foo\nbar\n    baz\n<i>foobar</i></b>").toPrettyString()
-        }
-        expect("HtmlSpan[innerHTML='aaa<b>bbbb</b>ccc']") {
-            HtmlSpan("aaa<b>bbbb</b>ccc").toPrettyString()
-        }
+    }
+    test("toPrettyStringCustomComponent()") {
         expect("MyComponentWithToString[my-div(25)]") {
             MyComponentWithToString().toPrettyString()
-        }
-        expect("Div[@title='foobar']") {
-            Div().apply { tooltip = "foobar" }.toPrettyString()
-        }
-        expect("Span[text='hi', @slot='prefix']") {
-            val testSpan = Span("hi")
-            TextField().prefixComponent = testSpan
-            testSpan.toPrettyString()
         }
     }
 
@@ -121,7 +137,7 @@ internal fun DynaNodeGroup.prettyPrintTreeTest() {
             }
         }
         expect("""
-└── ContextMenu[]
+└── ContextMenu[opened='false']
     ├── MenuItem[DISABLED, text='menu']
     │   └── MenuItem[text='click me']
     └── MenuItem[text='save as']""".trim()) { cm.toPrettyTree().trim() }


### PR DESCRIPTION
For Junit5 add `@ExtendWith(TreeOnFailureExtension.class)`
For Junit4 Override `printTree()` to return true

Fixes #1336
