### PR TITLE
chore: Added polymer template module explicitly

### DIFF
--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -345,6 +345,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-polymer-template</artifactId>
+            <version>${vaadin.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.mvysny.dynatest</groupId>
             <artifactId>dynatest</artifactId>
             <version>0.24</version>


### PR DESCRIPTION
Polymer templates module has been excluded from platform in V24, so we need to add it manually.