### PR TITLE
feat: Added exists terminal operator to ComponentQuery

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -565,6 +565,17 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Checks if this {@link ComponentQuery} describes existing components. Same
+     * as {@code !all().isEmpty() }.
+     *
+     * @return {@literal true} if components are found, otherwise
+     *         {@literal false}.
+     */
+    public boolean exists() {
+        return !all().isEmpty();
+    }
+
+    /**
      * Executes the search against current context and returns a list of test
      * wrappers for matching components.
      *

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -565,8 +565,7 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
-     * Checks if this {@link ComponentQuery} describes existing components. Same
-     * as {@code !all().isEmpty() }.
+     * Checks if this {@link ComponentQuery} describes existing components.
      *
      * @return {@literal true} if components are found, otherwise
      *         {@literal false}.

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -1375,6 +1375,30 @@ class ComponentQueryTest extends UIUnitTest {
                         .withoutAttribute("role", "tooltip").findComponent());
     }
 
+    @Test
+    void exists_matchingComponents_true() {
+        Element root = getCurrentView().getElement();
+
+        root.appendChild(new TextField().getElement());
+        root.appendChild(new TextField().getElement());
+        root.appendChild(new TextField().getElement());
+        root.appendChild(new TextField().getElement());
+        root.appendChild(new Button().getElement());
+
+        Assertions.assertTrue($(TextField.class).exists(),
+                "Expecting components to be found, but exists is false");
+
+        Assertions.assertTrue($(Button.class).exists(),
+                "Expecting components to be found, but exists is false");
+    }
+
+    @Test
+    void exists_noMatching_false() {
+        ComponentQuery<TextField> query = $(TextField.class);
+        Assertions.assertFalse(query.exists(),
+                "Expecting no components to be found, but exists is true");
+    }
+
     @Tag("span")
     private static class ComponentWithLabel extends TestComponent
             implements HasLabel {


### PR DESCRIPTION
Shortcut for `!all.isEmpty()`

Fixes #1382