### PR TITLE
Java 16 cherry-picks (#1287) (#1288)

### DIFF
--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -213,11 +213,11 @@
             <artifactId>gwt-elemental</artifactId>
             <version>2.8.2.vaadin2</version>
         </dependency>
-        <!-- Override transitive dependency with Java 11 compatible version -->
+        <!-- Override transitive dependency with Java 16 compatible version -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.9.13</version>
+            <version>1.10.21</version>
         </dependency>
         <!-- Override outdated transitive dependency of selenium-remote-driver -->
         <dependency>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.18.1-GA</version>
+            <version>3.27.0-GA</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
fix: support jdk 16 and align bytebuddy version with flow (#1287)
fix: Update to latest Javassist for Java 16 compat (#1288)