### PR TITLE
fix: Make Chrome 111 work (CP: 8.2)

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -68,6 +68,21 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-json</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-http</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-http-jdk-client</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-opera-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>

--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBench.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBench.java
@@ -87,6 +87,8 @@ public class TestBench {
     static {
         LicenseChecker.checkLicenseFromStaticBlock("vaadin-testbench",
                 TestBenchTestCase.testbenchVersion, null);
+        // Enable the Java 11+ HTTP client
+        System.setProperty("webdriver.http.factory", "jdk-http-client");
     }
 
     public static TestBenchDriverProxy createDriver(WebDriver driver) {


### PR DESCRIPTION
Uses the new JDK 11 based HTTP client which does not have a problem with sending extra Origin-headers
