### PR TITLE
chore: update maven.compiler.source/.target to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <Implementation-Version>${project.version}</Implementation-Version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>4.5.0</selenium.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <license.checker.version>1.9.0</license.checker.version>
     </properties>
     <modules>


### PR DESCRIPTION
Update OpenJDK to 17 due to upcoming Jakarta EE 9 update