### PR TITLE
feat!: Use test class package as base for classpath scan

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -36,8 +36,9 @@ import com.vaadin.flow.router.RouteParameters;
  *
  * Provides methods to set up and clean a mocked Vaadin environment.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap, by overriding {@link #scanPackage()} method.
+ * Classpath scanning is restricted to test class package and its subpackages
+ * for faster bootstrap, but surface can be widened or narrowed by overriding
+ * {@link #scanPackage()} method.
  *
  * For internal use only. May be renamed or removed in a future release.
  */
@@ -111,10 +112,12 @@ class BaseUIUnitTest {
      * Provide {@literal null} or empty string to scan the whole classpath, but
      * note that this may be quite slow.
      *
+     * Default is to scan the test class package and subpackages.
+     *
      * @return package name for classpath scanning.
      */
     protected String scanPackage() {
-        return null;
+        return getClass().getPackageName();
     }
 
     /**

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -9,13 +9,11 @@
  */
 package com.vaadin.testbench.unit;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.PrettyPrintTree;
@@ -23,8 +21,10 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
 /**
  * Base JUnit 4 class for UI unit tests.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap by overriding {@link #scanPackage()} method.
+ * For faster bootstrap, classpath scanning for routes and error views is
+ * restricted by default to the test class package and its subpackages, but
+ * surface can be widened or narrowed by subclasses overriding
+ * {@link #scanPackage()} method.
  *
  * Set up of Vaadin environment is performed before each test by
  * {@link #initVaadinEnvironment()} method, and will be executed before

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -15,8 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Base JUnit 5 class for UI unit tests.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap by overriding {@link #scanPackage()} method.
+ * For faster bootstrap, classpath scanning for routes and error views is
+ * restricted by default to the test class package and its subpackages, but
+ * surface can be widened or narrowed by subclasses overriding
+ * {@link #scanPackage()} method.
  *
  * Set up of Vaadin environment is performed before each test by
  * {@link #initVaadinEnvironment()} method, and will be executed before

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
@@ -18,11 +18,6 @@ import com.vaadin.testbench.unit.UIUnitTest;
 
 class AccordionWrapTest extends UIUnitTest {
 
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.flow.component.accordion";
-    }
-
     AccordionView view;
 
     @BeforeEach

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.button;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "button", registerAtStartup = false)
+public class ButtonView extends Component implements HasComponents {
+
+    final Button button = new Button();
+
+    public ButtonView() {
+        add(button);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
@@ -13,22 +13,28 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.UIUnitTest;
 
 public class ButtonWrapTest extends UIUnitTest {
 
-    @Override
-    protected String scanPackage() {
-        return "com.example";
+    ButtonView view;
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(ButtonView.class);
+        view = navigate(ButtonView.class);
     }
 
     @Test
     public void buttonWithDisableOnClick_notUsableAfterClick() {
-        Button button = new Button();
+        Button button = view.button;
         button.setDisableOnClick(true);
         getCurrentView().getElement().appendChild(button.getElement());
 
@@ -49,11 +55,9 @@ public class ButtonWrapTest extends UIUnitTest {
 
     @Test
     public void clickWithMiddleButton_middleButtonClickShouldBeRegistered() {
-        Button button = new Button();
+        Button button = view.button;
         AtomicInteger mouseButton = new AtomicInteger(-1);
         button.addClickListener(event -> mouseButton.set(event.getButton()));
-
-        getCurrentView().getElement().appendChild(button.getElement());
 
         final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.middleClick();
@@ -64,11 +68,9 @@ public class ButtonWrapTest extends UIUnitTest {
 
     @Test
     public void clickWithRightButton_rightButtonClickShouldBeRegistered() {
-        Button button = new Button();
+        Button button = view.button;
         AtomicInteger mouseButton = new AtomicInteger(-1);
         button.addClickListener(event -> mouseButton.set(event.getButton()));
-
-        getCurrentView().getElement().appendChild(button.getElement());
 
         final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.rightClick();
@@ -79,11 +81,10 @@ public class ButtonWrapTest extends UIUnitTest {
 
     @Test
     public void normalClick_noMetaKeysMarkedAsUsed() {
-        Button button = new Button();
+        Button button = view.button;
         AtomicReference<ClickEvent> event = new AtomicReference<>(null);
         button.addClickListener(
                 clickEvent -> event.compareAndSet(null, clickEvent));
-        getCurrentView().getElement().appendChild(button.getElement());
 
         final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.click();
@@ -102,10 +103,9 @@ public class ButtonWrapTest extends UIUnitTest {
 
     @Test
     public void clickWithMeta_metaKeysMarkedAsUsed() {
-        Button button = new Button();
+        Button button = view.button;
         AtomicReference<ClickEvent> event = new AtomicReference<>(null);
         button.addClickListener(clickEvent -> event.set(clickEvent));
-        getCurrentView().getElement().appendChild(button.getElement());
 
         final ButtonWrap button_ = wrap(ButtonWrap.class, button);
         button_.click(new MetaKeys(true, true, true, true));

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
@@ -20,11 +20,6 @@ import com.vaadin.testbench.unit.UIUnitTest;
 
 public class BasicGridWrapTest extends UIUnitTest {
 
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.flow.component.grid";
-    }
-
     BasicGridView view;
     GridWrap<Grid<Person>, Person> grid_;
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationView.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.notification;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "notification", registerAtStartup = false)
+public class NotificationView extends Component {
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
@@ -10,15 +10,20 @@
 package com.vaadin.flow.component.notification;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.accordion.AccordionView;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
 
 class NotificationWrapTest extends UIUnitTest {
 
-    @Override
-    protected String scanPackage() {
-        return "com.example";
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(NotificationView.class);
+        navigate(NotificationView.class);
     }
 
     @Test

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.textfield;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "text-field", registerAtStartup = false)
+public class TextFieldView extends Component implements HasComponents {
+
+    final TextField textField = new TextField();
+
+    public TextFieldView() {
+        add(textField);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -12,24 +12,29 @@ package com.vaadin.flow.component.textfield;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.HasValue.ValueChangeListener;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
 
 public class TextFieldWrapTest extends UIUnitTest {
 
-    @Override
-    protected String scanPackage() {
-        return "com.example";
+    TextFieldView view;
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(TextFieldView.class);
+        view = navigate(TextFieldView.class);
     }
 
     @Test
     public void readOnlyTextField_isNotUsable() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setReadOnly(true);
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
 
@@ -39,9 +44,8 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void readOnlyTextField_automaticWrapper_readOnlyIsCheckedInUsable() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setReadOnly(true);
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         Assertions.assertFalse(wrap(tf).isUsable(),
                 "Read only TextField shouldn't be usable");
@@ -49,8 +53,7 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void setTextFieldValue_eventIsFired_valueIsSet() {
-        TextField tf = new TextField();
-        getCurrentView().getElement().appendChild(tf.getElement());
+        TextField tf = view.textField;
 
         AtomicReference<String> value = new AtomicReference<>(null);
 
@@ -68,8 +71,7 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void nonInteractableField_throwsOnSetValue() {
-        TextField tf = new TextField();
-        getCurrentView().getElement().appendChild(tf.getElement());
+        TextField tf = view.textField;
 
         tf.getElement().setEnabled(false);
         final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -36,6 +36,11 @@ import static java.util.Arrays.asList;
 
 class ComponentQueryTest extends UIUnitTest {
 
+    @Override
+    protected String scanPackage() {
+        return "com.example.base";
+    }
+
     @Test
     void find_invisibleComponents_noResults() {
         Element rootElement = getCurrentView().getElement();

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -42,6 +42,11 @@ public class UIUnit4BaseClassTest {
 
     public static class TestMethodExecutionTest extends UIUnit4Test {
 
+        @Override
+        protected String scanPackage() {
+            return "com.example.base";
+        }
+
         @Test
         public void extendingBaseClass_runTest_vaadinInstancesAvailable() {
             Assert.assertNotNull(
@@ -71,6 +76,11 @@ public class UIUnit4BaseClassTest {
     }
 
     public static class DiscoverAllRoutesTest extends UIUnit4Test {
+
+        @Override
+        protected String scanPackage() {
+            return null;
+        }
 
         @Test
         public void extendingBaseClass_runTest_routesAreDiscovered() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -37,6 +37,12 @@ class UIUnitBaseClassTest {
 
     @Nested
     class TestMethodExecutionTest extends UIUnitTest {
+
+        @Override
+        protected String scanPackage() {
+            return "com.example.base";
+        }
+
         @Test
         void extendingBaseClass_runTest_vaadinInstancesAvailable() {
             Assertions.assertNotNull(UI.getCurrent(),
@@ -61,6 +67,11 @@ class UIUnitBaseClassTest {
 
     @Nested
     class DiscoverAllRoutesTest extends UIUnitTest {
+
+        @Override
+        protected String scanPackage() {
+            return null;
+        }
 
         @Test
         void extendingBaseClass_runTest_routesAreDiscovered() {


### PR DESCRIPTION
Restrict by default classpath scanning to current test class package and
subpackages.
Subclasses with different needs will overwrite scanPackage() method.
