### PR TITLE
chore: Add selenium-chromium-driver to testbench bom

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -54,6 +54,11 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-chromium-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-edge-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>


### PR DESCRIPTION
this should be picked to 8.2 and 8.1 which are using selenium 4.0+, as this module has been introduced since Selenium 4.0