### PR TITLE
fix!: Make Saucelabs integration use what Saucelabs recommends

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
@@ -29,7 +29,8 @@ public class BrowserUtil {
      *         on Safari
      */
     public static DesiredCapabilities safari() {
-        DesiredCapabilities c = browserFactory.create(com.vaadin.testbench.parallel.Browser.SAFARI);
+        DesiredCapabilities c = browserFactory
+                .create(com.vaadin.testbench.parallel.Browser.SAFARI);
         return c;
     }
 
@@ -40,7 +41,8 @@ public class BrowserUtil {
      *         on Chrome
      */
     public static DesiredCapabilities chrome() {
-        DesiredCapabilities c = browserFactory.create(com.vaadin.testbench.parallel.Browser.CHROME);
+        DesiredCapabilities c = browserFactory
+                .create(com.vaadin.testbench.parallel.Browser.CHROME);
         return c;
     }
 
@@ -51,7 +53,8 @@ public class BrowserUtil {
      *         on Firefox
      */
     public static DesiredCapabilities firefox() {
-        DesiredCapabilities c = browserFactory.create(com.vaadin.testbench.parallel.Browser.FIREFOX);
+        DesiredCapabilities c = browserFactory
+                .create(com.vaadin.testbench.parallel.Browser.FIREFOX);
         return c;
     }
 
@@ -62,7 +65,8 @@ public class BrowserUtil {
      *         on Edge
      */
     public static DesiredCapabilities edge() {
-        DesiredCapabilities c = browserFactory.create(com.vaadin.testbench.parallel.Browser.EDGE);
+        DesiredCapabilities c = browserFactory
+                .create(com.vaadin.testbench.parallel.Browser.EDGE);
         return c;
     }
 

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,10 +31,21 @@ public class SauceLabsIntegration {
     private static final String SAUCE_USERNAME_PROP = "sauce.user";
     private static final String SAUCE_ACCESS_KEY_ENV = "SAUCE_ACCESS_KEY";
     private static final String SAUCE_ACCESS_KEY_PROP = "sauce.sauceAccessKey";
+    private static final String SAUCE_TUNNELID_PROP = "sauce.tunnelId";
+    private static final String SAUCE_TUNNELID_ENV = "SAUCE_TUNNEL_ID";
 
     /**
-     * Sets needed desired capabilities, mainly tunnel identifier, based on the
-     * given sauce.options String.
+     * Sets needed desired capabilities for authentication and using the correct
+     * sauce tunnel (if in use).
+     * <p>
+     * Reads required credentials from sauce.user and sauce.sauceAccessKey or
+     * environment variables SAUCE_USERNAME and SAUCE_ACCESS_KEY.
+     * <p>
+     * Reads the tunnel identifier from a sauce.tunnelId system property or
+     * SAUCE_TUNNEL_ID environment vairable.
+     * <p>
+     * If both system property and environment variable are defined, the system
+     * property is used.
      *
      * @param desiredCapabilities
      *            DesiredCapabilities for RemoteWebDriver. Must not be null.
@@ -45,12 +55,26 @@ public class SauceLabsIntegration {
      */
     static void setDesiredCapabilities(
             DesiredCapabilities desiredCapabilities) {
-        String sauceOptions = System.getProperty("sauce.options");
-        if (sauceOptions == null || sauceOptions.isEmpty()) {
-            getLogger().debug("Null or empty sauce.options given. Ignoring.");
-            return;
+
+        String username = getSauceUser();
+        String accessKey = getSauceAccessKey();
+        String tunnelId = getTunnelIdentifier();
+
+        if (username != null) {
+            setSauceLabsOption(desiredCapabilities, "username", username);
+        } else {
+            getLogger().debug("You can give a Sauce Labs user name using -D"
+                    + SAUCE_USERNAME_PROP + "=<username> or by "
+                    + SAUCE_USERNAME_ENV + " environment variable.");
         }
-        String tunnelId = getTunnelIdentifier(sauceOptions, null);
+        if (accessKey != null) {
+            setSauceLabsOption(desiredCapabilities, "access_key", accessKey);
+        } else {
+            getLogger().debug("You can give a Sauce Labs access key using -D"
+                    + SAUCE_ACCESS_KEY_PROP + "=<accesskey> or by "
+                    + SAUCE_ACCESS_KEY_ENV + " environment variable.");
+        }
+
         if (tunnelId != null) {
             setSauceLabsOption(desiredCapabilities, "tunnelIdentifier",
                     tunnelId);
@@ -103,17 +127,21 @@ public class SauceLabsIntegration {
         return sauceOptions.get(key);
     }
 
-    /**
-     * @param options
-     *            the command line options used to launch Sauce Connect
-     * @param defaultValue
-     *            the default value to use for the identifier if none specified
-     *            in the options
-     * @return String representing the tunnel identifier
-     */
-    static String getTunnelIdentifier(String options, String defaultValue) {
+    static String getTunnelIdentifier() {
+        String tunnelId = getSystemPropertyOrEnv(SAUCE_TUNNELID_PROP,
+                SAUCE_TUNNELID_ENV);
+        if (tunnelId == null) {
+            // For backwards compatibility only
+            String sauceOptions = System.getProperty("sauce.options");
+            tunnelId = getTunnelIdentifierFromOptions(sauceOptions);
+        }
+
+        return tunnelId;
+    }
+
+    private static String getTunnelIdentifierFromOptions(String options) {
         if (options == null || options.isEmpty()) {
-            return defaultValue;
+            return null;
         }
         Iterator<String> tokensIterator = Arrays.asList(options.split(" "))
                 .iterator();
@@ -125,33 +153,16 @@ public class SauceLabsIntegration {
                 return tokensIterator.next();
             }
         }
-        return defaultValue;
+        return null;
     }
 
     /**
-     * Returns the HubUrl for running tests in Sauce Labs tunnel. Reads required
-     * credentials from sauce.user and sauce.sauceAccessKey or environment
-     * variables SAUCE_USERNAME and SAUCE_ACCESS_KEY. If both system property
-     * and environment variable are defined, the system property is used.
+     * Returns the HubUrl for running tests in Sauce Labs.
      *
      * @return url String to be used in Sauce Labs test run
      */
     static String getHubUrl() {
-        String username = getSauceUser();
-        String accessKey = getSauceAccessKey();
-
-        if (username == null) {
-            getLogger().debug("You can give a Sauce Labs user name using -D"
-                    + SAUCE_USERNAME_PROP + "=<username> or by "
-                    + SAUCE_USERNAME_ENV + " environment variable.");
-        }
-        if (accessKey == null) {
-            getLogger().debug("You can give a Sauce Labs access key using -D"
-                    + SAUCE_ACCESS_KEY_PROP + "=<accesskey> or by "
-                    + SAUCE_ACCESS_KEY_ENV + " environment variable.");
-        }
-        return "http://" + username + ":" + accessKey
-                + "@localhost:4445/wd/hub";
+        return "https://ondemand.saucelabs.com/wd/hub";
     }
 
     static boolean isConfiguredForSauceLabs() {

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -10,10 +10,10 @@
 package com.vaadin.testbench.parallel;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,13 +96,19 @@ public class SauceLabsIntegration {
      */
     public static void setSauceLabsOption(
             DesiredCapabilities desiredCapabilities, String key, Object value) {
-        Map<String, Object> sauceOptions = (Map<String, Object>) desiredCapabilities
-                .getCapability("sauce:options");
+        MutableCapabilities sauceOptions = getSauceLabsCapabilities(
+                desiredCapabilities);
         if (sauceOptions == null) {
-            sauceOptions = new HashMap<>();
+            sauceOptions = new MutableCapabilities();
             desiredCapabilities.setCapability("sauce:options", sauceOptions);
         }
-        sauceOptions.put(key, value);
+        sauceOptions.setCapability(key, value);
+    }
+
+    private static MutableCapabilities getSauceLabsCapabilities(
+            DesiredCapabilities desiredCapabilities) {
+        return (MutableCapabilities) desiredCapabilities
+                .getCapability("sauce:options");
     }
 
     /**
@@ -119,12 +125,12 @@ public class SauceLabsIntegration {
      */
     public static Object getSauceLabsOption(
             DesiredCapabilities desiredCapabilities, String key) {
-        Map<String, Object> sauceOptions = (Map<String, Object>) desiredCapabilities
-                .getCapability("sauce:options");
+        MutableCapabilities sauceOptions = getSauceLabsCapabilities(
+                desiredCapabilities);
         if (sauceOptions == null) {
             return null;
         }
-        return sauceOptions.get(key);
+        return sauceOptions.getCapability(key);
     }
 
     static String getTunnelIdentifier() {

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/ParallelHubTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/parallel/ParallelHubTest.java
@@ -44,24 +44,4 @@ public class ParallelHubTest extends ParallelTest {
         }
     }
 
-    @Test
-    public void sauceURLFromSystemProperty() {
-        String oldUser = System.getProperty(SAUCE_USER_PROPERTY);
-        String oldAccess = System.getProperty(SAUCE_ACCESS_KEY_PROPERTY);
-        try {
-            System.setProperty(SAUCE_USER_PROPERTY, "user1234");
-            System.setProperty(SAUCE_ACCESS_KEY_PROPERTY, "access1234");
-
-            Assert.assertEquals(
-                    "http://user1234:access1234@localhost:4445/wd/hub",
-                    getHubURL());
-        } finally {
-            if (oldUser != null) {
-                System.setProperty(SAUCE_USER_PROPERTY, oldUser);
-            }
-            if (oldAccess != null) {
-                System.setProperty(SAUCE_ACCESS_KEY_PROPERTY, oldAccess);
-            }
-        }
-    }
 }

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -21,7 +21,6 @@
 
         <!-- Frontend -->
         <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
-        <ci-sauce.version>1.151</ci-sauce.version>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmss.SSSZ</maven.build.timestamp.format>
     </properties>
     <repositories>
@@ -145,8 +144,6 @@
                 </executions>
                 <configuration>
                     <systemPropertyVariables>
-                        <sauce.user>${sauce.user}</sauce.user>
-                        <sauce.sauceAccessKey>${sauce.sauceAccessKey}</sauce.sauceAccessKey>
                         <sauce.options>${sauce.options}</sauce.options>
                     </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
@@ -182,43 +179,6 @@
                         <phase>post-integration-test</phase>
                         <goals>
                             <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.saucelabs.maven.plugin</groupId>
-                <artifactId>sauce-connect-plugin</artifactId>
-                <version>2.1.25</version>
-                <configuration>
-                    <sauceUsername>${sauce.user}</sauceUsername>
-                    <sauceAccessKey>${sauce.sauceAccessKey}</sauceAccessKey>
-                    <options>${sauce.options}</options>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.saucelabs</groupId>
-                        <artifactId>ci-sauce</artifactId>
-                        <version>${ci-sauce.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <!-- Start Sauce Connect prior to running the integration 
-                        tests -->
-                    <execution>
-                        <id>start-sauceconnect</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>start-sauceconnect</goal>
-                        </goals>
-                    </execution>
-                    <!-- Stop the Sauce Connect process after the integration 
-                        tests have finished -->
-                    <execution>
-                        <id>stop-sauceconnect</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop-sauceconnect</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Read tunnel identifier from sauce.tunnelId property or SAUCE_TUNNEL_ID env variable

Note that this changes the default URL used for Sauce Labs from http://localhost:4445/wd/hub to the recommended https://ondemand.saucelabs.com/wd/hub. If you have an existing setup relying on the old Maven plugin, you might need to override `getHubUrl` to return the old URL