### PR TITLE
feat: fail with informative message when Vaadin env is not set up correctly

### DIFF
--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -59,7 +59,7 @@ import com.vaadin.testbench.unit.mocks.MockedUI;
  *
  * @see ViewPackages
  */
-class BaseUIUnitTest {
+abstract class BaseUIUnitTest {
 
     private static final ConcurrentHashMap<String, Routes> routesCache = new ConcurrentHashMap<>();
 
@@ -204,7 +204,7 @@ class BaseUIUnitTest {
      * @return instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
-        UI.getCurrent().navigate(navigationTarget);
+        verifyAndGetUI().navigate(navigationTarget);
         return validateNavigationTarget(navigationTarget);
     }
 
@@ -239,7 +239,7 @@ class BaseUIUnitTest {
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> navigationTarget, C parameter) {
-        UI.getCurrent().navigate(navigationTarget, parameter);
+        verifyAndGetUI().navigate(navigationTarget, parameter);
         return validateNavigationTarget(navigationTarget);
     }
 
@@ -257,7 +257,7 @@ class BaseUIUnitTest {
      */
     public <T extends Component> T navigate(Class<T> navigationTarget,
             Map<String, String> parameters) {
-        UI.getCurrent().navigate(navigationTarget,
+        verifyAndGetUI().navigate(navigationTarget,
                 new RouteParameters(parameters));
         return validateNavigationTarget(navigationTarget);
     }
@@ -276,7 +276,7 @@ class BaseUIUnitTest {
      */
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
-        UI.getCurrent().navigate(location);
+        verifyAndGetUI().navigate(location);
         return validateNavigationTarget(expectedTarget);
     }
 
@@ -290,7 +290,7 @@ class BaseUIUnitTest {
      *            Key modifiers. Can be empty.
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
-        UI ui = UI.getCurrent();
+        UI ui = verifyAndGetUI();
         // TODO: should this logic be moved to ShortcutsKt.fireShortcut?
         if (ui.hasModalComponent()) {
             ShortcutsKt._fireShortcut(
@@ -307,7 +307,7 @@ class BaseUIUnitTest {
      * @return current view
      */
     public HasElement getCurrentView() {
-        return UI.getCurrent().getInternals().getActiveRouterTargetsChain()
+        return verifyAndGetUI().getInternals().getActiveRouterTargetsChain()
                 .get(0);
     }
 
@@ -338,6 +338,7 @@ class BaseUIUnitTest {
      */
     public <T extends ComponentWrap<Y>, Y extends Component> T wrap(
             Y component) {
+        verifyAndGetUI();
         return internalWrap(component);
     }
 
@@ -356,6 +357,7 @@ class BaseUIUnitTest {
      */
     public <T extends ComponentWrap<Y>, Y extends Component> T wrap(
             Class<T> wrap, Y component) {
+        verifyAndGetUI();
         return (T) initialize(wrap, component);
     }
 
@@ -381,6 +383,7 @@ class BaseUIUnitTest {
      * @return a query object for finding components
      */
     public <T extends Component> ComponentQuery<T> $(Class<T> componentType) {
+        verifyAndGetUI();
         return internalQuery(componentType);
     }
 
@@ -398,6 +401,7 @@ class BaseUIUnitTest {
      */
     public <T extends Component> ComponentQuery<T> $(Class<T> componentType,
             Component fromThis) {
+        verifyAndGetUI();
         return new ComponentQuery<>(componentType, this::wrap).from(fromThis);
     }
 
@@ -510,5 +514,37 @@ class BaseUIUnitTest {
             typeMap.put(typeParameter[i], actualTypeArgument[i]);
         }
     }
+
+    /*
+     * Checks that the mock UI is available, otherwise fails fast with an
+     * exception giving advices on possible causes of the problem.
+     *
+     * Principal cause for having a null UI is that the test extends the wrong
+     * base class for the current configuration, e.g. using UIUnit4Test with
+     * JUnit 5 or the opposite.
+     *
+     */
+    private UI verifyAndGetUI() {
+        UI ui = UI.getCurrent();
+        if (ui == null) {
+            String message = "Test Vaadin environment is not initialized correctly. "
+                    + "This may happen when the test is extending the wrong base class for the testing engine in use. "
+                    + "Current test class is expected to run with "
+                    + testingEngine() + ".";
+            throw new UIUnitTestSetupException(message);
+        }
+        return ui;
+    }
+
+    /**
+     * Gets the name of the Test Engine that is able to run the base class
+     * implementation.
+     *
+     * The Test Engine name is reported in the exception thrown when the Vaadin
+     * environment is not set up correctly.
+     *
+     * @return name of the Test Engine.
+     */
+    protected abstract String testingEngine();
 
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -85,6 +85,11 @@ public abstract class UIUnit4Test extends BaseUIUnitTest {
         super.initVaadinEnvironment();
     }
 
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 4";
+    }
+
     @Rule
     public TestRule treeOnFailure = new TestWatcher() {
         @Override

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -83,4 +83,9 @@ public abstract class UIUnitTest extends BaseUIUnitTest {
     protected void cleanVaadinEnvironment() {
         super.cleanVaadinEnvironment();
     }
+
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 5";
+    }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTestSetupException.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnitTestSetupException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+
+package com.vaadin.testbench.unit;
+
+/**
+ * Exception thrown by {@link BaseUIUnitTest} methods when the mock environment
+ * has not been set up correctly.
+ */
+public class UIUnitTestSetupException extends RuntimeException {
+    public UIUnitTestSetupException(String message) {
+        super(message);
+    }
+
+    public UIUnitTestSetupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnit4BaseClassTest.java
@@ -10,22 +10,23 @@
 package com.vaadin.testbench.unit;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.example.SingleParam;
 import com.example.TemplatedParam;
+import com.example.base.ParametrizedView;
 import com.example.base.WelcomeView;
-import com.example.base.child.ChildView;
-import com.example.base.navigation.NavigationPostponeView;
-import com.testapp.security.LoginView;
-import com.testapp.security.ProtectedView;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.di.Lookup;
@@ -109,6 +110,49 @@ public class UIUnit4BaseClassTest {
                                     .getSimpleName()
                             + " but was " + service.getClass().getSimpleName(),
                     service instanceof TestCustomInstantiatorFactory);
+        }
+    }
+
+    public static class WrongBaseClassTest extends UIUnitTest {
+
+        @Test
+        public void navigate_fails() {
+            assertExecutionFails(() -> navigate(WelcomeView.class));
+            assertExecutionFails(() -> navigate("welcome", WelcomeView.class));
+            assertExecutionFails(() -> navigate(ParametrizedView.class, 12));
+            assertExecutionFails(
+                    () -> navigate(ParametrizedView.class, Map.of()));
+        }
+
+        @Test
+        public void getCurrentView_fails() {
+            assertExecutionFails(this::getCurrentView);
+        }
+
+        @Test
+        public void fireShortcut_fails() {
+            assertExecutionFails(() -> fireShortcut(Key.ENTER));
+        }
+
+        @Test
+        public void wrap_fails() {
+            assertExecutionFails(() -> wrap(new ComponentWrapTest.Span()));
+            assertExecutionFails(() -> wrap(ComponentWrap.class,
+                    new ComponentWrapTest.Span()));
+        }
+
+        @Test
+        public void query_fails() {
+            assertExecutionFails(() -> $(Component.class));
+            assertExecutionFails(
+                    () -> $(Component.class, new ComponentWrapTest.Span()));
+            assertExecutionFails(() -> $view(Component.class));
+        }
+
+        private void assertExecutionFails(ThrowingRunnable executable) {
+            UIUnitTestSetupException exception = Assert
+                    .assertThrows(UIUnitTestSetupException.class, executable);
+            Assertions.assertTrue(exception.getMessage().contains("JUnit 5"));
         }
     }
 

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitBaseClassTest.java
@@ -10,26 +10,24 @@
 package com.vaadin.testbench.unit;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.example.SingleParam;
 import com.example.TemplatedParam;
+import com.example.base.ParametrizedView;
 import com.example.base.WelcomeView;
-import com.example.base.child.ChildView;
-import com.example.base.navigation.NavigationPostponeView;
-import io.github.classgraph.ClassGraph;
-import io.github.classgraph.ScanResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.di.Lookup;
-import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -105,6 +103,50 @@ class UIUnitBaseClassTest {
                             + TestCustomInstantiatorFactory.class
                                     .getSimpleName()
                             + " but was " + service.getClass().getSimpleName());
+        }
+    }
+
+    @Nested
+    class WrongBaseClassTest extends UIUnit4Test {
+
+        @Test
+        void navigate_fails() {
+            assertExecutionFails(() -> navigate(WelcomeView.class));
+            assertExecutionFails(() -> navigate("welcome", WelcomeView.class));
+            assertExecutionFails(() -> navigate(ParametrizedView.class, 12));
+            assertExecutionFails(
+                    () -> navigate(ParametrizedView.class, Map.of()));
+        }
+
+        @Test
+        void getCurrentView_fails() {
+            assertExecutionFails(this::getCurrentView);
+        }
+
+        @Test
+        void fireShortcut_fails() {
+            assertExecutionFails(() -> fireShortcut(Key.ENTER));
+        }
+
+        @Test
+        void wrap_fails() {
+            assertExecutionFails(() -> wrap(new ComponentWrapTest.Span()));
+            assertExecutionFails(() -> wrap(ComponentWrap.class,
+                    new ComponentWrapTest.Span()));
+        }
+
+        @Test
+        void query_fails() {
+            assertExecutionFails(() -> $(Component.class));
+            assertExecutionFails(
+                    () -> $(Component.class, new ComponentWrapTest.Span()));
+            assertExecutionFails(() -> $view(Component.class));
+        }
+
+        private void assertExecutionFails(Executable executable) {
+            UIUnitTestSetupException exception = Assertions
+                    .assertThrows(UIUnitTestSetupException.class, executable);
+            Assertions.assertTrue(exception.getMessage().contains("JUnit 4"));
         }
     }
 


### PR DESCRIPTION
The most used method of base test class now checks that
the UI is present and throw an exception if it is not.

Fixes #1475