### PR TITLE
fix!: Use W3C capabilities

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
@@ -149,7 +149,7 @@ public class BrowserUtil {
             return "Unknown";
         }
         try {
-            Platform p = capabilities.getPlatform();
+            Platform p = capabilities.getPlatformName();
             Platform family = p != null ? p.family() : null;
             if (family == Platform.WINDOWS || p == Platform.WINDOWS) {
                 return "Windows";
@@ -160,7 +160,7 @@ public class BrowserUtil {
         } catch (Exception e) {
         }
         Object rawPlatform = capabilities
-                .getCapability(CapabilityType.PLATFORM);
+                .getCapability(CapabilityType.PLATFORM_NAME);
         if (rawPlatform == null) {
             return "Unknown";
         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
@@ -9,8 +9,6 @@
  */
 package com.vaadin.testbench.parallel;
 
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
-
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -59,8 +57,8 @@ public class DefaultBrowserFactory implements TestBenchBrowserFactory {
         default:
             desiredCapabilities = new FirefoxOptions();
         }
-        desiredCapabilities.setCapability(CapabilityType.VERSION, version);
-        desiredCapabilities.setCapability(PLATFORM, platform);
+        desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION, version);
+        desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platform);
 
         return new DesiredCapabilities(desiredCapabilities);
     }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
@@ -57,8 +57,10 @@ public class DefaultBrowserFactory implements TestBenchBrowserFactory {
         default:
             desiredCapabilities = new FirefoxOptions();
         }
-        desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION, version);
-        desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platform);
+        desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION,
+                version);
+        desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME,
+                platform);
 
         return new DesiredCapabilities(desiredCapabilities);
     }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
@@ -105,7 +105,8 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
                         }
 
                         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
-                            SauceLabsIntegration.setSauceLabsOption(methodCapabilities,
+                            SauceLabsIntegration.setSauceLabsOption(
+                                    methodCapabilities,
                                     SauceLabsIntegration.CapabilityType.NAME,
                                     method.getName());
                         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
@@ -105,7 +105,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
                         }
 
                         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
-                            methodCapabilities.setCapability(
+                            SauceLabsIntegration.setSauceLabsOption(methodCapabilities,
                                     SauceLabsIntegration.CapabilityType.NAME,
                                     method.getName());
                         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
@@ -270,7 +270,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
         String exclude = System.getProperty("browsers.exclude");
 
         for (DesiredCapabilities d : desiredCapabilites) {
-            String browserName = (d.getBrowserName() + d.getVersion())
+            String browserName = (d.getBrowserName() + d.getBrowserVersion())
                     .toLowerCase();
             if (include != null && include.trim().length() > 0) {
                 if (include.trim().toLowerCase().contains(browserName)) {
@@ -519,7 +519,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
             if (capabilities == null) {
                 version = "Unknown";
             } else {
-                version = capabilities.getVersion();
+                version = capabilities.getBrowserVersion();
             }
             return platform + "_" + browser + "_" + version;
         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -10,8 +10,11 @@
 package com.vaadin.testbench.parallel;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +52,26 @@ public class SauceLabsIntegration {
         }
         String tunnelId = getTunnelIdentifier(sauceOptions, null);
         if (tunnelId != null) {
-            desiredCapabilities.setCapability("tunnelIdentifier", tunnelId);
+            setSauceLabsOption(desiredCapabilities, "tunnelIdentifier", tunnelId);
         }
+    }
+
+    public static void setSauceLabsOption(DesiredCapabilities desiredCapabilities, String sauceOptionKey,
+            String sauceOptionValue) {
+        Map<String,Object> sauceOptions = (Map<String, Object>) desiredCapabilities.getCapability("sauce:options");
+        if (sauceOptions == null) {
+            sauceOptions = new HashMap<>();
+            desiredCapabilities.setCapability("sauce:options", sauceOptions);
+        }
+        sauceOptions.put(sauceOptionKey, sauceOptionValue);
+    }
+
+    public static Object getSauceLabsOption(DesiredCapabilities desiredCapabilities, String sauceOptionKey) {
+        Map<String,Object> sauceOptions = (Map<String, Object>) desiredCapabilities.getCapability("sauce:options");
+        if (sauceOptions == null) {
+            return null;
+        }
+        return sauceOptions.get(sauceOptionKey);
     }
 
     /**

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -52,26 +52,55 @@ public class SauceLabsIntegration {
         }
         String tunnelId = getTunnelIdentifier(sauceOptions, null);
         if (tunnelId != null) {
-            setSauceLabsOption(desiredCapabilities, "tunnelIdentifier", tunnelId);
+            setSauceLabsOption(desiredCapabilities, "tunnelIdentifier",
+                    tunnelId);
         }
     }
 
-    public static void setSauceLabsOption(DesiredCapabilities desiredCapabilities, String sauceOptionKey,
-            String sauceOptionValue) {
-        Map<String,Object> sauceOptions = (Map<String, Object>) desiredCapabilities.getCapability("sauce:options");
+    /**
+     * Sets the given SauceLabs option to the given value.
+     *
+     * The available SauceLabs options are listed at
+     * https://docs.saucelabs.com/dev/test-configuration-options/.
+     *
+     * @param desiredCapabilities
+     *            the desired capabilities object
+     * @param key
+     *            the option key
+     * @param value
+     *            the option value
+     */
+    public static void setSauceLabsOption(
+            DesiredCapabilities desiredCapabilities, String key, Object value) {
+        Map<String, Object> sauceOptions = (Map<String, Object>) desiredCapabilities
+                .getCapability("sauce:options");
         if (sauceOptions == null) {
             sauceOptions = new HashMap<>();
             desiredCapabilities.setCapability("sauce:options", sauceOptions);
         }
-        sauceOptions.put(sauceOptionKey, sauceOptionValue);
+        sauceOptions.put(key, value);
     }
 
-    public static Object getSauceLabsOption(DesiredCapabilities desiredCapabilities, String sauceOptionKey) {
-        Map<String,Object> sauceOptions = (Map<String, Object>) desiredCapabilities.getCapability("sauce:options");
+    /**
+     * Gets the given SauceLabs option.
+     *
+     * The available SauceLabs options are listed at
+     * https://docs.saucelabs.com/dev/test-configuration-options/.
+     *
+     * @param desiredCapabilities
+     *            the desired capabilities object
+     * @param key
+     *            the option key
+     * @return the option value that was set or null
+     */
+    public static Object getSauceLabsOption(
+            DesiredCapabilities desiredCapabilities, String key) {
+        Map<String, Object> sauceOptions = (Map<String, Object>) desiredCapabilities
+                .getCapability("sauce:options");
         if (sauceOptions == null) {
             return null;
         }
-        return sauceOptions.get(sauceOptionKey);
+        return sauceOptions.get(key);
     }
 
     /**

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
@@ -33,7 +33,7 @@ public class ReferenceNameGenerator {
             Capabilities browserCapabilities) {
         String platformString;
 
-        Platform platform = browserCapabilities.getPlatform();
+        Platform platform = browserCapabilities.getPlatformName();
         if (platform != null && platform.family() != null && platform != Platform.LINUX) {
             platform = platform.family();
         }
@@ -56,7 +56,7 @@ public class ReferenceNameGenerator {
      * @return the major version of the browser.
      */
     public static String getMajorVersion(Capabilities browserCapabilities) {
-        String versionString = browserCapabilities.getVersion();
+        String versionString = browserCapabilities.getBrowserVersion();
         if (versionString.equals("")) {
             Object browserVersion = browserCapabilities
                     .getCapability("browserVersion");

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ReferenceNameGenerator.java
@@ -34,7 +34,8 @@ public class ReferenceNameGenerator {
         String platformString;
 
         Platform platform = browserCapabilities.getPlatformName();
-        if (platform != null && platform.family() != null && platform != Platform.LINUX) {
+        if (platform != null && platform.family() != null
+                && platform != Platform.LINUX) {
             platform = platform.family();
         }
         if (platform != null) {

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/BrowserUtilTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/BrowserUtilTest.java
@@ -39,7 +39,7 @@ public class BrowserUtilTest {
     @Test
     public void platformWithoutEnum() {
         DesiredCapabilities dc = new DesiredCapabilities();
-        dc.setCapability("platform", "foobar");
+        dc.setCapability("platformName", "foobar");
         Assert.assertEquals("foobar", BrowserUtil.getPlatform(dc));
     }
 }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/DefaultBrowserConfigurationTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/DefaultBrowserConfigurationTest.java
@@ -38,10 +38,10 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method = (TBMethod) testMethods.get(0);
             Assert.assertEquals(caps.getBrowserName(),
                     method.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps.getVersion(),
-                    method.getCapabilities().getVersion());
-            Assert.assertEquals(caps.getPlatform(),
-                    method.getCapabilities().getPlatform());
+            Assert.assertEquals(caps.getBrowserVersion(),
+                    method.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps.getPlatformName(),
+                    method.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }
@@ -66,16 +66,16 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method2 = (TBMethod) testMethods.get(1);
             Assert.assertEquals(caps1.getBrowserName(),
                     method1.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps1.getVersion(),
-                    method1.getCapabilities().getVersion());
-            Assert.assertEquals(caps1.getPlatform(),
-                    method1.getCapabilities().getPlatform());
+            Assert.assertEquals(caps1.getBrowserVersion(),
+                    method1.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps1.getPlatformName(),
+                    method1.getCapabilities().getPlatformName());
             Assert.assertEquals(caps2.getBrowserName(),
                     method2.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps2.getVersion(),
-                    method2.getCapabilities().getVersion());
-            Assert.assertEquals(caps2.getPlatform(),
-                    method2.getCapabilities().getPlatform());
+            Assert.assertEquals(caps2.getBrowserVersion(),
+                    method2.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps2.getPlatformName(),
+                    method2.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }
@@ -95,10 +95,10 @@ public class DefaultBrowserConfigurationTest {
             TBMethod method = (TBMethod) testMethods.get(0);
             Assert.assertEquals(caps.getBrowserName(),
                     method.getCapabilities().getBrowserName());
-            Assert.assertEquals(caps.getVersion(),
-                    method.getCapabilities().getVersion());
-            Assert.assertEquals(caps.getPlatform(),
-                    method.getCapabilities().getPlatform());
+            Assert.assertEquals(caps.getBrowserVersion(),
+                    method.getCapabilities().getBrowserVersion());
+            Assert.assertEquals(caps.getPlatformName(),
+                    method.getCapabilities().getPlatformName());
         } finally {
             Parameters.setGridBrowsers(oldBrowsers);
         }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/JobNameCapabilitiesTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/JobNameCapabilitiesTest.java
@@ -31,7 +31,8 @@ public class JobNameCapabilitiesTest {
         Assert.assertEquals(4, testMethods.size());
         for (FrameworkMethod testMethod : testMethods) {
             Assert.assertEquals(testMethod.getName(),
-                    SauceLabsIntegration.getSauceLabsOption(((TBMethod) testMethod).getCapabilities(),
+                    SauceLabsIntegration.getSauceLabsOption(
+                            ((TBMethod) testMethod).getCapabilities(),
                             SauceLabsIntegration.CapabilityType.NAME));
         }
     }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/JobNameCapabilitiesTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/JobNameCapabilitiesTest.java
@@ -31,7 +31,7 @@ public class JobNameCapabilitiesTest {
         Assert.assertEquals(4, testMethods.size());
         for (FrameworkMethod testMethod : testMethods) {
             Assert.assertEquals(testMethod.getName(),
-                    ((TBMethod) testMethod).getCapabilities().getCapability(
+                    SauceLabsIntegration.getSauceLabsOption(((TBMethod) testMethod).getCapabilities(),
                             SauceLabsIntegration.CapabilityType.NAME));
         }
     }

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
@@ -36,9 +35,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_shotFirefox11inCapabilities_returnsGeneratedName() {
         Capabilities ffcaps = Mockito.mock(Capabilities.class);
-        Mockito.when(ffcaps.getPlatform()).thenReturn(Platform.XP);
+        Mockito.when(ffcaps.getPlatformName()).thenReturn(Platform.XP);
         Mockito.when(ffcaps.getBrowserName()).thenReturn("Firefox");
-        Mockito.when(ffcaps.getVersion()).thenReturn("13.0.1");
+        Mockito.when(ffcaps.getBrowserVersion()).thenReturn("13.0.1");
         String name = rng.generateName("shot", ffcaps);
         assertEquals("shot_windows_Firefox_13", name);
     }
@@ -47,7 +46,7 @@ public class ReferenceNameGeneratorTest {
     public void testGenerateName_shotNoPlatformInCapabilities_returnsGeneratedName() {
         Capabilities someBrowser = Mockito.mock(Capabilities.class);
         Mockito.when(someBrowser.getBrowserName()).thenReturn("SomeBrowser");
-        Mockito.when(someBrowser.getVersion()).thenReturn("12.3");
+        Mockito.when(someBrowser.getBrowserVersion()).thenReturn("12.3");
         String name = rng.generateName("shot", someBrowser);
         assertEquals("shot_unknown_SomeBrowser_12", name);
     }
@@ -55,9 +54,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_fooSafari5inCapabilities_returnsGeneratedName() {
         Capabilities safari = Mockito.mock(Capabilities.class);
-        Mockito.when(safari.getPlatform()).thenReturn(Platform.MAC);
+        Mockito.when(safari.getPlatformName()).thenReturn(Platform.MAC);
         Mockito.when(safari.getBrowserName()).thenReturn("Safari");
-        Mockito.when(safari.getVersion()).thenReturn("5");
+        Mockito.when(safari.getBrowserVersion()).thenReturn("5");
         String name = rng.generateName("foo", safari);
         assertEquals("foo_mac_Safari_5", name);
     }
@@ -65,9 +64,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void testGenerateName_shotEdgeinCapabilities_returnsGeneratedName() {
         Capabilities chrome = Mockito.mock(Capabilities.class);
-        Mockito.when(chrome.getPlatform()).thenReturn(Platform.XP);
+        Mockito.when(chrome.getPlatformName()).thenReturn(Platform.XP);
         Mockito.when(chrome.getBrowserName()).thenReturn("MicrosoftEdge");
-        Mockito.when(chrome.getVersion()).thenReturn("");
+        Mockito.when(chrome.getBrowserVersion()).thenReturn("");
         Mockito.when(chrome.getCapability("browserVersion")).thenReturn("25");
         String name = rng.generateName("shot", chrome);
         assertEquals("shot_windows_MicrosoftEdge_25", name);
@@ -76,9 +75,9 @@ public class ReferenceNameGeneratorTest {
     @Test
     public void linuxUsedInScreenshotName() {
         Capabilities chrome = Mockito.mock(Capabilities.class);
-        Mockito.when(chrome.getPlatform()).thenReturn(Platform.LINUX);
+        Mockito.when(chrome.getPlatformName()).thenReturn(Platform.LINUX);
         Mockito.when(chrome.getBrowserName()).thenReturn("Chrome");
-        Mockito.when(chrome.getVersion()).thenReturn("");
+        Mockito.when(chrome.getBrowserVersion()).thenReturn("");
         Mockito.when(chrome.getCapability("browserVersion")).thenReturn("25");
         String name = rng.generateName("shot", chrome);
         assertEquals("shot_linux_Chrome_25", name);

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/screenshot/ReferenceNameGeneratorTest.java
@@ -71,7 +71,7 @@ public class ReferenceNameGeneratorTest {
         String name = rng.generateName("shot", chrome);
         assertEquals("shot_windows_MicrosoftEdge_25", name);
     }
-    
+
     @Test
     public void linuxUsedInScreenshotName() {
         Capabilities chrome = Mockito.mock(Capabilities.class);

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.parallel.Browser;
 import com.vaadin.testbench.parallel.DefaultBrowserFactory;
+import com.vaadin.testbench.parallel.SauceLabsIntegration;
 
 /**
  * Specifies default browser configuration for {@link AbstractTB6Test} tests.
@@ -33,10 +34,7 @@ public class TB6TestBrowserFactory extends DefaultBrowserFactory {
         DesiredCapabilities desiredCapabilities = super.create(browser, version,
                 platform);
 
-        if (browser.equals(Browser.FIREFOX)) {
-            desiredCapabilities.setCapability(Capability.MARIONETTE, false);
-        }
-        desiredCapabilities.setCapability("screenResolution", "1600x1200");
+        SauceLabsIntegration.setSauceLabsOption(desiredCapabilities, "screenResolution", "1600x1200");
         return desiredCapabilities;
     }
 }

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
@@ -34,7 +34,8 @@ public class TB6TestBrowserFactory extends DefaultBrowserFactory {
         DesiredCapabilities desiredCapabilities = super.create(browser, version,
                 platform);
 
-        SauceLabsIntegration.setSauceLabsOption(desiredCapabilities, "screenResolution", "1600x1200");
+        SauceLabsIntegration.setSauceLabsOption(desiredCapabilities,
+                "screenResolution", "1600x1200");
         return desiredCapabilities;
     }
 }

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListTester.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListTester.java
@@ -44,7 +44,7 @@ public class DescriptionListTester extends HtmlClickContainer<DescriptionList> {
      *
      * @return the list of terms for this description list
      */
-     public List<DescriptionList.Term> getTerms() {
+    public List<DescriptionList.Term> getTerms() {
         return getComponent().getChildren()
                 .filter(DescriptionList.Term.class::isInstance)
                 .map(DescriptionList.Term.class::cast)


### PR DESCRIPTION
If a test is using custom desired capabilities, these need to be updated to the W3C standard.
Saucelabs options need to be set using the `SauceLabsIntegration.setSauceLabsOption` and not directly on the `DesiredCapability` object.

Fixes #1429