### PR TITLE
feat: Added wrapper for Upload component

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/upload/UploadWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/upload/UploadWrap.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.upload;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.server.StreamVariable;
+import com.vaadin.flow.server.communication.streaming.StreamingEndEventImpl;
+import com.vaadin.flow.server.communication.streaming.StreamingErrorEventImpl;
+import com.vaadin.flow.server.communication.streaming.StreamingStartEventImpl;
+import com.vaadin.testbench.unit.ComponentWrap;
+import com.vaadin.testbench.unit.Wraps;
+
+/**
+ * Test wrapper for Upload components.
+ *
+ * @param <T>
+ *            the component type.
+ */
+@Wraps(Upload.class)
+public class UploadWrap<T extends Upload> extends ComponentWrap<T> {
+
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    public UploadWrap(T component) {
+        super(component);
+    }
+
+    /**
+     * Send the file data to the Upload component as if it is uploaded in the
+     * browser.
+     *
+     * @param fileName
+     *            name of the file to upload
+     * @param contentType
+     *            content type of the file to upload
+     * @param contents
+     *            file contents as an array of bytes
+     * @throws UncheckedIOException
+     *             if the upload component fails to handle file contents
+     */
+    public void upload(String fileName, String contentType,
+            InputStream contents) {
+        doUpload(List.of(
+                new UploadItem(fileName, contentType, contents::readAllBytes)));
+    }
+
+    /**
+     * Send the file data to the Upload component as if it is uploaded in the
+     * browser.
+     *
+     * @param fileName
+     *            name of the file to upload
+     * @param contentType
+     *            content type of the file to upload
+     * @param contents
+     *            file contents as an array of bytes
+     * @throws UncheckedIOException
+     *             if the upload component fails to handle file contents
+     */
+    public void upload(String fileName, String contentType, byte[] contents) {
+        doUpload(
+                List.of(new UploadItem(fileName, contentType, () -> contents)));
+    }
+
+    /**
+     * Send the file data to the Upload component as if it is uploaded in the
+     * browser.
+     *
+     * The content type is detected from file name.
+     *
+     * @param file
+     *            the file to upload
+     * @throws UncheckedIOException
+     *             if the upload component fails to handle file contents
+     */
+    public void upload(File file) {
+        doUpload(List.of(new UploadItem(file.getName(),
+                URLConnection.guessContentTypeFromName(file.getName()),
+                () -> Files.readAllBytes(file.toPath()))));
+    }
+
+    /**
+     * Simulates uploading multiple files at once.
+     *
+     * @param files
+     *            files to upload
+     */
+    public void uploadAll(File... files) {
+        uploadAll(List.of(files));
+    }
+
+    /**
+     * Simulates uploading multiple files at once.
+     *
+     * @param files
+     *            files to upload
+     */
+    public void uploadAll(Collection<File> files) {
+        if (!(getComponent().getReceiver() instanceof MultiFileReceiver)) {
+            throw new IllegalStateException(
+                    "Upload component is not configured with a MultiFileReceiver");
+        }
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "At least one file must be provided");
+        }
+        doUpload(files.stream()
+                .map(f -> new UploadItem(f.getName(),
+                        URLConnection.guessContentTypeFromName(f.getName()),
+                        () -> Files.readAllBytes(f.toPath())))
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Simulates upload interruption by user on browser.
+     *
+     * @param fileName
+     *            name of uploading file
+     * @param contentType
+     *            content type of the uploading file
+     */
+    public void uploadAborted(String fileName, String contentType) {
+        doFailUpload(fileName, contentType);
+    }
+
+    /**
+     * Simulates upload interruption by user on browser.
+     *
+     * @param file
+     *            uploading file
+     */
+    public void uploadAborted(File file) {
+        doFailUpload(file.getName(),
+                URLConnection.guessContentTypeFromName(file.getName()));
+    }
+
+    /**
+     * Simulates a failure during file upload.
+     *
+     * @param file
+     *            uploading file
+     */
+    public void uploadFailed(File file) {
+        doFailUpload(file.getName(),
+                URLConnection.guessContentTypeFromName(file.getName()));
+    }
+
+    /**
+     * Simulates a failure during file upload.
+     *
+     * @param fileName
+     *            name of uploading file
+     * @param contentType
+     *            content type of the uploading file
+     */
+    public void uploadFailed(String fileName, String contentType) {
+        doFailUpload(fileName, contentType);
+    }
+
+    private void fireAllFinish() {
+        try {
+            getMethod("fireAllFinish").invoke(getComponent());
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void doFailUpload(String fileName, String contentType) {
+        ensureComponentIsUsable();
+        StreamVariable streamVariable = getGetStreamVariable();
+        try {
+            streamVariable.streamingStarted(
+                    new StreamingStartEventImpl(fileName, contentType, 0));
+            streamVariable.streamingFailed(new StreamingErrorEventImpl(fileName,
+                    contentType, 0, 0, null));
+        } finally {
+            fireAllFinish();
+        }
+    }
+
+    private void doUpload(Collection<UploadItem> items) {
+        ensureComponentIsUsable();
+        try {
+            StreamVariable streamVariable = getGetStreamVariable();
+            AtomicReference<Exception> errorCollector = new AtomicReference<>();
+            // Collect all upload related events. They will be fired after all
+            // items completed because otherwise the current uploading count is
+            // decremented too early and check with max file size may fail
+            List<StreamVariable.StreamingEvent> events = items.stream()
+                    .map(item -> doUpload(streamVariable, item,
+                            ex -> errorCollector.compareAndSet(null, ex)))
+                    .filter(Optional::isPresent).map(Optional::get)
+                    .collect(Collectors.toList());
+
+            events.forEach(ev -> handleUploadResult(streamVariable, ev));
+
+            Exception ex = errorCollector.get();
+            if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
+            } else if (ex instanceof IOException) {
+                throw new UncheckedIOException((IOException) ex);
+            } else if (ex != null) {
+                throw new RuntimeException(ex);
+            }
+        } finally {
+            fireAllFinish();
+        }
+    }
+
+    private Optional<StreamVariable.StreamingEvent> doUpload(
+            StreamVariable streamVariable, UploadItem item,
+            Consumer<Exception> errorHandler) {
+        String fileName = item.fileName;
+        String contentType = item.contentType;
+        Callable<byte[]> contentsProducer = item.contentsProducer;
+
+        byte[] contents;
+        try {
+            contents = contentsProducer.call();
+        } catch (RuntimeException ex) {
+            throw ex;
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        } catch (Exception ex) {
+            throw new UncheckedIOException(new IOException(ex));
+        }
+        Objects.requireNonNull(contents, "file contents cannot be null");
+
+        try {
+            streamVariable.streamingStarted(new StreamingStartEventImpl(
+                    fileName, contentType, contents.length));
+            streamVariable.getOutputStream().write(contents);
+            return Optional.of(new StreamingEndEventImpl(fileName, contentType,
+                    contents.length));
+        } catch (IOException ex) {
+            errorHandler.accept(ex);
+        } catch (Exception ex) {
+            errorHandler.accept(ex);
+            return Optional.of(new StreamingErrorEventImpl(fileName,
+                    contentType, contents.length, 0, ex));
+        }
+        return Optional.empty();
+    }
+
+    private void handleUploadResult(StreamVariable streamVariable,
+            StreamVariable.StreamingEvent event) {
+        if (event instanceof StreamVariable.StreamingErrorEvent) {
+            streamVariable.streamingFailed(
+                    (StreamVariable.StreamingErrorEvent) event);
+        } else if (event instanceof StreamVariable.StreamingEndEvent) {
+            streamVariable.streamingFinished(
+                    (StreamVariable.StreamingEndEvent) event);
+        }
+    }
+
+    private StreamVariable getGetStreamVariable() {
+        try {
+            return (StreamVariable) getMethod("getStreamVariable")
+                    .invoke(getComponent());
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class UploadItem {
+        private final String fileName;
+        private final String contentType;
+
+        private final Callable<byte[]> contentsProducer;
+
+        UploadItem(String fileName, String contentType,
+                Callable<byte[]> contentsProducer) {
+
+            this.fileName = Objects.requireNonNull(fileName,
+                    "fileName cannot be null");
+            this.contentType = contentType;
+            this.contentsProducer = Objects.requireNonNull(contentsProducer,
+                    "content producers cannot be null");
+        }
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/upload/UploadView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/upload/UploadView.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.upload;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.upload.receivers.MemoryBuffer;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "upload", registerAtStartup = false)
+public class UploadView extends Component implements HasComponents {
+
+    MemoryBuffer receiver = new MemoryBuffer();
+    MultiFileMemoryBuffer multiReceiver = new MultiFileMemoryBuffer();
+    Upload uploadSingle;
+    Upload uploadMulti;
+
+    public UploadView() {
+        uploadSingle = new Upload(receiver);
+        uploadMulti = new Upload(multiReceiver);
+
+        add(uploadSingle, uploadMulti);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/upload/UploadWrapTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/upload/UploadWrapTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.upload;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages
+class UploadWrapTest extends UIUnitTest {
+
+    private static final String FIRST_FILE_CONTENTS = "First file";
+    private static final String SECOND_FILE_CONTENTS = "Second file";
+    private static final String THIRD_FILE_CONTENTS = "Third file";
+
+    @TempDir
+    private static Path tempDir;
+    private static File file1;
+    private static File file2;
+    private static File file3;
+
+    UploadView view;
+    UploadWrap<Upload> single_;
+    UploadWrap<Upload> multi_;
+
+    @BeforeAll
+    static void setupTestFiles() throws IOException {
+        file1 = tempDir.resolve("upload1.txt").toFile();
+        Files.writeString(file1.toPath(), FIRST_FILE_CONTENTS);
+        file2 = tempDir.resolve("file2.txt").toFile();
+        Files.writeString(file2.toPath(), SECOND_FILE_CONTENTS);
+        file3 = tempDir.resolve("third.txt").toFile();
+        Files.writeString(file3.toPath(), THIRD_FILE_CONTENTS);
+    }
+
+    @BeforeEach
+    void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(UploadView.class);
+        view = navigate(UploadView.class);
+        single_ = wrap(view.uploadSingle);
+        multi_ = wrap(view.uploadMulti);
+    }
+
+    @Test
+    void upload_notUsable_throws() {
+        view.uploadSingle.setVisible(false);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> single_.upload(file1));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> single_.uploadAborted(file1));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> single_.uploadFailed(file1));
+    }
+
+    @Test
+    void upload_singleFile_succeeds() {
+
+        AtomicBoolean started = new AtomicBoolean();
+        AtomicBoolean finished = new AtomicBoolean();
+        AtomicBoolean allFinished = new AtomicBoolean();
+        AtomicBoolean succeeded = new AtomicBoolean();
+        AtomicBoolean failed = new AtomicBoolean();
+
+        view.uploadSingle.addStartedListener(ev -> {
+            Assertions.assertEquals(ev.getFileName(), file1.getName());
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            Assertions.assertFalse(succeeded.get(),
+                    "Succeeded should not have been notified on start");
+            started.set(true);
+        });
+        view.uploadSingle.addSucceededListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            succeeded.set(true);
+        });
+        view.uploadSingle.addFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(succeeded.get(),
+                    "Succeeded should have been notified on succeeded");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            finished.set(true);
+        });
+        view.uploadSingle.addAllFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(succeeded.get(),
+                    "Succeeded should have been notified on succeeded");
+            Assertions.assertTrue(finished.get(),
+                    "Finished should have been notified on succeeded");
+            allFinished.set(true);
+        });
+        view.uploadSingle.addFailedListener(ev -> Assertions
+                .fail("Failed listener should not be notified"));
+
+        single_.upload(file1);
+
+        Assertions.assertTrue(started.get(),
+                "Started listener was not notified");
+        Assertions.assertTrue(succeeded.get(),
+                "Succeeded listener was not notified");
+        Assertions.assertFalse(failed.get(), "Failed listener was notified");
+        Assertions.assertTrue(finished.get(),
+                "Finished listener was not notified");
+        Assertions.assertTrue(allFinished.get(),
+                "All Finished listener was not notified");
+
+        Assertions.assertEquals(file1.getName(), view.receiver.getFileName());
+        Assertions.assertEquals("text/plain",
+                view.receiver.getFileData().getMimeType());
+        Assertions.assertEquals(FIRST_FILE_CONTENTS,
+                inputStreamToString(view.receiver.getInputStream()));
+    }
+
+    @Test
+    void upload_singleFile_failure() {
+
+        AtomicBoolean started = new AtomicBoolean();
+        AtomicBoolean finished = new AtomicBoolean();
+        AtomicBoolean allFinished = new AtomicBoolean();
+        AtomicBoolean succeeded = new AtomicBoolean();
+        AtomicBoolean failed = new AtomicBoolean();
+
+        view.uploadSingle.setReceiver((fileName, mimeType) -> {
+            throw new UncheckedIOException(new IOException("BOOM!"));
+        });
+        view.uploadSingle.addStartedListener(ev -> {
+            Assertions.assertEquals(ev.getFileName(), file1.getName());
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            Assertions.assertFalse(succeeded.get(),
+                    "Succeeded should not have been notified on start");
+            Assertions.assertFalse(failed.get(),
+                    "Succeeded should not have been notified on start");
+            started.set(true);
+        });
+        view.uploadSingle.addFailedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            failed.set(true);
+        });
+        view.uploadSingle.addFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(failed.get(),
+                    "Failed should have been notified on succeeded");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            finished.set(true);
+        });
+        view.uploadSingle.addAllFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(failed.get(),
+                    "Failed should have been notified on succeeded");
+            Assertions.assertTrue(finished.get(),
+                    "Finished should have been notified on succeeded");
+            allFinished.set(true);
+        });
+        view.uploadSingle.addSucceededListener(ev -> Assertions
+                .fail("Succeeded listener should not be notified"));
+
+        Assertions.assertThrows(UncheckedIOException.class,
+                () -> single_.upload(file1));
+
+        Assertions.assertTrue(started.get(),
+                "Started listener was not notified");
+        Assertions.assertFalse(succeeded.get(),
+                "Succeeded listener was notified");
+        Assertions.assertTrue(failed.get(), "Failed listener was not notified");
+        Assertions.assertTrue(finished.get(),
+                "Finished listener was not notified");
+        Assertions.assertTrue(allFinished.get(),
+                "All Finished listener was not notified");
+
+    }
+
+    @Test
+    void upload_multipleFiles_succeeds() {
+        AtomicInteger started = new AtomicInteger();
+        AtomicInteger finished = new AtomicInteger();
+        AtomicInteger allFinished = new AtomicInteger();
+        AtomicInteger succeeded = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+
+        view.uploadMulti.addStartedListener(ev -> started.incrementAndGet());
+        view.uploadMulti.addFailedListener(ev -> failed.incrementAndGet());
+        view.uploadMulti.addFinishedListener(ev -> finished.incrementAndGet());
+        view.uploadMulti
+                .addAllFinishedListener(ev -> allFinished.incrementAndGet());
+        view.uploadMulti
+                .addSucceededListener(ev -> succeeded.incrementAndGet());
+
+        multi_.uploadAll(file1, file2, file3);
+
+        Assertions.assertEquals(3, started.get(),
+                "Expected Started to be invoked once per uploaded file, but was called "
+                        + succeeded.get() + " times");
+        Assertions.assertEquals(3, succeeded.get(),
+                "Expected Succeeded to be invoked once per uploaded file, but was called "
+                        + succeeded.get() + " times");
+        Assertions.assertEquals(3, finished.get(),
+                "Expected Finished to be invoked once per uploaded file, but was called "
+                        + finished.get() + " times");
+        Assertions.assertEquals(0, failed.get(),
+                "Failed should not be invoked");
+        Assertions.assertEquals(1, allFinished.get(),
+                "All Finished should be invoked once");
+
+        Set<String> receivedFiles = view.multiReceiver.getFiles();
+        Assertions.assertEquals(3, receivedFiles.size());
+        Assertions.assertTrue(receivedFiles.containsAll(
+                Set.of(file1.getName(), file2.getName(), file3.getName())));
+    }
+
+    @Test
+    void uploadAll_noFiles_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> multi_.uploadAll());
+    }
+
+    @Test
+    void uploadAll_singleReceiver_throws() {
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> single_.uploadAll(file1, file2, file3));
+    }
+
+    @Test
+    void uploadAborted_failureNotified() {
+        assertFailedUpload(single_::uploadAborted);
+    }
+
+    @Test
+    void uploadFailed_failureNotified() {
+        assertFailedUpload(single_::uploadFailed);
+    }
+
+    @Test
+    void upload_fileCountExceeded_throws() {
+        view.uploadMulti.setMaxFiles(2);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> multi_.uploadAll(file1, file2, file3));
+    }
+
+    void assertFailedUpload(BiConsumer<String, String> wrapperAction) {
+        AtomicBoolean started = new AtomicBoolean();
+        AtomicBoolean finished = new AtomicBoolean();
+        AtomicBoolean allFinished = new AtomicBoolean();
+        AtomicBoolean succeeded = new AtomicBoolean();
+        AtomicBoolean failed = new AtomicBoolean();
+
+        view.uploadSingle.addStartedListener(ev -> {
+            Assertions.assertEquals(ev.getFileName(), file1.getName());
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            Assertions.assertFalse(succeeded.get(),
+                    "Succeeded should not have been notified on start");
+            Assertions.assertFalse(failed.get(),
+                    "Succeeded should not have been notified on start");
+            started.set(true);
+        });
+        view.uploadSingle.addFailedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertFalse(finished.get(),
+                    "Finished should not have been notified on start");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            failed.set(true);
+        });
+        view.uploadSingle.addFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(failed.get(),
+                    "Failed should have been notified on succeeded");
+            Assertions.assertFalse(allFinished.get(),
+                    "All Finished should not have been notified on start");
+            finished.set(true);
+        });
+        view.uploadSingle.addAllFinishedListener(ev -> {
+            Assertions.assertTrue(started.get(),
+                    "Started should have been notified on succeeded");
+            Assertions.assertTrue(failed.get(),
+                    "Failed should have been notified on succeeded");
+            Assertions.assertTrue(finished.get(),
+                    "Finished should have been notified on succeeded");
+            allFinished.set(true);
+        });
+        view.uploadSingle.addSucceededListener(ev -> Assertions
+                .fail("Succeeded listener should not be notified"));
+
+        wrapperAction.accept(file1.getName(), "text/plain");
+
+        Assertions.assertTrue(started.get(),
+                "Started listener was not notified");
+        Assertions.assertFalse(succeeded.get(),
+                "Succeeded listener was notified");
+        Assertions.assertTrue(failed.get(), "Failed listener was not notified");
+        Assertions.assertTrue(finished.get(),
+                "Finished listener was not notified");
+        Assertions.assertTrue(allFinished.get(),
+                "All Finished listener was not notified");
+    }
+
+    private String inputStreamToString(InputStream inputStream) {
+        try {
+            return new String(inputStream.readAllBytes(),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
Allows to simulate upload of single e multiple files, abort and failure.

Part of #1371