### PR TITLE
refactor: make MockRouteNotFoundError extend RouteNotFoundError

### DIFF
--- a/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
+++ b/vaadin-testbench-unit/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
@@ -21,6 +21,7 @@ import com.vaadin.flow.router.InternalServerError
 import com.vaadin.flow.router.NotFoundException
 import com.vaadin.flow.router.Route
 import com.vaadin.flow.router.RouteData
+import com.vaadin.flow.router.RouteNotFoundError
 import com.vaadin.flow.router.internal.DefaultErrorHandler
 import com.vaadin.flow.server.HttpStatusCode
 import com.vaadin.flow.server.VaadinContext
@@ -134,11 +135,13 @@ fun ApplicationRouteRegistry.clearPwaClass() {
  * any navigation to a missing route and can respond with an informative exception.
  */
 @Tag(Tag.DIV)
-open class MockRouteNotFoundError : Component(), HasErrorParameter<NotFoundException> {
+@DefaultErrorHandler
+open class MockRouteNotFoundError : RouteNotFoundError() {
 
     var cause: NotFoundException? = null;
 
     override fun setErrorParameter(event: BeforeEnterEvent, parameter: ErrorParameter<NotFoundException>): Int {
+
         val message: String = buildString {
             val path: String = event.location.path
             append("No route found for '").append(path).append("'")
@@ -151,8 +154,7 @@ open class MockRouteNotFoundError : Component(), HasErrorParameter<NotFoundExcep
             append("\nIf you'd like to revert back to the original Vaadin RouteNotFoundError, please remove the ${MockRouteNotFoundError::class.java} from Routes.errorRoutes")
         }
         cause = NotFoundException(message).apply { initCause(parameter.caughtException) }
-        element.text = message;
-        return HttpStatusCode.NOT_FOUND.code
+        return super.setErrorParameter(event, parameter)
     }
 
     private fun RouteData.toPrettyString(): String {

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/RoutesTest.kt
@@ -99,7 +99,9 @@ fun DynaNodeGroup.routesTestBatch() {
             throw (view as MockRouteNotFoundError).cause!!
         }
         expect(true) {
-            view.element.text.contains("No route found for 'A_VIEW_THAT_DOESNT_EXIST': Couldn't find route for 'A_VIEW_THAT_DOESNT_EXIST'\nAvailable routes:")
+            val errorMessage = view.element.textRecursively2
+            errorMessage.contains("Could not navigate to 'A_VIEW_THAT_DOESNT_EXIST'")
+            errorMessage.contains("Reason: Couldn't find route for 'A_VIEW_THAT_DOESNT_EXIST'")
         }
     }
 


### PR DESCRIPTION
Making MockRouteNotFoundError extending RouteNotFoundError and
annotating it with `@DefaultErrorHandler` won't make Vaadin apps fail at
startup when vaadin-testbench-unit incidentally is on classpath and
would also preserve the output from the out-of-the-box handler, so
testbench tests checking for it would continue to work without any
change.