### PR TITLE
feat: allow setting sauce hub url with property or env

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -33,6 +33,8 @@ public class SauceLabsIntegration {
     private static final String SAUCE_ACCESS_KEY_PROP = "sauce.sauceAccessKey";
     private static final String SAUCE_TUNNELID_PROP = "sauce.tunnelId";
     private static final String SAUCE_TUNNELID_ENV = "SAUCE_TUNNEL_ID";
+    private static final String SAUCE_HUB_URL_PROP = "sauce.hubUrl";
+    private static final String SAUCE_HUB_URL_ENV = "SAUCE_HUB_URL";
 
     /**
      * Sets needed desired capabilities for authentication and using the correct
@@ -173,7 +175,11 @@ public class SauceLabsIntegration {
      * @return url String to be used in Sauce Labs test run
      */
     static String getHubUrl() {
-        return "https://ondemand.us-west-1.saucelabs.com/wd/hub";
+        String hubUrl = getSystemPropertyOrEnv(SAUCE_HUB_URL_PROP, SAUCE_HUB_URL_ENV);
+        if (hubUrl == null) {
+            hubUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
+        }
+        return hubUrl;
     }
 
     static boolean isConfiguredForSauceLabs() {

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -27,6 +27,7 @@ public class SauceLabsIntegration {
         return LoggerFactory.getLogger(SauceLabsIntegration.class);
     }
 
+    private static final String SAUCE_DEFAULT_HUB_URL = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
     private static final String SAUCE_USERNAME_ENV = "SAUCE_USERNAME";
     private static final String SAUCE_USERNAME_PROP = "sauce.user";
     private static final String SAUCE_ACCESS_KEY_ENV = "SAUCE_ACCESS_KEY";
@@ -172,12 +173,16 @@ public class SauceLabsIntegration {
     /**
      * Returns the HubUrl for running tests in Sauce Labs.
      *
+     * The available SauceLabs URLs are listed at
+     * https://docs.saucelabs.com/basics/data-center-endpoints/#data-center-endpoints.
+     * 
      * @return url String to be used in Sauce Labs test run
      */
     static String getHubUrl() {
-        String hubUrl = getSystemPropertyOrEnv(SAUCE_HUB_URL_PROP, SAUCE_HUB_URL_ENV);
+        String hubUrl = getSystemPropertyOrEnv(SAUCE_HUB_URL_PROP,
+                SAUCE_HUB_URL_ENV);
         if (hubUrl == null) {
-            hubUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
+            hubUrl = SAUCE_DEFAULT_HUB_URL;
         }
         return hubUrl;
     }


### PR DESCRIPTION
Different users might have different saucelabs endpoints.
Now it's possible to configure it by using the `sauce.hubUrl` system property or the `SAUCE_HUB_URL` environment variable.
Possible values are available in https://docs.saucelabs.com/basics/data-center-endpoints/#data-center-endpoints

fixes: #1511
