### PR TITLE
fix: Remove scope from unit module

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -30,7 +30,6 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-testbench-unit</artifactId>
                 <version>${project.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
Drop the test scope in bom
for unit module as it makes
it not be brought in as a transitive
dependency with the core module
