### PR TITLE
feat: removing modal component creates roundtrip

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.internal.Routes;
+import com.vaadin.testbench.unit.mocks.MockedUI;
 
 /**
  * Base class for UI unit tests.
@@ -105,7 +106,7 @@ class BaseUIUnitTest {
 
     protected void initVaadinEnvironment() {
         scanForWrappers();
-        MockVaadin.setup(discoverRoutes(scanPackage()), UI::new,
+        MockVaadin.setup(discoverRoutes(scanPackage()), MockedUI::new,
                 lookupServices());
     }
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ComponentWrap.java
@@ -85,7 +85,6 @@ public class ComponentWrap<T extends Component> {
      */
     public void setModal(boolean modal) {
         UI.getCurrent().setChildComponentModal(component, modal);
-        roundTrip();
     }
 
     /**

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.mocks.MockSpringServlet;
+import com.vaadin.testbench.unit.mocks.MockedUI;
 import com.vaadin.testbench.unit.mocks.SpringSecurityRequestCustomizer;
 
 /**
@@ -71,8 +72,9 @@ public abstract class SpringUIUnit4Test extends UIUnit4Test {
     public void initVaadinEnvironment() {
         scanForWrappers();
         MockSpringServlet servlet = new MockSpringServlet(
-                discoverRoutes(scanPackage()), applicationContext, UI::new);
-        MockVaadin.setup(UI::new, servlet, lookupServices());
+                discoverRoutes(scanPackage()), applicationContext,
+                MockedUI::new);
+        MockVaadin.setup(MockedUI::new, servlet, lookupServices());
     }
 
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.mocks.MockSpringServlet;
+import com.vaadin.testbench.unit.mocks.MockedUI;
 import com.vaadin.testbench.unit.mocks.SpringSecurityRequestCustomizer;
 
 /**
@@ -78,7 +79,8 @@ public abstract class SpringUIUnitTest extends UIUnitTest {
     protected void initVaadinEnvironment() {
         scanForWrappers();
         MockSpringServlet servlet = new MockSpringServlet(
-                discoverRoutes(scanPackage()), applicationContext, UI::new);
-        MockVaadin.setup(UI::new, servlet, lookupServices());
+                discoverRoutes(scanPackage()), applicationContext,
+                MockedUI::new);
+        MockVaadin.setup(MockedUI::new, servlet, lookupServices());
     }
 }

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
@@ -9,10 +9,27 @@
  */
 package com.vaadin.testbench.unit.mocks
 
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.ComponentEventListener
 import com.vaadin.flow.component.UI
+import com.vaadin.flow.shared.Registration
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A simple no-op UI used by default by [com.vaadin.testbench.unit.MockVaadin.setup].
  * The class is open, in order to be extensible in user's library
  */
-open class MockedUI : UI()
+open class MockedUI : UI() {
+
+    override fun setChildComponentModal(childComponent: Component?, modal: Boolean) {
+        super.setChildComponentModal(childComponent, modal)
+        if (modal) {
+            val registrationCombination: AtomicReference<Registration?> = AtomicReference<Registration?>()
+            registrationCombination.set(childComponent?.addDetachListener(ComponentEventListener {
+                internals.stateTree.collectChanges { }
+                internals.stateTree.runExecutionsBeforeClientResponse()
+                registrationCombination.getAndSet(null)?.remove()
+            }))
+        }
+    }
+}

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
@@ -26,10 +26,15 @@ open class MockedUI : UI() {
         if (modal) {
             val registrationCombination: AtomicReference<Registration?> = AtomicReference<Registration?>()
             registrationCombination.set(childComponent?.addDetachListener(ComponentEventListener {
-                internals.stateTree.collectChanges { }
-                internals.stateTree.runExecutionsBeforeClientResponse()
+                roundTrip()
                 registrationCombination.getAndSet(null)?.remove()
             }))
         }
+        roundTrip();
+    }
+
+    private fun roundTrip() {
+        internals.stateTree.collectChanges { }
+        internals.stateTree.runExecutionsBeforeClientResponse()
     }
 }

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
@@ -101,9 +101,6 @@ public class ComponentWrapTest extends UIUnitTest {
 
         home.remove(span);
 
-        // TODO: can we have this automated?
-        roundTrip();
-
         Assertions.assertTrue(home_.isUsable(),
                 "Home should be interactable when Span is removed");
     }


### PR DESCRIPTION
An set modal component now gets a
detach listener that does a roundtrip
to propagate the modality change.

Fixes #1349
