### PR TITLE
test: remove sauce.options definition from pom

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -18,10 +18,6 @@
     <properties>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <flow.version>9.0-SNAPSHOT</flow.version>
-
-        <!-- Frontend -->
-        <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
-        <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmss.SSSZ</maven.build.timestamp.format>
     </properties>
     <repositories>
         <repository>
@@ -143,9 +139,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <systemPropertyVariables>
-                        <sauce.options>${sauce.options}</sauce.options>
-                    </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/TB6TestBrowserFactory.java
@@ -31,7 +31,7 @@ public class TB6TestBrowserFactory extends DefaultBrowserFactory {
     public DesiredCapabilities create(Browser browser, String version,
             Platform platform) {
         if (browser != Browser.SAFARI) {
-                platform = Platform.WIN10;
+            platform = Platform.WIN10;
         }
         DesiredCapabilities desiredCapabilities = super.create(browser, version,
                 platform);


### PR DESCRIPTION
currently SC start and stop is done outside of maven lifecycle and tunnel ID is defined as env variable or system property
