### PR TITLE
chore: Made GridWrap.getCellText return visible text for component renderers

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/grid/GridWrap.java
@@ -9,7 +9,6 @@
  */
 package com.vaadin.flow.component.grid;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ import com.vaadin.testbench.unit.MetaKeys;
 import com.vaadin.testbench.unit.MouseButton;
 import com.vaadin.testbench.unit.Wraps;
 import com.vaadin.testbench.unit.component.GridKt;
-import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
 
 /**
  * Test wrapper for Grid components.
@@ -252,9 +250,11 @@ public class GridWrap<T extends Grid<Y>, Y> extends ComponentWrap<T> {
         ensureVisible();
         final Grid.Column targetColumn = getColumns().get(column);
         if (targetColumn.getRenderer() instanceof ComponentRenderer) {
-            return PrettyPrintTreeKt.toPrettyString(
-                    ((ComponentRenderer<?, Y>) targetColumn.getRenderer())
-                            .createComponent(getRow(row)));
+            Component component = getCellComponent(row, column);
+            if (component == null) {
+                return null;
+            }
+            return component.getElement().getTextRecursively();
         } else if (targetColumn.getRenderer() instanceof ColumnPathRenderer) {
             // This renderer just writes the object text using a path
             return getValueProviderString(row, targetColumn);

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/GetTextCellRendererTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/GetTextCellRendererTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.grid;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
+@ViewPackages
+class GetTextCellRendererTest extends UIUnitTest {
+
+    RendererGridView view;
+    GridWrap<Grid<Person>, Person> grid_;
+
+    @BeforeEach
+    void init() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RendererGridView.class);
+
+        view = navigate(RendererGridView.class);
+        grid_ = wrap(view.grid);
+    }
+
+    @Test
+    void getCellText_componentRenderer_getTextRecursively() {
+        Assertions.assertEquals(
+                String.format("%s%s%d", view.first.getFirstName(),
+                        view.first.getLastName(), view.first.getAge()),
+                grid_.getCellText(0, 0));
+    }
+
+    @Test
+    void getCellText_renderNull_getsNull() {
+        Assertions.assertNull(grid_.getCellText(0, 1));
+    }
+
+    @Test
+    void getCellText_nonTextComponent_getsEmptyString() {
+        Assertions.assertTrue(grid_.getCellText(0, 2).isEmpty());
+    }
+
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/RendererGridView.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/flow/component/grid/RendererGridView.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.flow.component.grid;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "renderer-grid", registerAtStartup = false)
+public class RendererGridView extends Component implements HasComponents {
+
+    Grid<Person> grid = new Grid<>();
+    Person first = Person.createTestPerson1();
+    Person second = Person.createTestPerson2();
+
+    public RendererGridView() {
+        grid.setItems(first, second);
+
+        grid.addColumn(new ComponentRenderer<>(p -> new Container(
+                new Text(p.getFirstName()), new TextNode(p.getLastName()),
+                new TextNode(Integer.toString(p.getAge())))))
+                .setKey("componentRendered");
+        grid.addColumn(new ComponentRenderer<>(p -> null))
+                .setKey("nullRendered");
+        grid.addColumn(new ComponentRenderer<>(p -> new Icon("USER")));
+
+        add(grid);
+    }
+
+    @Tag("a-container")
+    public static class Container extends Component implements HasComponents {
+        public Container(Component... components) {
+            add(components);
+        }
+    }
+
+    @Tag("icon")
+    public static class Icon extends Component {
+        public Icon(String name) {
+            getElement().setProperty("name", name);
+        }
+    }
+
+    @Tag("text-node")
+    public static class TextNode extends Component {
+        public TextNode(String text) {
+            super(Element.createText(text));
+        }
+    }
+
+    @Tag("text")
+    public static class Text extends Component implements HasText {
+        public Text(String text) {
+            setText(text);
+        }
+    }
+
+}


### PR DESCRIPTION
Currently for columns with component renderer, getCellText returns
a textual representation of the component object, not what may be displayed
on the screen.
With this change the method returns the concatenation of text node the
component is made up.

Fixes #1468