### PR TITLE
fix: Make Chrome 111 work

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -89,6 +89,11 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-http-jdk-client</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-opera-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -162,6 +162,10 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-http-jdk-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBench.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBench.java
@@ -86,6 +86,8 @@ public class TestBench {
     static {
         LicenseChecker.checkLicenseFromStaticBlock("vaadin-testbench",
                 TestBenchVersion.testbenchVersion, null);
+        // Enable the Java 11+ HTTP client
+        System.setProperty("webdriver.http.factory", "jdk-http-client");
     }
 
     public static TestBenchDriverProxy createDriver(WebDriver driver) {


### PR DESCRIPTION
Uses the new JDK 11 based HTTP client which does not have a problem with sending extra Origin-headers
