### PR TITLE
chore: Use slf4j like the rest of the platform

### DIFF
--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -181,6 +181,13 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.35</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/Parameters.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Locale;
 
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.testbench.annotations.RunLocally;
 import com.vaadin.testbench.annotations.RunOnHub;
@@ -110,12 +112,16 @@ public class Parameters {
             try {
                 return Integer.parseInt(str);
             } catch (Exception e) {
-                System.err.println("Unable to parse parameter '"
+                getLogger().error("Unable to parse parameter '"
                         + getQualifiedParameter(unqualifiedName) + "' value "
                         + str + " to an integer");
             }
         }
         return defaultValue;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(Parameters.class);
     }
 
     private static double getSystemPropertyDouble(String unqualifiedName,
@@ -126,7 +132,7 @@ public class Parameters {
             try {
                 return Double.parseDouble(str);
             } catch (Exception e) {
-                System.err.println("Unable to parse parameter '"
+                getLogger().error("Unable to parse parameter '"
                         + getQualifiedParameter(unqualifiedName) + "' value "
                         + str + " to a double");
             }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ScreenshotOnFailureRule.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/ScreenshotOnFailureRule.java
@@ -16,16 +16,18 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
+
+import com.vaadin.testbench.screenshot.ImageFileUtil;
 
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.vaadin.testbench.screenshot.ImageFileUtil;
 
 /**
  * This JUnit {@link org.junit.Rule} grabs a screenshot when a test fails.
@@ -52,11 +54,12 @@ import com.vaadin.testbench.screenshot.ImageFileUtil;
  */
 public class ScreenshotOnFailureRule extends TestWatcher {
 
-    private static final Logger logger = Logger
-            .getLogger(ScreenshotOnFailureRule.class.getName());
-
     private HasDriver driverHolder;
     private boolean quitDriverOnFinish = false;
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ScreenshotOnFailureRule.class);
+    }
 
     /**
      * Creates a new ScreenshotOnFailureRule in the provided test case.
@@ -116,7 +119,7 @@ public class ScreenshotOnFailureRule extends TestWatcher {
             final File errorScreenshotFile = getErrorScreenshotFile(description);
             ImageIO.write(screenshotImage, "png",
                     errorScreenshotFile);
-            logger.info("Error screenshot written to: " + errorScreenshotFile.getAbsolutePath());
+            getLogger().info("Error screenshot written to: " + errorScreenshotFile.getAbsolutePath());
         } catch (IOException e1) {
             throw new RuntimeException(
                     "There was a problem grabbing and writing a screen shot of a test failure.",

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
@@ -14,8 +14,8 @@ package com.vaadin.testbench;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.junit.Rule;
 import org.openqa.selenium.JavascriptExecutor;
@@ -46,8 +46,7 @@ public abstract class TestBenchTestCase
             properties.load(TestBenchTestCase.class
                     .getResourceAsStream("testbench.properties"));
         } catch (Exception e) {
-            Logger.getLogger(TestBenchTestCase.class.getName()).log(
-                    Level.WARNING, "Unable to read TestBench properties file",
+            getLogger().warn("Unable to read TestBench properties file",
                     e);
             throw new ExceptionInInitializerError(e);
         }
@@ -57,7 +56,7 @@ public abstract class TestBenchTestCase
         String expectedVersion = properties.getProperty("selenium.version");
         if (seleniumVersion == null
                 || !seleniumVersion.equals(expectedVersion)) {
-            Logger.getLogger(TestBenchTestCase.class.getName()).warning(
+            getLogger().warn(
                     "This version of TestBench depends on Selenium version "
                             + expectedVersion + " but version "
                             + seleniumVersion
@@ -79,6 +78,10 @@ public abstract class TestBenchTestCase
     public RetryRule maxAttempts = new RetryRule(Parameters.getMaxAttempts());
 
     protected WebDriver driver;
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(TestBenchTestCase.class);
+    }
 
     /**
      * Convenience method the return {@link TestBenchCommands} for the default

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/ScreenshotComparator.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
@@ -21,6 +20,8 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.screenshot.ImageComparison;
@@ -174,7 +175,7 @@ public class ScreenshotComparator {
                 ImageFileUtil.createScreenshotDirectoriesIfNeeded();
                 ImageIO.write(screenshotImage, "png",
                         ImageFileUtil.getErrorScreenshotFile(referenceName));
-                getLogger().severe("No reference found for " + referenceName
+                getLogger().error("No reference found for " + referenceName
                         + " in "
                         + ImageFileUtil.getScreenshotReferenceDirectory());
                 return false;
@@ -190,7 +191,7 @@ public class ScreenshotComparator {
     }
 
     private static Logger getLogger() {
-        return Logger.getLogger(ScreenshotComparator.class.getName());
+        return LoggerFactory.getLogger(ScreenshotComparator.class);
     }
 
     private static void pause(int delay) {

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.HasCapabilities;
@@ -29,6 +27,8 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.testbench.HasDriver;
 import com.vaadin.testbench.TestBenchDriverProxy;
@@ -42,7 +42,7 @@ import com.vaadin.testbench.screenshot.ReferenceNameGenerator;
 public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
 
     private static Logger getLogger() {
-        return Logger.getLogger(TestBenchCommandExecutor.class.getName());
+        return LoggerFactory.getLogger(TestBenchCommandExecutor.class);
     }
 
     private TestBenchDriverProxy driver;
@@ -97,7 +97,7 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
                 ia = InetAddress.getLocalHost();
             }
         } catch (UnknownHostException e) {
-            getLogger().log(Level.WARNING,
+            getLogger().warn(
                     "Could not find name of remote control", e);
             return "unknown";
         }
@@ -128,7 +128,7 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
             if (finished == null) {
                 // This should never happen but according to
                 // https://dev.vaadin.com/ticket/19703, it happens
-                getLogger().fine(
+                getLogger().debug(
                         "waitForVaadin returned null, this should never happen");
                 finished = false;
             }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelRunner.java
@@ -22,8 +22,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import com.vaadin.testbench.Parameters;
+import com.vaadin.testbench.annotations.BrowserConfiguration;
+import com.vaadin.testbench.annotations.BrowserFactory;
+import com.vaadin.testbench.annotations.RunLocally;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,11 +37,8 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
-
-import com.vaadin.testbench.Parameters;
-import com.vaadin.testbench.annotations.BrowserConfiguration;
-import com.vaadin.testbench.annotations.BrowserFactory;
-import com.vaadin.testbench.annotations.RunLocally;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This runner is loosely based on FactoryTestRunner by Ted Young
@@ -48,8 +48,9 @@ import com.vaadin.testbench.annotations.RunLocally;
  */
 public class ParallelRunner extends BlockJUnit4ClassRunner {
 
-    private static Logger logger = Logger
-            .getLogger(ParallelRunner.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ParallelRunner.class);
+    }
 
     /**
      * This is the total limit of actual JUnit test instances run in parallel
@@ -327,7 +328,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
                                 "Error occurred while invoking BrowserConfiguration method %s.%s(). Method was ignored, searching BrowserConfiguration method in superclasses",
                                 method.getDeclaringClass().getName(),
                                 method.getName());
-                        logger.log(Level.INFO, errMsg, e);
+                        getLogger().info(errMsg, e);
 
                         /*
                          * ignore this method and searches for another
@@ -349,7 +350,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
      * Validates the signature of a BrowserConfiguration annotated method.
      *
      * @param method
-     *            BrowserConfiguration annotated method
+     *               BrowserConfiguration annotated method
      * @return true if method signature is valid. false otherwise.
      */
     private boolean validateBrowserConfigurationAnnotatedSignature(
@@ -361,7 +362,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
             String errMsg = String.format(genericErrorMessage,
                     method.getDeclaringClass().getName(), method.getName(),
                     "BrowserConfiguration annotated method must not require any arguments");
-            logger.info(errMsg);
+            getLogger().info(errMsg);
             return false;
         }
         if (!Collection.class.isAssignableFrom(method.getReturnType())) {
@@ -373,7 +374,7 @@ public class ParallelRunner extends BlockJUnit4ClassRunner {
             String errMsg = String.format(genericErrorMessage,
                     method.getDeclaringClass().getName(), method.getName(),
                     "BrowserConfiguration annotated method must return a Collection<DesiredCapabilities>");
-            logger.info(errMsg);
+            getLogger().info(errMsg);
             return false;
         }
         return true;

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/ParallelTest.java
@@ -12,18 +12,8 @@
  */
 package com.vaadin.testbench.parallel;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
@@ -32,6 +22,14 @@ import com.vaadin.testbench.annotations.BrowserConfiguration;
 import com.vaadin.testbench.annotations.RunLocally;
 import com.vaadin.testbench.annotations.RunOnHub;
 import com.vaadin.testbench.parallel.setup.SetupDriver;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Unit tests should extend {@link ParallelTest} if they are to be run in
@@ -51,8 +49,9 @@ public class ParallelTest extends TestBenchTestCase {
     public ScreenshotOnFailureRule screenshotOnFailure = new ScreenshotOnFailureRule(
             this, true);
 
-    private static final Logger logger = Logger
-            .getLogger(ParallelTest.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ParallelTest.class);
+    }
 
     private SetupDriver driverConfiguration = new SetupDriver();
 
@@ -129,7 +128,7 @@ public class ParallelTest extends TestBenchTestCase {
      * </p>
      *
      * @throws Exception
-     *             if unable to instantiate {@link WebDriver}
+     *                   if unable to instantiate {@link WebDriver}
      */
     @Before
     public void setup() throws Exception {
@@ -152,7 +151,7 @@ public class ParallelTest extends TestBenchTestCase {
                     .setupRemoteDriver(getHubURL());
             setDriver(driver);
         } else {
-            logger.log(Level.INFO,
+            getLogger().info(
                     "Did not find a configuration to run locally, on Sauce Labs or on other test grid. Falling back to running locally on Chrome.");
             WebDriver driver = driverConfiguration
                     .setupLocalDriver(Browser.CHROME);

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -15,16 +15,17 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.openqa.selenium.remote.DesiredCapabilities;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Integration methods for Sauce Labs testing used by {@link ParallelTest}
  *
  */
 public class SauceLabsIntegration {
-    private static final Logger logger = Logger
-            .getLogger(SauceLabsIntegration.class.getName());
-
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(SauceLabsIntegration.class);
+    }
 
     private static final String SAUCE_DEFAULT_HUB_URL = "https://ondemand.us-west-1.saucelabs.com/wd/hub";
     private static final String SAUCE_USERNAME_ENV = "SAUCE_USERNAME";
@@ -58,14 +59,14 @@ public class SauceLabsIntegration {
         if (username != null) {
             setSauceLabsOption(desiredCapabilities, "username", username);
         } else {
-            logger.log(Level.FINE, "You can give a Sauce Labs user name using -D"
+            getLogger().debug("You can give a Sauce Labs user name using -D"
                     + SAUCE_USERNAME_PROP + "=<username> or by "
                     + SAUCE_USERNAME_ENV + " environment variable.");
         }
         if (accessKey != null) {
             setSauceLabsOption(desiredCapabilities, "access_key", accessKey);
         } else {
-            logger.log(Level.FINE, "You can give a Sauce Labs access key using -D"
+            getLogger().debug("You can give a Sauce Labs access key using -D"
                     + SAUCE_ACCESS_KEY_PROP + "=<accesskey> or by "
                     + SAUCE_ACCESS_KEY_ENV + " environment variable.");
         }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/RemoteDriver.java
@@ -17,6 +17,8 @@ import java.net.URL;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.testbench.TestBench;
 
@@ -40,7 +42,7 @@ public class RemoteDriver {
                         new RemoteWebDriver(new URL(hubURL), capabilities));
                 return dr;
             } catch (Exception e) {
-                System.err.println("Browser startup for " + capabilities
+                getLogger().error("Browser startup for " + capabilities
                         + " failed on attempt " + i + ": " + e.getMessage());
                 if (i == BROWSER_INIT_ATTEMPTS) {
                     throw e;
@@ -50,5 +52,10 @@ public class RemoteDriver {
 
         // should never happen
         return null;
+    }
+
+    private Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
+
     }
 }

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ImageComparison.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ImageComparison.java
@@ -21,14 +21,15 @@ import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
 
-import org.openqa.selenium.Capabilities;
-
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.screenshot.ImageUtil.ImageProperties;
+
+import org.openqa.selenium.Capabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class with features for comparing 2 images.
@@ -48,8 +49,9 @@ public class ImageComparison {
     // class.
     //
 
-    private static Logger logger = Logger
-            .getLogger(ImageComparison.class.getName());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ImageComparison.class);
+    }
 
     /**
      * Data collection type, used as input for image comparison functions. Saves
@@ -83,14 +85,15 @@ public class ImageComparison {
      * hues 0.1% (default) per macroblock of 16x16
      *
      * @param screenshotImage
-     *            Image of canvas (must have proper dimensions)
+     *                        Image of canvas (must have proper dimensions)
      * @param referenceFileId
-     *            File id for this image without .png extension
+     *                        File id for this image without .png extension
      * @param errorTolerance
-     *            Allowed RGB error for a macroblock (value range 0-1 default
-     *            0.025 == 2.5%)
+     *                        Allowed RGB error for a macroblock (value range 0-1
+     *                        default
+     *                        0.025 == 2.5%)
      * @param capabilities
-     *            browser capabilities
+     *                        browser capabilities
      * @return true if images are the same
      * @throws IOException
      */
@@ -108,7 +111,7 @@ public class ImageComparison {
             // Save the screenshot in the error directory.
             ImageIO.write(screenshotImage, "png", ImageFileUtil
                     .getErrorScreenshotFile(referenceFileId + ".png"));
-            logger.severe("No reference found for " + referenceFileId + " in "
+            getLogger().error("No reference found for " + referenceFileId + " in "
                     + ImageFileUtil.getScreenshotReferenceDirectory());
             return false;
         }
@@ -161,7 +164,7 @@ public class ImageComparison {
     /**
      *
      * @param params
-     *            a ComparisonParameters object. See {@link createParameters}.
+     *               a ComparisonParameters object. See {@link createParameters}.
      * @return
      */
     private ScreenShotFailureReporter compareImages(
@@ -326,7 +329,7 @@ public class ImageComparison {
      * the screenshot.
      *
      * @param params
-     *            a ComparisonParameters object. See {@link createParameters}.
+     *               a ComparisonParameters object. See {@link createParameters}.
      *
      * @return A Point referring to the x and y coordinates in the image where
      *         the cursor might be (actually might be inside a 16x32 block
@@ -388,10 +391,13 @@ public class ImageComparison {
      * Check if failure is because of a blinking text cursor.
      *
      * @param possibleCursorPosition
-     *            The position in the image where a cursor possibly can be found
-     *            (pixel coordinates of the top left corner of a block)
+     *                               The position in the image where a cursor
+     *                               possibly can be found
+     *                               (pixel coordinates of the top left corner of a
+     *                               block)
      * @param params
-     *            a ComparisonParameters object. See {@link createParameters}.
+     *                               a ComparisonParameters object. See
+     *                               {@link createParameters}.
      * @return true If cursor (vertical line of at least 5 pixels if not at the
      *         top or bottom) is the only difference between the images.
      */
@@ -562,11 +568,11 @@ public class ImageComparison {
      * maintainable).
      *
      * @param reference
-     *            a BufferedImage
+     *                   a BufferedImage
      * @param screenshot
-     *            a BufferedImage
+     *                   a BufferedImage
      * @param tolerance
-     *            error tolerance value
+     *                   error tolerance value
      * @return a ComparisonParameters descriptor object
      */
     private static final ComparisonParameters createParameters(

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ImageComparison.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ImageComparison.java
@@ -176,10 +176,10 @@ public class ImageComparison {
             if (Parameters.isDebug()) {
                 if (imagesEqual) {
                     // The images are equal but of different size
-                    System.out.println("Images are of different size.");
+                    getLogger().debug("Images are of different size.");
                 } else {
                     // Neither size nor contents match
-                    System.out.println(
+                    getLogger().debug(
                             "Images differ and are of different size.");
                 }
             }
@@ -191,7 +191,7 @@ public class ImageComparison {
 
         if (imagesEqual) {
             if (Parameters.isDebug()) {
-                System.out.println("Screenshot matched reference");
+                getLogger().debug("Screenshot matched reference");
             }
 
             // Images match. Nothing else to do.
@@ -205,20 +205,20 @@ public class ImageComparison {
             if (possibleCursorPosition != null) {
                 if (isCursorTheOnlyError(possibleCursorPosition, param)) {
                     if (Parameters.isDebug()) {
-                        System.out.println(
+                        getLogger().debug(
                                 "Screenshot matched reference after removing cursor");
                     }
                     // Cursor is the only difference so we are done.
                     return null;
                 } else if (Parameters.isDebug()) {
-                    System.out.println(
+                    getLogger().debug(
                             "Screenshot did not match reference after removing cursor");
                 }
             }
         }
 
         if (Parameters.isDebug()) {
-            System.out.println("Screenshot did not match reference");
+            getLogger().debug("Screenshot did not match reference");
         }
 
         // Make a failure reporter that is used upstream
@@ -420,7 +420,7 @@ public class ImageComparison {
         }
 
         if (Parameters.isDebug()) {
-            System.out.println("Looking for cursor starting from " + x + "," + y
+            getLogger().debug("Looking for cursor starting from " + x + "," + y
                     + " using width=" + width + " and height=" + height);
         }
         // getBlock writes the result into the int[] sample parameter, in
@@ -457,7 +457,7 @@ public class ImageComparison {
                     cursorX = i;
                     cursorStartY = j;
                     if (Parameters.isDebug()) {
-                        System.out.println("Cursor found at " + cursorX + ","
+                        getLogger().debug("Cursor found at " + cursorX + ","
                                 + cursorStartY);
                     }
                     break findCursor;
@@ -467,7 +467,7 @@ public class ImageComparison {
 
         if (-1 == cursorX) {
             if (Parameters.isDebug()) {
-                System.out.println("Cursor not found");
+                getLogger().debug("Cursor not found");
             }
             // No difference found with cursor detection threshold
             return false;
@@ -502,14 +502,14 @@ public class ImageComparison {
         if (cursorEndY - cursorStartY < 5 && cursorStartY > 0
                 && cursorEndY < height - 1) {
             if (Parameters.isDebug()) {
-                System.out.println("Cursor rejected at " + cursorX + ","
+                getLogger().debug("Cursor rejected at " + cursorX + ","
                         + cursorStartY + "-" + cursorEndY);
             }
             return false;
         }
 
         if (Parameters.isDebug()) {
-            System.out.println("Cursor is at " + cursorX + "," + cursorStartY
+            getLogger().debug("Cursor is at " + cursorX + "," + cursorStartY
                     + "-" + cursorEndY);
         }
         // Copy pixels from reference over the possible cursor, then

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ScreenShotFailureReporter.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/screenshot/ScreenShotFailureReporter.java
@@ -23,6 +23,9 @@ import java.util.List;
 
 import javax.imageio.ImageIO;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ScreenShotFailureReporter {
     private final BufferedImage referenceImage;
     private final boolean[][] falseBlocks;
@@ -44,9 +47,9 @@ public class ScreenShotFailureReporter {
             ImageIO.write(screenshotImage, "png",
                     ImageFileUtil.getErrorScreenshotFile(fileName));
         } catch (IOException e) {
-            System.err.println("Error writing screenshot to "
-                    + ImageFileUtil.getErrorScreenshotFile(fileName).getPath());
-            e.printStackTrace();
+            getLogger().error("Error writing screenshot to "
+                    + ImageFileUtil.getErrorScreenshotFile(fileName).getPath(),
+                    e);
         }
 
         // collect big error blocks of differences
@@ -56,6 +59,10 @@ public class ScreenShotFailureReporter {
         drawErrorsToImage(errorAreas, screenshotImage);
 
         createDiffHtml(errorAreas, fileName, screenshotImage, referenceImage);
+    }
+
+    private Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
     }
 
     /**


### PR DESCRIPTION
Cherry picks the following log related changes:

* a261ab85 - chore: Log using logger instead of system.out
* b28709d2 - fix: Log using logger instead of system.err (#1505)
* 26301926 - chore: Use slf4j like the rest of the platform (#1313)
