### PR TITLE
refactor!: MockRouteNotFoundError does not rethrow exception anymore

### DIFF
--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
@@ -22,6 +22,7 @@ import com.vaadin.flow.router.NotFoundException
 import com.vaadin.flow.router.Route
 import com.vaadin.flow.router.RouteData
 import com.vaadin.flow.router.internal.DefaultErrorHandler
+import com.vaadin.flow.server.HttpStatusCode
 import com.vaadin.flow.server.VaadinContext
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry
 import com.vaadin.flow.server.startup.RouteRegistryInitializer
@@ -134,6 +135,9 @@ fun ApplicationRouteRegistry.clearPwaClass() {
  */
 @Tag(Tag.DIV)
 open class MockRouteNotFoundError : Component(), HasErrorParameter<NotFoundException> {
+
+    var cause: NotFoundException? = null;
+
     override fun setErrorParameter(event: BeforeEnterEvent, parameter: ErrorParameter<NotFoundException>): Int {
         val message: String = buildString {
             val path: String = event.location.path
@@ -146,7 +150,9 @@ open class MockRouteNotFoundError : Component(), HasErrorParameter<NotFoundExcep
             append(routes.map { it.toPrettyString() })
             append("\nIf you'd like to revert back to the original Vaadin RouteNotFoundError, please remove the ${MockRouteNotFoundError::class.java} from Routes.errorRoutes")
         }
-        throw NotFoundException(message).apply { initCause(parameter.caughtException) }
+        cause = NotFoundException(message).apply { initCause(parameter.caughtException) }
+        element.text = message;
+        return HttpStatusCode.NOT_FOUND.code
     }
 
     private fun RouteData.toPrettyString(): String {

--- a/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitNavigationTest.java
+++ b/vaadin-testbench-unit/src/test/java/com/vaadin/testbench/unit/UIUnitNavigationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.testbench.unit.internal.MockRouteNotFoundError;
 
 @ViewPackages(packages = "com.example")
 public class UIUnitNavigationTest extends UIUnitTest {
@@ -40,9 +41,14 @@ public class UIUnitNavigationTest extends UIUnitTest {
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> navigate(SingleParam.class),
                 "Illegal argument should be thrown for missing parameter");
-        Assertions.assertThrows(NotFoundException.class,
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class,
                 () -> navigate("param", SingleParam.class),
                 "No matching route should be found for string without parameter");
+        Assertions.assertTrue(exception.getMessage()
+                .contains("Navigation resulted in unexpected class"));
+        Assertions.assertTrue(exception.getMessage()
+                .contains(MockRouteNotFoundError.class.getName()));
     }
 
     @Test

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
@@ -87,11 +87,19 @@ fun DynaNodeGroup.routesTestBatch() {
         }
     }
 
-    test("MockRouteNotFoundError is called when the route doesn't exist, and it fails immediately with an informative error message") {
+    test("MockRouteNotFoundError is called when the route doesn't exist and it contains informative error message") {
         val routes: Routes = Routes().autoDiscoverViews("com.example.base")
         MockVaadin.setup(routes)
+        UI.getCurrent().navigate("A_VIEW_THAT_DOESNT_EXIST")
+        val view = UI.getCurrent().internals.activeRouterTargetsChain.first();
+        expect(MockRouteNotFoundError::class.java) {
+            view::class.java
+        }
         expectThrows(NotFoundException::class, "No route found for 'A_VIEW_THAT_DOESNT_EXIST': Couldn't find route for 'A_VIEW_THAT_DOESNT_EXIST'\nAvailable routes:") {
-            UI.getCurrent().navigate("A_VIEW_THAT_DOESNT_EXIST")
+            throw (view as MockRouteNotFoundError).cause!!
+        }
+        expect(true) {
+            view.element.text.contains("No route found for 'A_VIEW_THAT_DOESNT_EXIST': Couldn't find route for 'A_VIEW_THAT_DOESNT_EXIST'\nAvailable routes:")
         }
     }
 


### PR DESCRIPTION
MockRouteNotFoundError was used to rethrow a more detailed exception on
navigation errors.
Now it does not throws but holds a reference to the exception and adds
informative message as Div text content.

Fixes #1447