### PR TITLE
refactor!:view scan restriction by annotation

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -18,9 +18,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.googlecode.gentyref.GenericTypeReflector;
 import io.github.classgraph.ClassGraph;
@@ -43,14 +46,18 @@ import com.vaadin.testbench.unit.mocks.MockedUI;
  *
  * Provides methods to set up and clean a mocked Vaadin environment.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap, by overriding {@link #scanPackage()} method.
+ * The class allows scan classpath for routes and error views. Subclasses should
+ * typically restrict classpath scanning to a specific packages for faster
+ * bootstrap, by using {@link ViewPackages} annotation. If the annotation is not
+ * present a full classpath scan is performed
  *
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @see ViewPackages
  */
 class BaseUIUnitTest {
 
-    private static final ConcurrentHashMap<String, Routes> routesCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Set<String>, Routes> routesCache = new ConcurrentHashMap<>();
 
     protected static final Map<Class<?>, Class<? extends ComponentWrap>> wrappers = new HashMap<>();
     protected static final Set<String> scanned = new HashSet<>();
@@ -113,16 +120,19 @@ class BaseUIUnitTest {
         }
     }
 
-    static synchronized Routes discoverRoutes(String packageName) {
-        packageName = packageName == null ? "" : packageName;
-        return routesCache.computeIfAbsent(packageName,
-                pn -> new Routes().autoDiscoverViews(pn));
+    synchronized Routes discoverRoutes() {
+        return discoverRoutes(scanPackages());
+    }
+
+    static synchronized Routes discoverRoutes(Set<String> packageNames) {
+        packageNames = packageNames == null ? Set.of() : packageNames;
+        return routesCache.computeIfAbsent(packageNames, pn -> new Routes()
+                .autoDiscoverViews(pn.toArray(String[]::new)));
     }
 
     protected void initVaadinEnvironment() {
         scanForWrappers();
-        MockVaadin.setup(discoverRoutes(scanPackage()), MockedUI::new,
-                lookupServices());
+        MockVaadin.setup(discoverRoutes(), MockedUI::new, lookupServices());
     }
 
     void scanForWrappers() {
@@ -135,6 +145,23 @@ class BaseUIUnitTest {
                         .getAnnotation(ComponentWrapPackages.class).value()));
             }
         }
+    }
+
+    Set<String> scanPackages() {
+        Set<String> packagesToScan = new HashSet<>();
+        ViewPackages packages = getClass().getAnnotation(ViewPackages.class);
+        if (packages != null) {
+            Stream.of(packages.classes()).map(Class::getPackageName)
+                    .collect(Collectors.toCollection(() -> packagesToScan));
+            packagesToScan.addAll(Set.of(packages.packages()));
+            // Assume current class package scan if annotation exist but does
+            // not provide any restriction
+            if (packagesToScan.isEmpty()) {
+                packagesToScan.add(getClass().getPackageName());
+            }
+        }
+        packagesToScan.removeIf(Objects::isNull);
+        return packagesToScan;
     }
 
     protected void cleanVaadinEnvironment() {
@@ -154,19 +181,6 @@ class BaseUIUnitTest {
      */
     protected Set<Class<?>> lookupServices() {
         return Collections.emptySet();
-    }
-
-    /**
-     * Gets the name of the package that should be used as root to scan for
-     * routes and error views.
-     *
-     * Provide {@literal null} or empty string to scan the whole classpath, but
-     * note that this may be quite slow.
-     *
-     * @return package name for classpath scanning.
-     */
-    protected String scanPackage() {
-        return null;
     }
 
     /**

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
@@ -18,7 +18,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.mocks.MockSpringServlet;
 import com.vaadin.testbench.unit.mocks.MockedUI;
@@ -71,9 +70,8 @@ public abstract class SpringUIUnit4Test extends UIUnit4Test {
     @Override
     public void initVaadinEnvironment() {
         scanForWrappers();
-        MockSpringServlet servlet = new MockSpringServlet(
-                discoverRoutes(scanPackage()), applicationContext,
-                MockedUI::new);
+        MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
+                applicationContext, MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
     }
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
@@ -14,18 +14,11 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.TestContext;
-import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.mocks.MockSpringServlet;
 import com.vaadin.testbench.unit.mocks.MockedUI;
@@ -78,9 +71,8 @@ public abstract class SpringUIUnitTest extends UIUnitTest {
     @BeforeEach
     protected void initVaadinEnvironment() {
         scanForWrappers();
-        MockSpringServlet servlet = new MockSpringServlet(
-                discoverRoutes(scanPackage()), applicationContext,
-                MockedUI::new);
+        MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
+                applicationContext, MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
     }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -9,13 +9,11 @@
  */
 package com.vaadin.testbench.unit;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.internal.PrettyPrintTree;
@@ -23,19 +21,40 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
 /**
  * Base JUnit 4 class for UI unit tests.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap by overriding {@link #scanPackage()} method.
+ * The class automatically scans classpath for routes and error views.
+ * Subclasses should typically restrict classpath scanning to a specific
+ * packages for faster bootstrap, by using {@link ViewPackages} annotation. If
+ * the annotation is not present a full classpath scan is performed
  *
- * Set up of Vaadin environment is performed before each test by
- * {@link #initVaadinEnvironment()} method, and will be executed before
- * {@code @Before} methods defined in subclasses. At the same way, cleanup tasks
- * operated by {@link #cleanVaadinEnvironment()} are executed after each test,
- * and after all {@code @After} annotated methods in subclasses.
+ * <pre>
+ * {@code
+ * &#64;ViewPackages(classes = {CartView.class, CheckoutView.class})
+ * public class CartViewTest extends UIUnit4Test {
+ * }
  *
- * Custom Flow service implementations supported by
- * {@link com.vaadin.flow.di.Lookup} SPI can be provided overriding
- * {@link #initVaadinEnvironment()} and passing to super implementation the
- * service classes that should be initialized during setup.
+ * &#64;ViewPackages(packages = {"com.example.shop.cart", "com.example.security"})
+ * public class CartViewTest extends UIUnit4Test {
+ * }
+ *
+ * &#64;ViewPackages(
+ *    classes = {CartView.class, CheckoutView.class},
+ *    packages = {"com.example.security"}
+ * )
+ * public class CartViewTest extends UIUnit4Test {
+ * }
+ * </pre>
+ *
+ *
+ * Set up of Vaadin environment is performed before each test by {@link
+ * #initVaadinEnvironment()} method, and will be executed before {@code @Before}
+ * methods defined in subclasses. At the same way, cleanup tasks operated by
+ * {@link #cleanVaadinEnvironment()} are executed after each test, and after all
+ * {@code @After} annotated methods in subclasses.
+ *
+ * Custom Flow service implementations supported by {@link
+ * com.vaadin.flow.di.Lookup} SPI can be provided overriding {@link
+ * #initVaadinEnvironment()} and passing to super implementation the service
+ * classes that should be initialized during setup.
  *
  * <pre>
  * {@code

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -15,11 +15,31 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Base JUnit 5 class for UI unit tests.
  *
- * Subclasses should typically restrict classpath scanning to a specific package
- * for faster bootstrap by overriding {@link #scanPackage()} method.
+ * The class automatically scans classpath for routes and error views.
+ * Subclasses should typically restrict classpath scanning to a specific
+ * packages for faster bootstrap, by using {@link ViewPackages} annotation. If
+ * the annotation is not present a full classpath scan is performed
  *
- * Set up of Vaadin environment is performed before each test by
- * {@link #initVaadinEnvironment()} method, and will be executed before
+ * <pre>
+ * {@code
+ * &#64;ViewPackages(classes = {CartView.class, CheckoutView.class})
+ * class CartViewTest extends UIUnitTest {
+ * }
+ *
+ * &#64;ViewPackages(packages = {"com.example.shop.cart", "com.example.security"})
+ * class CartViewTest extends UIUnitTest {
+ * }
+ *
+ * &#64;ViewPackages(
+ *    classes = {CartView.class, CheckoutView.class},
+ *    packages = {"com.example.security"}
+ * )
+ * class CartViewTest extends UIUnitTest {
+ * }
+ * </pre>
+ *
+ * Set up of Vaadin environment is performed before each test by {@link
+ * #initVaadinEnvironment()} method, and will be executed before
  * {@code @BeforeEach} methods defined in subclasses. At the same way, cleanup
  * tasks operated by {@link #cleanVaadinEnvironment()} are executed after each
  * test, and after all {@code @AfterEach} annotated methods in subclasses.
@@ -30,10 +50,10 @@ import org.junit.jupiter.api.BeforeEach;
  * in the subclass, in order to have hooks handled by testing framework.
  *
  * A use case for overriding {@link #initVaadinEnvironment()} is to provide
- * custom Flow service implementations supported by
- * {@link com.vaadin.flow.di.Lookup} SPI. Implementations can be provided
- * overriding {@link #initVaadinEnvironment()} and passing to super
- * implementation the service classes that should be initialized during setup.
+ * custom Flow service implementations supported by {@link
+ * com.vaadin.flow.di.Lookup} SPI. Implementations can be provided overriding
+ * {@link #initVaadinEnvironment()} and passing to super implementation the
+ * service classes that should be initialized during setup.
  *
  * <pre>
  * {@code
@@ -48,6 +68,8 @@ import org.junit.jupiter.api.BeforeEach;
  * To get a graphical ascii representation of the UI tree on failure add the
  * annotation {@code @ExtendWith(TreeOnFailureExtension.class)} to the test
  * class.
+ *
+ * @see ViewPackages
  */
 public abstract class UIUnitTest extends BaseUIUnitTest {
 

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ViewPackages.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ViewPackages.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to use to scan given packages for routes and error views.
+ *
+ * Packages can be defined by their fully-qualified name or by providing classes
+ * that are members of them.
+ *
+ * If both {@link #classes()} and {@link #packages()} are empty, the scan is
+ * assumed to be limited to the annotated class package.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface ViewPackages {
+
+    /**
+     * Array of classes whose packages will be scanned for views
+     *
+     * @return Array of classes whose packages will be scanned for views
+     */
+    Class<?>[] classes() default {};
+
+    /**
+     * Array of packages to scan for views
+     *
+     * @return String array of packages to scan
+     */
+    String[] packages() default {};
+}

--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
@@ -85,6 +85,24 @@ data class Routes(
             }
         }
 
+        cleanupErrorRoutes()
+
+        println("Auto-discovered views: $this")
+    }
+
+    fun merge(other: Routes): Routes {
+        return Routes(LinkedHashSet(this.routes), LinkedHashSet(this.errorRoutes), this.skipPwaInit).apply {
+            routes.addAll(other.routes)
+            errorRoutes.addAll(other.errorRoutes)
+            cleanupErrorRoutes()
+        }
+    }
+
+    override fun toString(): String =
+            "Routes(routes=${routes.joinToString { it.simpleName }}, errorRoutes=${errorRoutes.joinToString { it.simpleName }})"
+
+
+    private fun cleanupErrorRoutes() {
         // https://github.com/mvysny/karibu-testing/issues/50
         // if the app defines its own NotFoundException handler, remove MockRouteNotFoundError
         if (errorRoutes.any { it != MockRouteNotFoundError::class.java && it.isRouteNotFound }) {
@@ -95,12 +113,7 @@ data class Routes(
         // implementation that exposes error details for PrettyPrinter
         errorRoutes.remove(InternalServerError::class.java)
         errorRoutes.add(MockInternalSeverError::class.java)
-
-        println("Auto-discovered views: $this")
     }
-
-    override fun toString(): String =
-            "Routes(routes=${routes.joinToString { it.simpleName }}, errorRoutes=${errorRoutes.joinToString { it.simpleName }})"
 }
 
 /**

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
@@ -15,13 +15,10 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages(packages = "com.vaadin.flow.component.accordion")
 class AccordionWrapTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.flow.component.accordion";
-    }
 
     AccordionView view;
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/accordion/AccordionWrapTest.java
@@ -17,7 +17,7 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
-@ViewPackages(packages = "com.vaadin.flow.component.accordion")
+@ViewPackages
 class AccordionWrapTest extends UIUnitTest {
 
     AccordionView view;

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/button/ButtonWrapTest.java
@@ -17,19 +17,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.checkbox.CheckboxView;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class ButtonWrapTest extends UIUnitTest {
 
     private ButtonView view;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/checkbox/CheckboxGroupWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/checkbox/CheckboxGroupWrapTest.java
@@ -21,16 +21,13 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 class CheckboxGroupWrapTest extends UIUnitTest {
 
     CheckboxView view;
     CheckboxGroupWrap<CheckboxGroup<CheckboxView.Name>, CheckboxView.Name> checkboxGroup_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/checkbox/CheckboxWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/checkbox/CheckboxWrapTest.java
@@ -18,16 +18,13 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 class CheckboxWrapTest extends UIUnitTest {
 
     CheckboxView view;
     CheckboxWrap<Checkbox> checkbox_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/combobox/ComboBoxWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/combobox/ComboBoxWrapTest.java
@@ -18,12 +18,10 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class ComboBoxWrapTest extends UIUnitTest {
-    @Override
-    protected String scanPackage() {
-        return this.getClass().getPackageName();
-    }
 
     ComboBoxView view;
     ComboBoxWrap<ComboBox<ComboBoxView.Name>, ComboBoxView.Name> combo_;

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/datepicker/DatePickerWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/datepicker/DatePickerWrapTest.java
@@ -10,8 +10,6 @@
 package com.vaadin.flow.component.datepicker;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
@@ -22,18 +20,15 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ViewPackages
 class DatePickerWrapTest extends UIUnitTest {
 
     DatePickerView view;
     DatePickerWrap<DatePicker> pick_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerWrapTest.java
@@ -20,21 +20,17 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ViewPackages
 class DateTimePickerWrapTest extends UIUnitTest {
 
     DateTimePickerView view;
     DateTimePickerWrap<DateTimePicker> pick_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BasicGridWrapTest.java
@@ -17,13 +17,10 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class BasicGridWrapTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.flow.component.grid";
-    }
 
     BasicGridView view;
     GridWrap<Grid<Person>, Person> grid_;

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BeanGridWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/BeanGridWrapTest.java
@@ -9,21 +9,16 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class BeanGridWrapTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.flow.component.grid";
-    }
 
     BeanGridView view;
     GridWrap<Grid<Person>, Person> grid_;

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/listbox/ListBoxWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/listbox/ListBoxWrapTest.java
@@ -15,17 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
+@ViewPackages
 class ListBoxWrapTest extends UIUnitTest {
     ListBoxView view;
     ListBoxWrap<ListBox<String>, String> list_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxWrapTest.java
@@ -15,17 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
+@ViewPackages
 class MultiSelectListBoxWrapTest extends UIUnitTest {
     ListBoxView view;
     MultiSelectListBoxWrap<MultiSelectListBox<String>, String> list_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/login/LoginFormWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/login/LoginFormWrapTest.java
@@ -16,16 +16,13 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class LoginFormWrapTest extends UIUnitTest {
 
     LoginFormView view;
     LoginFormWrap<LoginForm> login_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     void init() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/login/LoginOverlayWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/login/LoginOverlayWrapTest.java
@@ -16,16 +16,13 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class LoginOverlayWrapTest extends UIUnitTest {
 
     LoginOverlayView view;
     LoginOverlayWrap<LoginOverlay> login_;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     void init() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/notification/NotificationWrapTest.java
@@ -13,16 +13,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.flow.component.accordion.AccordionView;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 class NotificationWrapTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/select/SelectWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/select/SelectWrapTest.java
@@ -15,9 +15,11 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ViewPackages
 class SelectWrapTest extends UIUnitTest {
     SelectView view;
 
@@ -26,11 +28,6 @@ class SelectWrapTest extends UIUnitTest {
         RouteConfiguration.forApplicationScope()
                 .setAnnotatedRoute(SelectView.class);
         view = navigate(SelectView.class);
-    }
-
-    @Override
-    protected String scanPackage() {
-        return this.getClass().getPackageName();
     }
 
     @Test

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/NumberFieldWrapTest.java
@@ -19,17 +19,14 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ViewPackages
 class NumberFieldWrapTest extends UIUnitTest {
 
     private NumberFieldView view;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextAreaWrapTest.java
@@ -19,17 +19,14 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ViewPackages
 class TextAreaWrapTest extends UIUnitTest {
 
     private TextAreaView view;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/textfield/TextFieldWrapTest.java
@@ -20,15 +20,12 @@ import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.HasValue.ValueChangeListener;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
 
+@ViewPackages
 public class TextFieldWrapTest extends UIUnitTest {
 
     TextFieldView view;
-
-    @Override
-    protected String scanPackage() {
-        return getClass().getPackageName();
-    }
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ComponentWrapTest.java
@@ -18,6 +18,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Tag;
 
+@ViewPackages(packages = "com.example")
 public class ComponentWrapTest extends UIUnitTest {
 
     private WelcomeView home;
@@ -25,11 +26,6 @@ public class ComponentWrapTest extends UIUnitTest {
     @BeforeEach
     public void initHome() {
         home = getHome();
-    }
-
-    @Override
-    protected String scanPackage() {
-        return "com.example";
     }
 
     @Test

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/SpringUnit4SecurityTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/SpringUnit4SecurityTest.java
@@ -24,12 +24,8 @@ import org.springframework.test.context.ContextConfiguration;
 import com.vaadin.flow.server.VaadinRequest;
 
 @ContextConfiguration(classes = SecurityTestConfig.class)
+@ViewPackages(packages = "com.testapp.security")
 public class SpringUnit4SecurityTest extends SpringUIUnit4Test {
-
-    @Override
-    protected String scanPackage() {
-        return "com.testapp.security";
-    }
 
     @Test
     @WithMockUser(username = "john", roles = { "DEV", "PO" })

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/SpringUnitSecurityTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/SpringUnitSecurityTest.java
@@ -24,12 +24,8 @@ import org.springframework.test.context.ContextConfiguration;
 import com.vaadin.flow.server.VaadinRequest;
 
 @ContextConfiguration(classes = SecurityTestConfig.class)
+@ViewPackages(packages = "com.testapp.security")
 class SpringUnitSecurityTest extends SpringUIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.testapp.security";
-    }
 
     @Test
     @WithMockUser(username = "john", roles = { "DEV", "PO" })

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -17,6 +17,9 @@ import com.example.SingleParam;
 import com.example.TemplatedParam;
 import com.example.base.WelcomeView;
 import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -79,24 +82,6 @@ public class UIUnit4BaseClassTest {
             allViews.add(TemplatedParam.class);
             Assert.assertEquals(allViews.size(), routes.size());
             Assert.assertTrue(routes.containsAll(allViews));
-        }
-    }
-
-    public static class DiscoverRoutesInPackageTest extends UIUnit4Test {
-
-        @Override
-        protected String scanPackage() {
-            return ChildView.class.getPackageName();
-        }
-
-        @Test
-        public void extendingBaseClass_runTest_routesAreDiscovered() {
-            Set<Class<? extends Component>> routes = VaadinService.getCurrent()
-                    .getRouter().getRegistry().getRegisteredRoutes().stream()
-                    .map(RouteBaseData::getNavigationTarget)
-                    .collect(Collectors.toSet());
-            Assert.assertEquals(1, routes.size());
-            Assert.assertTrue(routes.contains(ChildView.class));
         }
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -17,16 +17,19 @@ import com.example.SingleParam;
 import com.example.TemplatedParam;
 import com.example.base.WelcomeView;
 import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.grid.BasicGridView;
 import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -74,25 +77,6 @@ class UIUnitBaseClassTest {
             allViews.add(TemplatedParam.class);
             Assertions.assertEquals(allViews.size(), routes.size());
             Assertions.assertTrue(routes.containsAll(allViews));
-        }
-    }
-
-    @Nested
-    class DiscoverRoutesInPackageTest extends UIUnitTest {
-
-        @Override
-        protected String scanPackage() {
-            return ChildView.class.getPackageName();
-        }
-
-        @Test
-        void extendingBaseClass_runTest_routesAreDiscovered() {
-            Set<Class<? extends Component>> routes = VaadinService.getCurrent()
-                    .getRouter().getRegistry().getRegisteredRoutes().stream()
-                    .map(RouteBaseData::getNavigationTarget)
-                    .collect(Collectors.toSet());
-            Assertions.assertEquals(1, routes.size());
-            Assertions.assertTrue(routes.contains(ChildView.class));
         }
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitNavigationTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitNavigationTest.java
@@ -11,12 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.NotFoundException;
 
+@ViewPackages(packages = "com.example")
 public class UIUnitNavigationTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.example";
-    }
 
     @Test
     public void getCurrentView_returnsExpectedView() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/WrapperResolutionTest.java
@@ -16,12 +16,8 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 
 @ComponentWrapPackages("com.vaadin.testbench.unit")
+@ViewPackages(packages = "com.vaadin.testbench")
 public class WrapperResolutionTest extends UIUnitTest {
-
-    @Override
-    protected String scanPackage() {
-        return "com.vaadin.testbench";
-    }
 
     @Test
     public void wrapTest_returnsTestWrap() {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byannotatedclass/DiscoverRoutesInAnnotatedClassPackageTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byannotatedclass/DiscoverRoutesInAnnotatedClassPackageTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan.byannotatedclass;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages
+class DiscoverRoutesInAnnotatedClassPackageTest extends UIUnitTest {
+
+    @Test
+    void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(1, routes.size());
+        Assertions.assertTrue(routes.contains(ViewPackagesTestView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byannotatedclass/ViewPackagesTestView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byannotatedclass/ViewPackagesTestView.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan.byannotatedclass;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route("view-packages-test")
+public class ViewPackagesTestView extends Component {
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byclasses/DiscoverRoutesInPackageByClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/byclasses/DiscoverRoutesInPackageByClassTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan.byclasses;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(classes = { ChildView.class, NavigationPostponeView.class })
+class DiscoverRoutesInPackageByClassTest extends UIUnitTest {
+
+    @Test
+    void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(2, routes.size());
+        Assertions.assertTrue(routes.contains(ChildView.class));
+        Assertions.assertTrue(routes.contains(NavigationPostponeView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/bypackagename/DiscoverRoutesInPackageByNameTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/bypackagename/DiscoverRoutesInPackageByNameTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan.bypackagename;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(packages = "com.example.base.child")
+class DiscoverRoutesInPackageByNameTest extends UIUnitTest {
+
+    @Test
+    void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(1, routes.size());
+        Assertions.assertTrue(routes.contains(ChildView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/bypackagenameandclass/DiscoverRoutesInPackageByClassAndNameTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan/bypackagenameandclass/DiscoverRoutesInPackageByClassAndNameTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan.bypackagenameandclass;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(classes = NavigationPostponeView.class, packages = "com.example.base.child")
+public class DiscoverRoutesInPackageByClassAndNameTest extends UIUnitTest {
+
+    @Test
+    void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(2, routes.size());
+        Assertions.assertTrue(routes.contains(ChildView.class));
+        Assertions.assertTrue(routes.contains(NavigationPostponeView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byannotatedclass/DiscoverRoutesInAnnotatedClassPackageTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byannotatedclass/DiscoverRoutesInAnnotatedClassPackageTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan4.byannotatedclass;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnit4Test;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages
+public class DiscoverRoutesInAnnotatedClassPackageTest extends UIUnit4Test {
+
+    @Test
+    public void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(1, routes.size());
+        Assert.assertTrue(routes.contains(ViewPackagesTest4View.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byannotatedclass/ViewPackagesTest4View.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byannotatedclass/ViewPackagesTest4View.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan4.byannotatedclass;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route("view-packages-test4")
+public class ViewPackagesTest4View extends Component {
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byclasses/DiscoverRoutesInPackageByClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/byclasses/DiscoverRoutesInPackageByClassTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan4.byclasses;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnit4Test;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(classes = { ChildView.class, NavigationPostponeView.class })
+public class DiscoverRoutesInPackageByClassTest extends UIUnit4Test {
+
+    @Test
+    public void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(2, routes.size());
+        Assert.assertTrue(routes.contains(ChildView.class));
+        Assert.assertTrue(routes.contains(NavigationPostponeView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/bypackagename/DiscoverRoutesInPackageByNameTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/bypackagename/DiscoverRoutesInPackageByNameTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan4.bypackagename;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnit4Test;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(packages = "com.example.base.child")
+public class DiscoverRoutesInPackageByNameTest extends UIUnit4Test {
+
+    @Test
+    public void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(1, routes.size());
+        Assert.assertTrue(routes.contains(ChildView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/bypackagenameandclass/DiscoverRoutesInPackageByClassAndNameTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/viewscan4/bypackagenameandclass/DiscoverRoutesInPackageByClassAndNameTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit.viewscan4.bypackagenameandclass;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.child.ChildView;
+import com.example.base.navigation.NavigationPostponeView;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.testbench.unit.UIUnit4Test;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages(classes = NavigationPostponeView.class, packages = "com.example.base.child")
+public class DiscoverRoutesInPackageByClassAndNameTest extends UIUnit4Test {
+
+    @Test
+    public void extendingBaseClass_runTest_routesAreDiscovered() {
+        Set<Class<? extends Component>> routes = VaadinService.getCurrent()
+                .getRouter().getRegistry().getRegisteredRoutes().stream()
+                .map(RouteBaseData::getNavigationTarget)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(2, routes.size());
+        Assert.assertTrue(routes.contains(ChildView.class));
+        Assert.assertTrue(routes.contains(NavigationPostponeView.class));
+    }
+}

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
@@ -18,6 +18,8 @@ import com.vaadin.flow.router.RouteNotFoundError
 import com.vaadin.flow.server.VaadinContext
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry
 import com.vaadin.testbench.unit.mocks.MockVaadinHelper
+import com.vaadin.testbench.unit.viewscan.byannotatedclass.ViewPackagesTestView
+import com.vaadin.testbench.unit.viewscan4.byannotatedclass.ViewPackagesTest4View
 import com.example.base.ErrorView
 import com.example.base.HelloWorldView
 import com.example.base.ParametrizedView
@@ -32,22 +34,27 @@ import com.testapp.MyRouteNotFoundError
 
 val allViews: Set<Class<out Component>> = setOf<Class<out Component>>(
         HelloWorldView::class.java, WelcomeView::class.java,
-        ParametrizedView::class.java, ChildView::class.java, NavigationPostponeView::class.java)
+        ParametrizedView::class.java, ChildView::class.java, NavigationPostponeView::class.java,
+        ViewPackagesTest4View::class.java, ViewPackagesTestView::class.java)
 val allErrorRoutes: Set<Class<out HasErrorParameter<*>>> = setOf(ErrorView::class.java, MockRouteNotFoundError::class.java, MockInternalSeverError::class.java)
 
 @DynaTestDsl
 fun DynaNodeGroup.routesTestBatch() {
     afterEach { MockVaadin.tearDown() }
 
+    // TODO: restrict scan until we have component wrapper test views on this codebase
+    val packagesToScan = arrayOf("com.example.base", "com.vaadin.testbench.unit.viewscan",
+            "com.vaadin.testbench.unit.viewscan4")
+
     test("All views discovered") {
-        val routes: Routes = Routes().autoDiscoverViews("com.example.base")
+        val routes: Routes = Routes().autoDiscoverViews(*packagesToScan)
         expect(allViews) { routes.routes.toSet() }
         expect(allErrorRoutes) { routes.errorRoutes.toSet() }
     }
 
     test("calling autoDiscoverViews() multiple times won't fail") {
-        expect(allViews) { Routes().autoDiscoverViews("com.example.base").routes }
-        expect(allViews) { Routes().autoDiscoverViews("com.example.base").routes }
+        expect(allViews) { Routes().autoDiscoverViews(*packagesToScan).routes }
+        expect(allViews) { Routes().autoDiscoverViews(*packagesToScan).routes }
     }
 
     // https://github.com/mvysny/karibu-testing/issues/50

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
@@ -17,6 +17,7 @@ import com.vaadin.flow.router.NotFoundException
 import com.vaadin.flow.router.RouteNotFoundError
 import com.vaadin.flow.server.VaadinContext
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry
+import com.vaadin.testbench.unit.expectList
 import com.vaadin.testbench.unit.mocks.MockVaadinHelper
 import com.vaadin.testbench.unit.viewscan.byannotatedclass.ViewPackagesTestView
 import com.vaadin.testbench.unit.viewscan4.byannotatedclass.ViewPackagesTest4View
@@ -92,5 +93,16 @@ fun DynaNodeGroup.routesTestBatch() {
         expectThrows(NotFoundException::class, "No route found for 'A_VIEW_THAT_DOESNT_EXIST': Couldn't find route for 'A_VIEW_THAT_DOESNT_EXIST'\nAvailable routes:") {
             UI.getCurrent().navigate("A_VIEW_THAT_DOESNT_EXIST")
         }
+    }
+
+    test("merge routes") {
+        val routes1 = Routes(mutableSetOf(HelloWorldView::class.java, WelcomeView::class.java, ViewPackagesTest4View::class.java,
+                ViewPackagesTestView::class.java),
+                mutableSetOf(ErrorView::class.java))
+        val routes2 = Routes(mutableSetOf(ParametrizedView::class.java, ChildView::class.java, NavigationPostponeView::class.java),
+                mutableSetOf(MockRouteNotFoundError::class.java, MockInternalSeverError::class.java))
+        val merged = routes1.merge(routes2);
+        expect(allViews) { merged.routes.toSet() }
+        expect(allErrorRoutes) { merged.errorRoutes.toSet() }
     }
 }


### PR DESCRIPTION
Introduced the ViewPackages annotation for classpath scan restriction.
It replaces the scanPackage method, that has been removed.

Fixes #1420