### PR TITLE
feat: Support setting the read timeout for remote web drivers

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/Parameters.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ public class Parameters {
     private static int maxAttempts;
     private static String testbenchGridBrowsers;
     private static boolean headless;
+    private static int readTimeout;
     static {
         isDebug = getSystemPropertyBoolean("debug", false);
 
@@ -61,6 +63,8 @@ public class Parameters {
         testbenchGridBrowsers = getSystemPropertyString("gridBrowsers",
                 System.getenv("TESTBENCH_GRID_BROWSERS"));
         headless = getSystemPropertyBoolean("headless", false);
+        readTimeout = getSystemPropertyInt("readTimeout",
+                (int) ClientConfig.defaultConfig().readTimeout().toSeconds());
     }
 
     /**
@@ -476,5 +480,34 @@ public class Parameters {
      */
     public static void setHeadless(boolean headless) {
         Parameters.headless = headless;
+    }
+
+    /**
+     * Sets the time to wait for a response to a command sent to a remote web
+     * driver.
+     * <p>
+     * If you are running on a hub that limits the number of concurrent sessions
+     * and you are requesting more sessions than that, your session request
+     * might time out before the hub responds with a new session. In this case,
+     * you can increase this timeout to make it wait longer.
+     * <p>
+     * Note that this value must be set before a remote web driver is created,
+     * which typically happens during the "before" phase of a unit test.
+     *
+     * @param readTimeout
+     *            the timeout in seconds
+     */
+    public static void setReadTimeout(int readTimeout) {
+        Parameters.readTimeout = readTimeout;
+    }
+
+    /**
+     * Gets the time to wait for a response to a command sent to a remote web
+     * driver.
+     *
+     * @return the timeout in seconds
+     */
+    public static int getReadTimeout() {
+        return readTimeout;
     }
 }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
@@ -10,13 +10,16 @@
 package com.vaadin.testbench.parallel.setup;
 
 import java.net.URL;
+import java.time.Duration;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBench;
 
 public class RemoteDriver {
@@ -33,11 +36,14 @@ public class RemoteDriver {
      */
     public WebDriver createDriver(String hubURL,
             DesiredCapabilities capabilities) throws Exception {
+        ClientConfig config = ClientConfig.defaultConfig()
+                .readTimeout(Duration.ofSeconds(Parameters.getReadTimeout()));
         for (int i = 1; i <= BROWSER_INIT_ATTEMPTS; i++) {
             try {
-                WebDriver dr = TestBench.createDriver(
-                        new RemoteWebDriver(new URL(hubURL), capabilities));
-                return dr;
+                WebDriver driver = RemoteWebDriver.builder()
+                        .address(new URL(hubURL)).oneOf(capabilities)
+                        .config(config).build();
+                return TestBench.createDriver(driver);
             } catch (Exception e) {
                 getLogger().error("Browser startup for " + capabilities
                         + " failed on attempt " + i + ": " + e.getMessage());

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ParametersTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ParametersTest.java
@@ -11,6 +11,7 @@ package com.vaadin.testbench;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.remote.http.ClientConfig;
 
 public class ParametersTest {
 
@@ -30,6 +31,9 @@ public class ParametersTest {
         Assert.assertEquals(false,
                 Parameters.isScreenshotComparisonCursorDetection());
         Assert.assertFalse(Parameters.isHeadless());
+        Assert.assertEquals(
+                ClientConfig.defaultConfig().readTimeout().toSeconds(),
+                Parameters.getReadTimeout());
     }
 
     @Test


### PR DESCRIPTION
This allows you to increase the timeout e.g. when using Saucelabs so that tests wait for a session to become available instead of timing out and causing test failures
