### PR TITLE
test: remove sauce.options definition from pom (#1544)

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -23,8 +23,6 @@
         <node.version>v8.1.2</node.version>
         <yarn.version>v0.27.5</yarn.version>
         <buildtools.directory>build-tools</buildtools.directory>
-        <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
-        <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmss.SSSZ</maven.build.timestamp.format>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
     <repositories>
@@ -138,9 +136,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <systemPropertyVariables>
-                        <sauce.options>${sauce.options}</sauce.options>
-                    </systemPropertyVariables>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>


### PR DESCRIPTION
currently SC start and stop is done outside of maven lifecycle and tunnel ID is defined as env variable or system property
