### PR TITLE
chore: use flow 9.0-SNAPSHOT

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <jetty.version>9.4.43.v20210629</jetty.version>
-        <flow.version>9.0.5</flow.version>
+        <flow.version>9.0-SNAPSHOT</flow.version>
 
         <!-- Frontend -->
         <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>


### PR DESCRIPTION
Use 9.0-snapshot of Flow instead of a
release version that is broken
due to npm package updates
