### PR TITLE
feat: Add wrap for NumberField and TextArea

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/NumberFieldWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/NumberFieldWrap.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import java.util.Objects;
+
+import com.vaadin.testbench.unit.ComponentWrap;
+import com.vaadin.testbench.unit.Wraps;
+
+/**
+ * Test wrapper for NumberField components.
+ *
+ * @param <T>
+ *            component type
+ * @param <V>
+ *            value type
+ */
+@Wraps(fqn = { "com.vaadin.flow.component.textfield.IntegerField",
+        "com.vaadin.flow.component.textfield.NumberField" })
+public class NumberFieldWrap<T extends AbstractNumberField<T, V>, V extends Number>
+        extends ComponentWrap<T> {
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    public NumberFieldWrap(T component) {
+        super(component);
+    }
+
+    /**
+     * Set the given value for the component.
+     * <p/>
+     * Throws if component is not usable or the value is invalid.
+     *
+     * @param value
+     *            value to set
+     * @throws IllegalArgumentException
+     *             if given value is not valid
+     */
+    public void setValue(V value) {
+        ensureComponentIsUsable();
+        if (!isValid(value)) {
+            throw new IllegalArgumentException(
+                    "Given value '" + value + "' is not valid");
+        }
+        getComponent().setValue(value);
+    }
+
+    private boolean isValid(V value) {
+        final boolean isRequiredButEmpty = getComponent().isRequiredBoolean()
+                && Objects.equals(getComponent().getEmptyValue(), value);
+        final boolean isGreaterThanMax = value != null
+                && value.doubleValue() > getComponent().getMaxDouble();
+        final boolean isSmallerThanMin = value != null
+                && value.doubleValue() < getComponent().getMinDouble();
+
+        return !(isRequiredButEmpty || isGreaterThanMax || isSmallerThanMin);
+        // TODO: Can we access the Generic isValidByStep
+        // || !isValidByStep(value);
+    }
+
+    // TODO: support stepUp/stepDown if controls are visible.
+
+    @Override
+    public boolean isUsable() {
+        // TextFields can be read only so the usable check needs extending
+        return super.isUsable() && !getComponent().isReadOnly();
+    }
+}

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextAreaWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/textfield/TextAreaWrap.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.testbench.unit.ComponentWrap;
+import com.vaadin.testbench.unit.Wraps;
+
+/**
+ * Test wrapper for TextArea components.
+ *
+ * @param <T>
+ *            component type
+ */
+@Wraps(TextArea.class)
+public class TextAreaWrap<T extends TextArea> extends ComponentWrap<T> {
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    public TextAreaWrap(T component) {
+        super(component);
+    }
+
+    /**
+     * Set the value to the component if it is usable.
+     * <p>
+     * For a non interactable component an IllegalStateException will be thrown
+     * as the end user would not be able to set a value.
+     *
+     * @param value
+     *            value to set
+     */
+    public void setValue(String value) {
+        ensureComponentIsUsable();
+
+        if (hasValidation() && value != null
+                && getValidationSupport().isInvalid(value)) {
+            if (getComponent().isPreventInvalidInputBoolean()) {
+                throw new IllegalArgumentException(
+                        "Given value doesn't pass field value validation. Check validation settings for field.");
+            }
+            LoggerFactory.getLogger(TextAreaWrap.class).warn(
+                    "Gave invalid input, but value set as invalid input is not prevented.");
+        }
+
+        getComponent().setValue(value);
+    }
+
+    private boolean hasValidation() {
+        return getValidationSupport() != null;
+    }
+
+    private TextFieldValidationSupport getValidationSupport() {
+        try {
+            return (TextFieldValidationSupport) getField("validationSupport")
+                    .get(getComponent());
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            // NO-OP Field didn't exist for given GeneratedVaadinTextField
+            // implementation
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isUsable() {
+        // TextFields can be read only so the usable check needs extending
+        return super.isUsable() && !getComponent().isReadOnly();
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "number-fields", registerAtStartup = false)
+public class NumberFieldView extends Component implements HasComponents {
+    NumberField numberField;
+    IntegerField integerField;
+
+    public NumberFieldView() {
+        numberField = new NumberField();
+        integerField = new IntegerField();
+
+        add(numberField, integerField);
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldWrapTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.testbench.unit.UIUnitTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NumberFieldWrapTest extends UIUnitTest {
+
+    private NumberFieldView view;
+
+    @Override
+    protected String scanPackage() {
+        return getClass().getPackageName();
+    }
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(NumberFieldView.class);
+        view = navigate(NumberFieldView.class);
+    }
+
+    @Test
+    public void readOnlyNumberField_isNotUsable() {
+        view.numberField.setReadOnly(true);
+
+        final NumberFieldWrap<NumberField, Double> nf_ = wrap(view.numberField);
+
+        Assertions.assertFalse(nf_.isUsable(),
+                "Read only NumberField shouldn't be usable");
+    }
+
+    @Test
+    public void readOnlyNumberField_automaticWrapper_readOnlyIsCheckedInUsable() {
+        view.numberField.setReadOnly(true);
+
+        Assertions.assertFalse(wrap(view.numberField).isUsable(),
+                "Read only NumberField shouldn't be usable");
+    }
+
+    @Test
+    public void setNumberFieldValue_eventIsFired_valueIsSet() {
+
+        AtomicReference<Double> value = new AtomicReference<>(null);
+
+        view.numberField.addValueChangeListener(
+                (HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<NumberField, Double>>) event -> {
+                    value.compareAndSet(null, event.getValue());
+                });
+
+        final NumberFieldWrap<NumberField, Double> nf_ = wrap(view.numberField);
+        final Double newValue = 15d;
+        nf_.setValue(newValue);
+
+        Assertions.assertEquals(newValue, value.get());
+    }
+
+    @Test
+    public void setIntegerFieldValue_eventIsFired_valueIsSet() {
+
+        AtomicReference<Integer> value = new AtomicReference<>(null);
+
+        view.integerField.addValueChangeListener(
+                (HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<IntegerField, Integer>>) event -> {
+                    value.compareAndSet(null, event.getValue());
+                });
+
+        final NumberFieldWrap<IntegerField, Integer> inf_ = wrap(
+                view.integerField);
+        final Integer newValue = 15;
+        inf_.setValue(newValue);
+
+        Assertions.assertEquals(newValue, value.get());
+    }
+
+    @Test
+    public void nonInteractableField_throwsOnSetValue() {
+
+        view.numberField.getElement().setEnabled(false);
+        view.integerField.getElement().setEnabled(false);
+        final NumberFieldWrap<NumberField, Double> nf_ = wrap(view.numberField);
+        final NumberFieldWrap<IntegerField, Integer> inf_ = wrap(
+                view.integerField);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> nf_.setValue(12d),
+                "Setting value to a non interactable number field should fail");
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> inf_.setValue(12),
+                "Setting value to a non interactable integer field should fail");
+    }
+
+    @Test
+    public void maxValue_throwsExceptionForTooSmallValue() {
+        view.numberField.setMax(10.0);
+
+        final NumberFieldWrap<NumberField, Double> nf_ = wrap(view.numberField);
+        final Double newValue = 15d;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> nf_.setValue(newValue));
+    }
+
+    @Test
+    public void minValue_throwsExceptionForTooSmallValue() {
+        view.numberField.setMin(20.0);
+
+        final NumberFieldWrap<NumberField, Double> nf_ = wrap(view.numberField);
+        final Double newValue = 15d;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> nf_.setValue(newValue));
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "text-area", registerAtStartup = false)
+public class TextAreaView extends Component implements HasComponents {
+
+    TextArea textArea;
+
+    public TextAreaView() {
+        this.textArea = new TextArea();
+        add(textArea);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaWrapTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.testbench.unit.UIUnitTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TextAreaWrapTest extends UIUnitTest {
+
+    private TextAreaView view;
+
+    @Override
+    protected String scanPackage() {
+        return getClass().getPackageName();
+    }
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(TextAreaView.class);
+        view = navigate(TextAreaView.class);
+    }
+
+    @Test
+    public void readOnlyTextArea_isNotUsable() {
+        view.textArea.setReadOnly(true);
+
+        final TextAreaWrap<TextArea> ta_ = wrap(view.textArea);
+
+        Assertions.assertFalse(ta_.isUsable(),
+                "Read only TextArea shouldn't be usable");
+    }
+
+    @Test
+    public void readOnlyTextArea_automaticWrapper_readOnlyIsCheckedInUsable() {
+        view.textArea.setReadOnly(true);
+
+        Assertions.assertFalse(wrap(view.textArea).isUsable(),
+                "Read only TextArea shouldn't be usable");
+    }
+
+    @Test
+    public void setTextAreaValue_eventIsFired_valueIsSet() {
+
+        AtomicReference<String> value = new AtomicReference<>(null);
+
+        view.textArea.addValueChangeListener(
+                (HasValue.ValueChangeListener<AbstractField.ComponentValueChangeEvent<TextArea, String>>) event -> {
+                    value.compareAndSet(null, event.getValue());
+                });
+
+        final TextAreaWrap<TextArea> ta_ = wrap(view.textArea);
+        final String newValue = "Test";
+        ta_.setValue(newValue);
+
+        Assertions.assertEquals(newValue, value.get());
+    }
+
+    @Test
+    public void nonInteractableField_throwsOnSetValue() {
+
+        view.textArea.getElement().setEnabled(false);
+        final TextAreaWrap<TextArea> ta_ = wrap(view.textArea);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> ta_.setValue("fail"),
+                "Setting value to a non interactable field should fail");
+    }
+
+    @Test
+    void textAreaWithValidation_doNotPreventInvalid_doNotThrow() {
+        // Only accept numbers
+        view.textArea.setPattern("\\d*");
+
+        final TextAreaWrap<TextArea> ta_ = wrap(view.textArea);
+        final String faultyValue = "Invalid value, but doesn't throw";
+        ta_.setValue(faultyValue);
+        Assertions.assertEquals(faultyValue, view.textArea.getValue(),
+                "Value should have been set.");
+    }
+
+    @Test
+    public void textAreaWithPattern_patternIsValidated() {
+        TextArea tf = view.textArea;
+        tf.setPreventInvalidInput(true);
+        // Only accept numbers
+        tf.setPattern("\\d*");
+
+        final TextAreaWrap<TextArea> ta_ = wrap(tf);
+        ta_.setValue("1234");
+
+        Assertions.assertEquals("1234", tf.getValue());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ta_.setValue("hello"),
+                "Value should have been validated against pattern");
+    }
+
+    @Test
+    public void textAreaWithMinLength_lengthIsChecked() {
+        TextArea tf = view.textArea;
+        tf.setPreventInvalidInput(true);
+        tf.setMinLength(5);
+
+        final TextAreaWrap<TextArea> ta_ = wrap(tf);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ta_.setValue("1234"),
+                "Value should have been validated against minLength");
+    }
+
+    @Test
+    public void textAreaWithMaxLength_lengthIsChecked() {
+        TextArea tf = view.textArea;
+        tf.setPreventInvalidInput(true);
+        tf.setMaxLength(3);
+
+        final TextAreaWrap<TextArea> ta_ = wrap(tf);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ta_.setValue("1234"),
+                "Value should have been validated against maxLength");
+    }
+
+    @Test
+    public void textAreaWithRequired_valueIsChecked() {
+        TextArea tf = view.textArea;
+        tf.setPreventInvalidInput(true);
+        tf.setRequired(true);
+
+        final TextAreaWrap<TextArea> ta_ = wrap(tf);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ta_.setValue(""),
+                "Required field should not accept empty");
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.flow.component.textfield;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "text-fields", registerAtStartup = false)
+public class TextFieldView extends Component implements HasComponents {
+    TextField textField;
+
+    public TextFieldView() {
+        textField = new TextField("Text field");
+        add(textField);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -13,26 +13,35 @@ import java.math.BigDecimal;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.HasValue.ValueChangeListener;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
 
 public class TextFieldWrapTest extends UIUnitTest {
 
+    TextFieldView view;
+
     @Override
     protected String scanPackage() {
-        return "com.example";
+        return getClass().getPackageName();
+    }
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(TextFieldView.class);
+        view = navigate(TextFieldView.class);
     }
 
     @Test
     public void readOnlyTextField_isNotUsable() {
-        TextField tf = new TextField();
-        tf.setReadOnly(true);
-        getCurrentView().getElement().appendChild(tf.getElement());
+        view.textField.setReadOnly(true);
 
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
+        final TextFieldWrap<TextField, String> tf_ = wrap(view.textField);
 
         Assertions.assertFalse(tf_.isUsable(),
                 "Read only TextField shouldn't be usable");
@@ -40,27 +49,23 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void readOnlyTextField_automaticWrapper_readOnlyIsCheckedInUsable() {
-        TextField tf = new TextField();
-        tf.setReadOnly(true);
-        getCurrentView().getElement().appendChild(tf.getElement());
+        view.textField.setReadOnly(true);
 
-        Assertions.assertFalse(wrap(tf).isUsable(),
+        Assertions.assertFalse(wrap(view.textField).isUsable(),
                 "Read only TextField shouldn't be usable");
     }
 
     @Test
     public void setTextFieldValue_eventIsFired_valueIsSet() {
-        TextField tf = new TextField();
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         AtomicReference<String> value = new AtomicReference<>(null);
 
-        tf.addValueChangeListener(
+        view.textField.addValueChangeListener(
                 (ValueChangeListener<ComponentValueChangeEvent<TextField, String>>) event -> {
                     value.compareAndSet(null, event.getValue());
                 });
 
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
+        final TextFieldWrap<TextField, String> tf_ = wrap(view.textField);
         final String newValue = "Test";
         tf_.setValue(newValue);
 
@@ -69,11 +74,9 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void nonInteractableField_throwsOnSetValue() {
-        TextField tf = new TextField();
-        getCurrentView().getElement().appendChild(tf.getElement());
 
-        tf.getElement().setEnabled(false);
-        final TextFieldWrap tf_ = wrap(TextFieldWrap.class, tf);
+        view.textField.getElement().setEnabled(false);
+        final TextFieldWrap<TextField, String> tf_ = wrap(view.textField);
 
         Assertions.assertThrows(IllegalStateException.class,
                 () -> tf_.setValue("fail"),
@@ -82,25 +85,22 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     void textFieldWithValidation_doNotPreventInvalid_doNotThrow() {
-        TextField tf = new TextField();
         // Only accept numbers
-        tf.setPattern("\\d*");
-        getCurrentView().getElement().appendChild(tf.getElement());
+        view.textField.setPattern("\\d*");
 
-        final TextFieldWrap<TextField, String> tf_ = wrap(tf);
+        final TextFieldWrap<TextField, String> tf_ = wrap(view.textField);
         final String faultyValue = "Invalid value, but doesn't throw";
         tf_.setValue(faultyValue);
-        Assertions.assertEquals(faultyValue, tf.getValue(),
+        Assertions.assertEquals(faultyValue, view.textField.getValue(),
                 "Value should have been set.");
     }
 
     @Test
     public void textFieldWithPattern_patternIsValidated() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setPreventInvalidInput(true);
         // Only accept numbers
         tf.setPattern("\\d*");
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         final TextFieldWrap<TextField, String> tf_ = wrap(tf);
         tf_.setValue("1234");
@@ -114,11 +114,9 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void textFieldWithMinLength_lengthIsChecked() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setPreventInvalidInput(true);
-        // Only accept numbers
         tf.setMinLength(5);
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         final TextFieldWrap<TextField, String> tf_ = wrap(tf);
 
@@ -129,11 +127,9 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void textFieldWithMaxLength_lengthIsChecked() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setPreventInvalidInput(true);
-        // Only accept numbers
         tf.setMaxLength(3);
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         final TextFieldWrap<TextField, String> tf_ = wrap(tf);
 
@@ -144,11 +140,9 @@ public class TextFieldWrapTest extends UIUnitTest {
 
     @Test
     public void textFieldWithRequired_valueIsChecked() {
-        TextField tf = new TextField();
+        TextField tf = view.textField;
         tf.setPreventInvalidInput(true);
-        // Only accept numbers
         tf.setRequired(true);
-        getCurrentView().getElement().appendChild(tf.getElement());
 
         final TextFieldWrap<TextField, String> tf_ = wrap(tf);
 


### PR DESCRIPTION
Also update TextFieldWrapTest to
use a registered view instead of trusting
an external view to be available.

part of #1371
