### PR TITLE
fix: Only set version and platform if they are not empty/null

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/DefaultBrowserFactory.java
@@ -57,10 +57,14 @@ public class DefaultBrowserFactory implements TestBenchBrowserFactory {
         default:
             desiredCapabilities = new FirefoxOptions();
         }
-        desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION,
-                version);
-        desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME,
-                platform);
+        if (version != null && !version.isEmpty()) {
+            desiredCapabilities.setCapability(CapabilityType.BROWSER_VERSION,
+                    version);
+        }
+        if (platform != null) {
+            desiredCapabilities.setCapability(CapabilityType.PLATFORM_NAME,
+                    platform);
+        }
 
         return new DesiredCapabilities(desiredCapabilities);
     }


### PR DESCRIPTION
Both Selenium server (hub) and Selenoid wants no browserVersion capability to match any version
