### PR TITLE
fix: Made withTextContaining work with all components

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ElementConditions.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/ElementConditions.java
@@ -40,8 +40,9 @@ public final class ElementConditions {
      * Input text is compared with value obtained either by
      * {@link HasText#getText()}, {@link Element#getText()} if element is a text
      * node, or the normalized version of {@link Html#getInnerHtml()}. In all
-     * other cases the predicate returns {@literal false}. The only Comparison
-     * is case-sensitive.
+     * other cases {@link Element#getTextRecursively()} is used, but in this
+     * case text from nested elements is concatenated without space separators.
+     * The comparison is case-sensitive.
      *
      * For {@link Html} components the {@literal innerHTML} tags are stripped
      * and whitespace is normalized and trimmed.
@@ -61,8 +62,9 @@ public final class ElementConditions {
      *            {@literal null}.
      * @return this element query instance for chaining
      * @see HasText#getText()
-     * @see Element#getText()
      * @see Element#isTextNode()
+     * @see Element#getText()
+     * @see Element#getTextRecursively()
      * @see Html#getInnerHtml()
      */
     public static <T extends Component> Predicate<T> containsText(String text) {
@@ -74,8 +76,9 @@ public final class ElementConditions {
      *
      * Input text is compared with value obtained either by
      * {@link HasText#getText()}, {@link Element#getText()} if element is a text
-     * node, or {@link Html#getInnerHtml()}. In all other cases the predicate
-     * returns {@literal false}.
+     * node, or {@link Html#getInnerHtml()}. In all other cases
+     * {@link Element#getTextRecursively()} is used, but in this case text from
+     * nested elements is concatenated without space separators.
      *
      * For {@link Html} components the {@literal innerHTML} tags are stripped
      * and whitespace is normalized and trimmed.
@@ -97,8 +100,9 @@ public final class ElementConditions {
      *            flag to indicate if comparison must be case-insensitive.
      * @return this element query instance for chaining
      * @see HasText#getText()
-     * @see Element#getText()
      * @see Element#isTextNode()
+     * @see Element#getText()
+     * @see Element#getTextRecursively()
      * @see Html#getInnerHtml()
      */
     public static <T extends Component> Predicate<T> containsText(String text,
@@ -214,7 +218,7 @@ public final class ElementConditions {
             } else if (component.getElement().isTextNode()) {
                 componentText = component.getElement().getText();
             } else {
-                return false;
+                componentText = component.getElement().getTextRecursively();
             }
             if (componentText == null) {
                 return false;

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ElementConditionsTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/ElementConditionsTest.java
@@ -106,16 +106,32 @@ class ElementConditionsTest {
     }
 
     @Test
-    void containsText_nonTextNode_alwaysFalse() {
+    void containsText_nonTextNode_checksTextRecursively() {
         NonTextComponent component = new NonTextComponent(
                 "this is the content");
-        Assertions.assertFalse(containsText("").test(component));
-        Assertions.assertFalse(containsText("is").test(component));
-        Assertions.assertFalse(containsText("this").test(component));
-        Assertions.assertFalse(containsText("content").test(component));
-        Assertions.assertFalse(containsText(" is the ").test(component));
-        Assertions.assertFalse(
+        Assertions.assertTrue(containsText("").test(component));
+        Assertions.assertTrue(containsText("is").test(component));
+        Assertions.assertTrue(containsText("this").test(component));
+        Assertions.assertTrue(containsText("content").test(component));
+        Assertions.assertTrue(containsText(" is the ").test(component));
+        Assertions.assertTrue(
                 containsText("this is the content").test(component));
+        Assertions.assertFalse(containsText("some text").test(component));
+        Assertions.assertFalse(containsText("CONTENT").test(component));
+    }
+
+    @Test
+    void containsText_nonTextNodeWithChildren_checksTextRecursively() {
+        NonTextComponent component = new NonTextComponent(
+                new NonTextComponent("this is"),
+                new TextComponent("the content"));
+        Assertions.assertTrue(containsText("").test(component));
+        Assertions.assertTrue(containsText("is").test(component));
+        Assertions.assertTrue(containsText("this").test(component));
+        Assertions.assertTrue(containsText("content").test(component));
+        Assertions.assertTrue(containsText("isthe").test(component));
+        Assertions
+                .assertTrue(containsText("this isthe content").test(component));
         Assertions.assertFalse(containsText("some text").test(component));
         Assertions.assertFalse(containsText("CONTENT").test(component));
     }
@@ -265,9 +281,13 @@ class ElementConditionsTest {
     }
 
     @Tag("span")
-    static class NonTextComponent extends Component {
+    static class NonTextComponent extends Component implements HasComponents {
         public NonTextComponent(String text) {
             getElement().setText(text);
+        }
+
+        public NonTextComponent(Component... components) {
+            add(components);
         }
     }
 


### PR DESCRIPTION
Currently withTextContaining returns false if the component is not HasText,
Html or if element is not a text node.
This change adds support for all other component types, by checking the input
against Element.getTextRecursively.
To be noted that the result from getTextRecursively() may be a the concatenation
of text from child nodes, but without space separators