### PR TITLE
feat: Added clear to TextFieldWrap

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextFieldWrap.java
@@ -11,6 +11,7 @@ package com.vaadin.flow.component.textfield;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.testbench.unit.ComponentWrap;
 import com.vaadin.testbench.unit.Wraps;
 
@@ -65,6 +66,28 @@ public class TextFieldWrap<T extends GeneratedVaadinTextField<T, V>, V>
         }
 
         getComponent().setValue(value);
+    }
+
+    /**
+     * Resets the value to the empty one, as when clicking on component clear
+     * button on the browser.
+     *
+     * An {@link IllegalStateException} is thrown if the clear button is not
+     * visible.
+     *
+     * @throws IllegalStateException
+     *             if the text field is not usable or the clear button is not
+     *             visible.
+     */
+    public void clear() {
+        ensureComponentIsUsable();
+
+        if (getComponent() instanceof HasClearButton
+                && ((HasClearButton) getComponent()).isClearButtonVisible()) {
+            setValue(getComponent().getEmptyValue());
+        } else {
+            throw new IllegalStateException("Clear button is not visible");
+        }
     }
 
     private boolean hasValidation() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -181,4 +181,62 @@ public class TextFieldWrapTest extends UIUnitTest {
         bdf_.setValue(null);
     }
 
+    @Test
+    void textFieldWithClearButton_clear_valueIsCleared() {
+        TextField tf = new TextField();
+        tf.setClearButtonVisible(true);
+        tf.setValue("Some value");
+        getCurrentView().getElement().appendChild(tf.getElement());
+
+        TextFieldWrap<TextField, String> tf_ = wrap(tf);
+        tf_.clear();
+
+        Assertions.assertTrue(tf.isEmpty(), "Value should have cleared");
+    }
+
+    @Test
+    void textFieldWithCustomEmptyValue_clear_valueIsCleared() {
+        TextField tf = new TextField() {
+            @Override
+            public String getEmptyValue() {
+                return "EMPTY";
+            }
+        };
+        tf.setValue("Some value");
+        tf.setClearButtonVisible(true);
+        getCurrentView().getElement().appendChild(tf.getElement());
+
+        TextFieldWrap<TextField, String> tf_ = wrap(tf);
+        tf_.clear();
+
+        Assertions.assertTrue(tf.isEmpty(), "Value should have cleared");
+        Assertions.assertEquals("EMPTY", tf.getValue(),
+                "Value should have cleared");
+    }
+
+    @Test
+    void textFieldWithoutClearButton_clear_throws() {
+        TextField tf = new TextField();
+        tf.setClearButtonVisible(false);
+        getCurrentView().getElement().appendChild(tf.getElement());
+
+        TextFieldWrap<TextField, String> tf_ = wrap(tf);
+
+        Assertions.assertThrows(IllegalStateException.class, tf_::clear,
+                "Clear should not be usable when clear button is not visible");
+    }
+
+    @Test
+    void notUsableTextField_clear_throws() {
+        TextField tf = new TextField();
+        tf.setClearButtonVisible(true);
+        tf.setEnabled(false);
+        getCurrentView().getElement().appendChild(tf.getElement());
+
+        TextFieldWrap<TextField, String> tf_ = wrap(tf);
+
+        Assertions.assertThrows(IllegalStateException.class, tf_::clear,
+                "Clear should not be usable when text field is not usable");
+    }
+
 }


### PR DESCRIPTION
Clears the text field setting the correct empty value.
Throws if clear button is not visible or component is not usable.

Fixes #1423