### PR TITLE
test: adapt Testers to component changes

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
@@ -126,7 +126,7 @@ class TextAreaWrapTest extends UIUnitTest {
     @Test
     public void textAreaWithRequired_valueIsChecked() {
         TextArea tf = view.textArea;
-        tf.setRequired(true);
+        tf.setRequiredIndicatorVisible(true);
 
         final TextAreaTester<TextArea> ta_ = test(tf);
         ta_.setValue("value1"); // must be value changed to trigger required

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/testbench/unit/ComponentQueryTest.java
@@ -24,8 +24,8 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.textfield.GeneratedVaadinTextField;
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.InternalFieldBase;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.testbench.unit.ComponentTesterTest.Span;
@@ -493,7 +493,7 @@ class ComponentQueryTest extends UIUnitTest {
         rootElement.appendChild(otherField.getElement());
 
         Assertions.assertIterableEquals(List.of(targetField, otherField),
-                $(GeneratedVaadinTextField.class).withValue(null).all());
+                $(InternalFieldBase.class).withValue(null).all());
     }
 
     @Test

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
@@ -56,7 +56,7 @@ public class NumberFieldTester<T extends AbstractNumberField<T, V>, V extends Nu
     }
 
     private boolean isValid(V value) {
-        final boolean isRequiredButEmpty = getComponent().isRequiredBoolean()
+        final boolean isRequiredButEmpty = getComponent().isRequired()
                 && Objects.equals(getComponent().getEmptyValue(), value);
         final boolean isGreaterThanMax = value != null
                 && value.doubleValue() > getComponent().getMaxDouble();

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
@@ -34,6 +34,9 @@ public class TextAreaTester<T extends TextArea> extends ComponentTester<T> {
     /**
      * Set the value to the component if it is usable.
      *
+     * For a non interactable component an IllegalStateException will be thrown
+     * as the end user would not be able to set a value.
+     *
      * @param value
      *            value to set
      */

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
@@ -24,7 +24,7 @@ import com.vaadin.testbench.unit.Tests;
  */
 @Tests({ TextField.class, PasswordField.class, EmailField.class,
         BigDecimalField.class })
-public class TextFieldTester<T extends GeneratedVaadinTextField<T, V>, V>
+public class TextFieldTester<T extends InternalFieldBase<T, V>, V>
         extends ComponentTester<T> {
 
     /**
@@ -39,6 +39,9 @@ public class TextFieldTester<T extends GeneratedVaadinTextField<T, V>, V>
 
     /**
      * Set the value to the component if it is usable.
+     *
+     * For a non interactable component an IllegalStateException will be thrown
+     * as the end user would not be able to set a value.
      *
      * @param value
      *            value to set


### PR DESCRIPTION
Adapt TextFieldTester to new TextField hierarchy.
Temporary fix for TextAreaTester test, setting required with setRequiredIndicatorVisible