### PR TITLE
feat: detect wrapper component type inspecting hierarchy

### DIFF
--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/NonGenericTestWrap.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/NonGenericTestWrap.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component;
+
+import com.vaadin.testbench.unit.ComponentWrap;
+import com.vaadin.testbench.unit.TestComponent;
+import com.vaadin.testbench.unit.TestComponentForConcreteWrapper;
+import com.vaadin.testbench.unit.Wraps;
+
+@Wraps(TestComponentForConcreteWrapper.class)
+public class NonGenericTestWrap
+        extends ComponentWrap<TestComponentForConcreteWrapper> {
+
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    public NonGenericTestWrap(TestComponentForConcreteWrapper component) {
+        super(component);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/TestComponentForConcreteWrapper.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/TestComponentForConcreteWrapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.testbench.unit;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+@Tag("span")
+public class TestComponentForConcreteWrapper extends Component {
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.NonGenericTestWrap;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.TestWrap;
 
@@ -43,10 +44,42 @@ public class WrapperResolutionTest extends UIUnitTest {
         Assertions.assertTrue(wrap(sc).getClass().equals(ComponentWrap.class));
     }
 
+    @Test
+    public void wrapTestComponentForConcreteWrapper_returnsNonGenericTestWrap() {
+        TestComponentForConcreteWrapper component = new TestComponentForConcreteWrapper();
+        Assertions.assertEquals(wrap(component).getClass(),
+                NonGenericTestWrap.class);
+    }
+
+    @Test
+    void detectComponentType_resolvesComponentTypeThroughHierarchy() {
+        Assertions.assertEquals(Component.class,
+                detectComponentType(ComponentWrap.class));
+        Assertions.assertEquals(TestComponent.class,
+                detectComponentType(MyWrap.class));
+        Assertions.assertEquals(MyTest.class,
+                detectComponentType(MyExtendedWrap.class));
+        Assertions.assertEquals(TestComponentForConcreteWrapper.class,
+                detectComponentType(NonGenericTestWrap.class));
+    }
+
     public static class MyTest extends TestComponent {
     }
 
     @Tag("div")
     public static class SpecialComponent extends Component {
     }
+
+    static class MyWrap<Y, Z extends TestComponent> extends ComponentWrap<Z> {
+        public MyWrap(Z component) {
+            super(component);
+        }
+    }
+
+    static class MyExtendedWrap<Y> extends MyWrap<Y, MyTest> {
+        public MyExtendedWrap(MyTest component) {
+            super(component);
+        }
+    }
+
 }


### PR DESCRIPTION
Wrapper may not always be generic or they may have more than one generic type,
so we need to inspect class hierarchy to detect the correct component type
that matches the declaration in ComponentWrap.

Fixes #1387