### PR TITLE
feat!: Extend BrowserTestBase with common methods from flow-tests

### DIFF
--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -181,6 +181,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
@@ -9,18 +9,34 @@
  */
 package com.vaadin.testbench;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsElement;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.testbench.commands.TestBenchCommandExecutor;
 import com.vaadin.testbench.commands.TestBenchCommands;
@@ -31,6 +47,13 @@ import com.vaadin.testbench.commands.TestBenchCommands;
  */
 public abstract class AbstractBrowserTestBase
         implements HasDriver, HasTestBenchCommandExecutor, HasElementQuery {
+
+    /**
+     * When an error occurs during establishing a WebSocket connection, a severe
+     * error is added to the console by the browser. We can't prevent it, so we
+     * have to ignore it for now until we figure out a way to supress it.
+     */
+    private static final String WEB_SOCKET_CONNECTION_ERROR_PREFIX = "WebSocket connection to ";
 
     /**
      * Returns the {@link WebDriver} instance or (if the previously provided
@@ -187,6 +210,327 @@ public abstract class AbstractBrowserTestBase
             return baseUrl + uri.substring(1);
         }
         return baseUrl + uri;
+    }
+
+    /**
+     * Waits up to 10s for the given condition to become false. Use e.g. as
+     * {@link #waitUntilNot(ExpectedCondition)}.
+     *
+     * @param condition
+     *            the condition to wait for to become false
+     * @param <T>
+     *            the return type of the expected condition
+     */
+    protected <T> void waitUntilNot(ExpectedCondition<T> condition) {
+        waitUntilNot(condition, 10);
+    }
+
+    /**
+     * Returns true if an element can be found from the driver with given
+     * selector.
+     *
+     * @param by
+     *            the selector used to find element
+     * @return true if the element can be found
+     */
+    public boolean isElementPresent(By by) {
+        try {
+            WebElement element = getDriver().findElement(by);
+            return element != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Simulate DnD of {@code source} element into the {@code target} element.
+     *
+     * @param source
+     * @param target
+     */
+    public void dragAndDrop(WebElement source, WebElement target) {
+        getCommandExecutor().executeScript(LazyDndSimulationLoad.DND_SCRIPT,
+                source, target, "DND");
+    }
+
+    /**
+     * Simulate only a drag of {@code source}.
+     *
+     * @param source
+     */
+    public void drag(WebElement source) {
+        getCommandExecutor().executeScript(LazyDndSimulationLoad.DND_SCRIPT,
+                source, null, "DRAG");
+    }
+
+    /**
+     * Simulate a drag of {@code source} element and over the {@code target}
+     * element.
+     *
+     * @param source
+     * @param target
+     */
+    public void dragElementOver(WebElement source, WebElement target) {
+        getCommandExecutor().executeScript(LazyDndSimulationLoad.DND_SCRIPT,
+                source, target, "DRAG_OVER");
+    }
+
+    /**
+     * Waits the given number of seconds for the given condition to become
+     * false. Use e.g. as {@link #waitUntilNot(ExpectedCondition)}.
+     *
+     * @param condition
+     *            the condition to wait for to become false
+     * @param timeoutInSeconds
+     *            the number of seconds to wait
+     * @param <T>
+     *            the return type of the expected condition
+     */
+    protected <T> void waitUntilNot(ExpectedCondition<T> condition,
+            long timeoutInSeconds) {
+        waitUntil(ExpectedConditions.not(condition), timeoutInSeconds);
+    }
+
+    protected void waitForElementPresent(final By by) {
+        waitUntil(ExpectedConditions.presenceOfElementLocated(by));
+    }
+
+    protected void waitForElementNotPresent(final By by) {
+        waitUntil(input -> input.findElements(by).isEmpty());
+    }
+
+    protected void waitForElementVisible(final By by) {
+        waitUntil(ExpectedConditions.visibilityOfElementLocated(by));
+    }
+
+    /**
+     * Checks if the given element has the given class name.
+     *
+     * Matches only full class names, i.e. has ("foo") does not match
+     * class="foobar"
+     *
+     * @param element
+     *            the element to test
+     * @param className
+     *            the class names to match
+     * @return <code>true</code> if matches, <code>false</code> if not
+     */
+    protected boolean hasCssClass(WebElement element, String className) {
+        String classes = element.getAttribute("class");
+        if (classes == null || classes.isEmpty()) {
+            return className == null || className.isEmpty();
+        }
+        return Stream.of(classes.split(" ")).anyMatch(className::equals);
+    }
+
+    /**
+     * Assert that the two elements are equal.
+     * <p>
+     * Can be removed if https://dev.vaadin.com/ticket/18484 is fixed.
+     *
+     * @param expectedElement
+     *            the expected element
+     * @param actualElement
+     *            the actual element
+     */
+    protected static void assertEquals(WebElement expectedElement,
+            WebElement actualElement) {
+        WebElement unwrappedExpected = expectedElement;
+        WebElement unwrappedActual = actualElement;
+        while (unwrappedExpected instanceof WrapsElement) {
+            unwrappedExpected = ((WrapsElement) unwrappedExpected)
+                    .getWrappedElement();
+        }
+        while (unwrappedActual instanceof WrapsElement) {
+            unwrappedActual = ((WrapsElement) unwrappedActual)
+                    .getWrappedElement();
+        }
+        Assertions.assertEquals(unwrappedExpected, unwrappedActual);
+    }
+
+    /**
+     * Scrolls the page by given amount of x and y deltas. Actual scroll values
+     * can be different if any delta is bigger then the corresponding document
+     * dimension.
+     *
+     * @param deltaX
+     *            the offset in pixels to scroll horizontally
+     * @param deltaY
+     *            the offset in pixels to scroll vertically
+     */
+    protected void scrollBy(int deltaX, int deltaY) {
+        executeScript("window.scrollBy(" + deltaX + ',' + deltaY + ");");
+    }
+
+    /**
+     * Scrolls the page to the element given using javascript.
+     *
+     * Standard Selenium api does not work for current newest Chrome and
+     * ChromeDriver.
+     *
+     * @param element
+     *            the element to scroll to, not {@code null}
+     */
+    protected void scrollToElement(WebElement element) {
+        Objects.requireNonNull(element,
+                "The element to scroll to should not be null");
+        getCommandExecutor().executeScript("arguments[0].scrollIntoView(true);",
+                element);
+    }
+
+    /**
+     * Scrolls the page to the element specified and clicks it.
+     *
+     * @param element
+     *            the element to scroll to and click
+     */
+    protected void scrollIntoViewAndClick(WebElement element) {
+        scrollToElement(element);
+        element.click();
+    }
+
+    /**
+     * Gets current scroll position on x axis.
+     *
+     * @return current scroll position on x axis.
+     */
+    protected int getScrollX() {
+        return ((Number) executeScript("return window.pageXOffset")).intValue();
+    }
+
+    /**
+     * Gets current scroll position on y axis.
+     *
+     * @return current scroll position on y axis.
+     */
+    protected int getScrollY() {
+        return ((Number) executeScript("return window.pageYOffset")).intValue();
+    }
+
+    /**
+     * Clicks on the element, using JS. This method is more convenient then
+     * Selenium {@code findElement(By.id(urlId)).click()}, because Selenium
+     * method changes scroll position, which is not always needed.
+     *
+     * @param elementId
+     *            id of the
+     */
+    protected void clickElementWithJs(String elementId) {
+        executeScript(String.format("document.getElementById('%s').click();",
+                elementId));
+    }
+
+    /**
+     * Clicks on the element, using JS. This method is more convenient then
+     * Selenium {@code element.click()}, because Selenium method changes scroll
+     * position, which is not always needed.
+     *
+     * @param element
+     *            the element to be clicked on
+     */
+    protected void clickElementWithJs(WebElement element) {
+        executeScript("arguments[0].click();", element);
+    }
+
+    /**
+     * Gets the log entries from the browser that have the given logging level
+     * or higher.
+     *
+     * @param level
+     *            the minimum severity of logs included
+     * @return log entries from the browser
+     */
+    protected List<LogEntry> getLogEntries(Level level) {
+        // https://github.com/vaadin/testbench/issues/1233
+        getCommandExecutor().waitForVaadin();
+
+        return getDriver().manage().logs().get(LogType.BROWSER).getAll()
+                .stream()
+                .filter(logEntry -> logEntry.getLevel().intValue() >= level
+                        .intValue())
+                // we always have this error
+                .filter(logEntry -> !logEntry.getMessage()
+                        .contains("favicon.ico"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks browser's log entries, throws an error for any client-side error
+     * and logs any client-side warnings.
+     *
+     * @param acceptableMessagePredicate
+     *            allows to ignore log entries whose message is accaptable
+     *
+     * @throws AssertionError
+     *             if an error is found in the browser logs
+     */
+    protected void checkLogsForErrors(
+            Predicate<String> acceptableMessagePredicate) {
+        getLogEntries(Level.WARNING).forEach(logEntry -> {
+            if ((Objects.equals(logEntry.getLevel(), Level.SEVERE)
+                    || logEntry.getMessage().contains(" 404 "))
+                    && !logEntry.getMessage()
+                            .contains(WEB_SOCKET_CONNECTION_ERROR_PREFIX)
+                    && !acceptableMessagePredicate
+                            .test(logEntry.getMessage())) {
+                throw new AssertionError(String.format(
+                        "Received error message in browser log console right after opening the page, message: %s",
+                        logEntry));
+            } else {
+                LoggerFactory.getLogger(AbstractBrowserTestBase.class.getName())
+                        .warn("This message in browser log console may be a potential error: '{}'",
+                                logEntry);
+            }
+        });
+    }
+
+    /**
+     * Checks browser's log entries, throws an error for any client-side error
+     * and logs any client-side warnings.
+     *
+     * @throws AssertionError
+     *             if an error is found in the browser logs
+     */
+    protected void checkLogsForErrors() {
+        checkLogsForErrors(msg -> false);
+    }
+
+    /**
+     * If dev server start in progress wait until it's started. Otherwise return
+     * immidiately.
+     */
+    protected void waitForDevServer() {
+        Object result;
+        do {
+            getCommandExecutor().waitForVaadin();
+            result = getCommandExecutor().executeScript(
+                    "return window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded;");
+        } while (Boolean.TRUE.equals(result));
+    }
+
+    /**
+     * Calls the {@code blur()} function on the current active element of the
+     * page, if any.
+     */
+    public void blur() {
+        executeScript(
+                "!!document.activeElement ? document.activeElement.blur() : 0");
+    }
+
+    private static class LazyDndSimulationLoad {
+        private static final String DND_SCRIPT = loadDndScript(
+                "/dnd-simulation.js");
+
+        private static String loadDndScript(String scriptLocation) {
+            InputStream stream = AbstractBrowserTestBase.class
+                    .getResourceAsStream(scriptLocation);
+            try {
+                return IOUtils.readLines(stream, StandardCharsets.UTF_8)
+                        .stream().collect(Collectors.joining("\n"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
 }

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestBase.java
@@ -12,31 +12,42 @@ package com.vaadin.testbench;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.WebDriver;
+
+import com.vaadin.testbench.browser.BrowserTestInfo;
+import com.vaadin.testbench.parallel.Browser;
 
 /**
  * A superclass with helper methods to aid TestBench developers create a JUnit 5
  * based tests.
  */
-public abstract class BrowserTestBase extends AbstractBrowserDriverTestBase
-        implements HasCapabilities {
+public abstract class BrowserTestBase extends AbstractBrowserDriverTestBase {
 
     @RegisterExtension
     public ScreenshotOnFailureExtension screenshotOnFailureExtension = new ScreenshotOnFailureExtension(
             this, true);
 
-    private Capabilities capabilities;
+    private BrowserTestInfo browserTestInfo;
 
     @BeforeEach
-    public void setWebDriverAndCapabilities(WebDriver driver,
-            Capabilities capabilities) {
-        setDriver(driver);
-        this.capabilities = capabilities;
+    public void setBrowserTestInfo(BrowserTestInfo browserTestInfo) {
+        setDriver(browserTestInfo.driver());
+        this.browserTestInfo = browserTestInfo;
     }
 
-    @Override
-    public Capabilities getCapabilities() {
-        return capabilities;
+    protected Capabilities getCapabilities() {
+        return browserTestInfo.capabilities();
     }
+
+    protected String getHubHostname() {
+        return browserTestInfo.hubHostname();
+    }
+
+    protected Browser getRunLocallyBrowser() {
+        return browserTestInfo.runLocallyBrowser();
+    }
+
+    protected String getRunLocallyBrowserVersion() {
+        return browserTestInfo.runLocallyBrowserVersion();
+    }
+
 }

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestClass.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestClass.java
@@ -20,8 +20,7 @@ import com.vaadin.testbench.browser.MultipleBrowsersExtension;
 
 /**
  * Shorthand annotation for enabling
- * {@code @ExtendWith(MultipleBrowsersExtension.class)} on test
- * class.
+ * {@code @ExtendWith(MultipleBrowsersExtension.class)} on test class.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -269,19 +269,18 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
     public boolean supportsParameter(ParameterContext parameterContext,
             ExtensionContext extensionContext)
             throws ParameterResolutionException {
-        Class parameterType = parameterContext.getParameter().getType();
-        return parameterType == WebDriver.class
-                || parameterType == Capabilities.class;
+        return parameterContext.getParameter()
+                .getType() == BrowserTestInfo.class;
     }
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext,
             ExtensionContext extensionContext)
             throws ParameterResolutionException {
-        if (parameterContext.getParameter().getType() == WebDriver.class) {
-            return driver;
-        } else {
-            return new ImmutableCapabilities(desiredCapabilities);
-        }
+        Class testClass = extensionContext.getRequiredTestClass();
+        return new BrowserTestInfo(driver,
+                new ImmutableCapabilities(desiredCapabilities),
+                getHubHostname(testClass), getRunLocallyBrowser(testClass),
+                getRunLocallyBrowserVersion(testClass));
     }
 }

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -153,7 +153,7 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
         }
 
         RunOnHub runOnHub = getRunOnHub(testClass);
-        return runOnHub.value();
+        return runOnHub == null ? null : runOnHub.value();
     }
 
     /**

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
 package com.vaadin.testbench.browser;
 
 import org.openqa.selenium.Capabilities;

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
@@ -1,0 +1,21 @@
+package com.vaadin.testbench.browser;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+
+import com.vaadin.testbench.parallel.Browser;
+
+/**
+ * Record that is automatically resolved by {@link BrowserExtension} providing
+ * most important information on currently run test.
+ * @param driver reference to {@link WebDriver}
+ * @param capabilities immutable list of capabilities
+ * @param hubHostname hostname of the hub
+ * @param runLocallyBrowser {@link Browser} used for local execution
+ * @param runLocallyBrowserVersion version of {@link Browser} used for local execution
+ */
+public record BrowserTestInfo(WebDriver driver, Capabilities capabilities,
+                              String hubHostname, Browser runLocallyBrowser,
+                              String runLocallyBrowserVersion) {
+
+}

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserTestClassTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserTestClassTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestTemplate;
 import org.mockito.Mockito;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -33,18 +32,18 @@ public class BrowserTestClassTest implements DriverSupplier {
 
     @TestTemplate // run by extension, standard JUnit annotation
     public void testTemplate_hasCapabilitiesInjected(TestInfo testInfo,
-            Capabilities capabilities) {
+            BrowserTestInfo browserTestInfo) {
         Assertions.assertTrue(
                 testInfo.getDisplayName().contains("[ANY_Chrome_]"));
-        assertCapabilities(testInfo, capabilities);
+        assertCapabilities(testInfo, browserTestInfo);
     }
 
     @BrowserTest // run by extension, using wrapper additionally
     public void browserTest_hasCapabilitiesInjected(TestInfo testInfo,
-            Capabilities capabilities) {
+            BrowserTestInfo browserTestInfo) {
         Assertions.assertTrue(
                 testInfo.getDisplayName().contains("[ANY_Chrome_]"));
-        assertCapabilities(testInfo, capabilities);
+        assertCapabilities(testInfo, browserTestInfo);
     }
 
     @Test // not run by extension
@@ -54,9 +53,9 @@ public class BrowserTestClassTest implements DriverSupplier {
     }
 
     private void assertCapabilities(TestInfo testInfo,
-            Capabilities capabilities) {
+            BrowserTestInfo browserTestInfo) {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(
-                capabilities);
+                browserTestInfo.capabilities());
         Assertions.assertEquals("bar", SauceLabsIntegration
                 .getSauceLabsOption(desiredCapabilities, "foo"));
         Assertions.assertEquals(testInfo.getDisplayName(),

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithBrowserConfigurationInParametersTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithBrowserConfigurationInParametersTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -46,24 +45,24 @@ public class ExtensionWithBrowserConfigurationInParametersTest
 
     @BrowserTest
     public void withBrowsersConfigurationInParameters(TestInfo testInfo,
-            Capabilities capabilities) {
+            BrowserTestInfo browserTestInfo) {
         DesiredCapabilities caps1 = Browser.FIREFOX.getDesiredCapabilities();
         DesiredCapabilities caps2 = Browser.SAFARI.getDesiredCapabilities();
         caps2.setVersion("9");
         if (testInfo.getDisplayName().contains("Firefox")) {
             Assertions.assertEquals(caps1.getBrowserName(),
-                    capabilities.getBrowserName());
+                    browserTestInfo.capabilities().getBrowserName());
             Assertions.assertEquals(caps1.getBrowserVersion(),
-                    capabilities.getBrowserVersion());
+                    browserTestInfo.capabilities().getBrowserVersion());
             Assertions.assertEquals(caps1.getPlatformName(),
-                    capabilities.getPlatformName());
+                    browserTestInfo.capabilities().getPlatformName());
         } else {
             Assertions.assertEquals(caps2.getBrowserName(),
-                    capabilities.getBrowserName());
+                    browserTestInfo.capabilities().getBrowserName());
             Assertions.assertEquals(caps2.getBrowserVersion(),
-                    capabilities.getBrowserVersion());
+                    browserTestInfo.capabilities().getBrowserVersion());
             Assertions.assertEquals(caps2.getPlatformName(),
-                    capabilities.getPlatformName());
+                    browserTestInfo.capabilities().getPlatformName());
         }
     }
 

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithBrowserConfigurationTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithBrowserConfigurationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -47,14 +46,15 @@ public class ExtensionWithBrowserConfigurationTest implements DriverSupplier {
     }
 
     @BrowserTest
-    public void withBrowserConfigurationInClass(Capabilities capabilities) {
+    public void withBrowserConfigurationInClass(
+            BrowserTestInfo browserTestInfo) {
         DesiredCapabilities caps = Browser.FIREFOX.getDesiredCapabilities();
         Assertions.assertEquals(caps.getBrowserName(),
-                capabilities.getBrowserName());
+                browserTestInfo.capabilities().getBrowserName());
         Assertions.assertEquals(caps.getBrowserVersion(),
-                capabilities.getBrowserVersion());
+                browserTestInfo.capabilities().getBrowserVersion());
         Assertions.assertEquals(caps.getPlatformName(),
-                capabilities.getPlatformName());
+                browserTestInfo.capabilities().getPlatformName());
     }
 
     @BrowserConfiguration

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithoutBrowserConfigurationTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/ExtensionWithoutBrowserConfigurationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -43,15 +42,15 @@ public class ExtensionWithoutBrowserConfigurationTest
     }
 
     @BrowserTest
-    public void withoutBrowsersConfiguration(Capabilities capabilities) {
+    public void withoutBrowsersConfiguration(BrowserTestInfo browserTestInfo) {
         DesiredCapabilities caps = CapabilitiesUtil.getDefaultCapabilities()
                 .get(0);
         Assertions.assertEquals(caps.getBrowserName(),
-                capabilities.getBrowserName());
+                browserTestInfo.capabilities().getBrowserName());
         Assertions.assertEquals(caps.getBrowserVersion(),
-                capabilities.getBrowserVersion());
+                browserTestInfo.capabilities().getBrowserVersion());
         Assertions.assertEquals(caps.getPlatformName(),
-                capabilities.getPlatformName());
+                browserTestInfo.capabilities().getPlatformName());
     }
 
 }

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/JobNameCapabilitiesTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/JobNameCapabilitiesTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -29,9 +28,9 @@ public class JobNameCapabilitiesTest implements DriverSupplier {
 
     @BrowserTest
     public void tbMethodNameInCapabilities(TestInfo testInfo,
-            Capabilities capabilities) {
+            BrowserTestInfo browserTestInfo) {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities(
-                capabilities);
+                browserTestInfo.capabilities());
         Assertions.assertEquals("bar", SauceLabsIntegration
                 .getSauceLabsOption(desiredCapabilities, "foo"));
         Assertions.assertEquals(testInfo.getDisplayName(),

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/AbstractBrowserTB9Test.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/AbstractBrowserTB9Test.java
@@ -22,12 +22,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.testbench.ScreenshotOnFailureExtension;
 import com.vaadin.testbench.annotations.BrowserConfiguration;
 import com.vaadin.testbench.annotations.BrowserFactory;
+import com.vaadin.testbench.browser.BrowserTestInfo;
 import com.vaadin.testbench.parallel.BrowserUtil;
 
 /**
@@ -56,10 +56,9 @@ public abstract class AbstractBrowserTB9Test extends AbstractTB9Test {
     private Capabilities capabilities;
 
     @BeforeEach
-    public void setWebDriverAndCapabilities(WebDriver driver,
-            Capabilities capabilities) {
-        setDriver(driver);
-        this.capabilities = capabilities;
+    public void setWebDriverAndCapabilities(BrowserTestInfo browserTestInfo) {
+        setDriver(browserTestInfo.driver());
+        this.capabilities = browserTestInfo.capabilities();
     }
 
     public Capabilities getCapabilities() {

--- a/vaadin-testbench-integration-tests-junit5/vite.generated.ts
+++ b/vaadin-testbench-integration-tests-junit5/vite.generated.ts
@@ -25,7 +25,8 @@ const appShellUrl = '.';
 const frontendFolder = path.resolve(__dirname, settings.frontendFolder);
 const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
-const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
+const jarResourcesFolder = path.resolve(__dirname, settings.jarResourcesFolder);
+const generatedFlowImportsFolder = path.resolve(__dirname, settings.generatedFlowImportsFolder);
 const themeResourceFolder = path.resolve(__dirname, settings.themeResourceFolder);
 const statsFile = path.resolve(frontendBundleFolder, '..', 'config', 'stats.json');
 
@@ -40,7 +41,7 @@ const themeProjectFolders = projectStaticAssetsFolders.map((folder) => path.reso
 
 const themeOptions = {
   devMode: false,
-  // The following matches folder 'target/flow-frontend/themes/'
+  // The following matches folder 'frontend/generated/themes/'
   // (not 'frontend/themes') for theme in JAR that is copied there
   themeResourceFolder: path.resolve(themeResourceFolder, settings.themeFolder),
   themeProjectFolders: themeProjectFolders,
@@ -460,8 +461,8 @@ let spaMiddlewareForceRemoved = false;
 
 const allowedFrontendFolders = [
   frontendFolder,
-  addonFrontendFolder,
-  path.resolve(addonFrontendFolder, '..', 'frontend'), // Contains only generated-flow-imports
+  jarResourcesFolder,
+  path.resolve(generatedFlowImportsFolder), // Contains only generated-flow-imports
   path.resolve(__dirname, 'node_modules')
 ];
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
@@ -130,7 +130,8 @@ class TextAreaWrapTest extends UIUnitTest {
         tf.setRequired(true);
 
         final TextAreaTester<TextArea> ta_ = test(tf);
-        ta_.setValue("value1"); // must be value changed to trigger required validation
+        ta_.setValue("value1"); // must be value changed to trigger required
+                                // validation
         ta_.setValue("");
         Assertions.assertTrue(ta_.getComponent().isInvalid());
     }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextFieldTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextFieldTesterTest.java
@@ -132,7 +132,8 @@ public class TextFieldTesterTest extends UIUnitTest {
         tf.setRequired(true);
 
         final TextFieldTester<TextField, String> tf_ = test(tf);
-        tf_.setValue("value1"); // must be value changed to trigger required validation
+        tf_.setValue("value1"); // must be value changed to trigger required
+                                // validation
         tf_.setValue("");
         Assertions.assertTrue(tf_.getComponent().isInvalid());
     }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
@@ -328,8 +328,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
     @Deprecated
     public String getHeaderCell(int column) {
         ensureVisible();
-        final Grid.Column<Y> targetColumn = getColumns().get(column);
-        return GridKt.getHeader2(targetColumn);
+        return getColumns().get(column).getHeaderText();
     }
 
     private List<Grid.Column<Y>> getColumns() {
@@ -373,9 +372,9 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *             {@link Grid.Column#getFooterComponent()} directly
      */
     @Deprecated
-    public ValueProvider<?, ?> getFooterCell(int column) {
+    public String getFooterCell(int column) {
         ensureVisible();
-        return x -> getColumns().get(column).getFooterText();
+        return getColumns().get(column).getFooterText();
     }
 
     /**

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
@@ -321,7 +321,11 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      * @return header contents
      * @throws IllegalStateException
      *             if component is not visible
+     *
+     * @deprecated Use {@link Grid.Column#getHeaderText()} or
+     *             {@link Grid.Column#getHeaderComponent()}
      */
+    @Deprecated
     public String getHeaderCell(int column) {
         ensureVisible();
         final Grid.Column<Y> targetColumn = getColumns().get(column);
@@ -358,20 +362,20 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
     }
 
     /**
-     * Get content in footer for given column. TODO: How to get the value for
-     * footer. Is it possible?
+     * Get content in footer for given column.
      *
      * @param column
      *            column to get footer for
      * @return footer contents
      * @throws IllegalStateException
      *             if component is not visible
+     * @deprecated Use {@link Grid.Column#getFooterText()} or
+     *             {@link Grid.Column#getFooterComponent()} directly
      */
+    @Deprecated
     public ValueProvider<?, ?> getFooterCell(int column) {
         ensureVisible();
-        final Grid.Column<Y> targetColumn = getColumns().get(column);
-        return targetColumn.getFooterRenderer().getValueProviders()
-                .get(getColumnInternalId(targetColumn));
+        return x -> getColumns().get(column).getFooterText();
     }
 
     /**


### PR DESCRIPTION
Helper methods used in flow-tests have been moved to testbench. Injection of `WebDriver` and `Capabilities` have been replaced with single `BrowserTestInfo` with extended properties.