### PR TITLE
Use a custom CommandExecutor instead of RemoteDriverBuilder

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
@@ -13,7 +13,9 @@ import java.net.URL;
 import java.time.Duration;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.slf4j.Logger;
@@ -36,13 +38,14 @@ public class RemoteDriver {
      */
     public WebDriver createDriver(String hubURL,
             DesiredCapabilities capabilities) throws Exception {
-        ClientConfig config = ClientConfig.defaultConfig()
-                .readTimeout(Duration.ofSeconds(Parameters.getReadTimeout()));
         for (int i = 1; i <= BROWSER_INIT_ATTEMPTS; i++) {
             try {
-                WebDriver driver = RemoteWebDriver.builder()
-                        .address(new URL(hubURL)).oneOf(capabilities)
-                        .config(config).build();
+                ClientConfig config = ClientConfig.defaultConfig()
+                        .readTimeout(
+                                Duration.ofSeconds(Parameters.getReadTimeout()))
+                        .baseUrl(new URL(hubURL));
+                CommandExecutor executor = new HttpCommandExecutor(config);
+                WebDriver driver = new RemoteWebDriver(executor, capabilities);
                 return TestBench.createDriver(driver);
             } catch (Exception e) {
                 getLogger().error("Browser startup for " + capabilities


### PR DESCRIPTION
RemoteDriverBuilder apparently causes problems with Selenoid for unknown reasons
