### PR TITLE
fix: Add 'remote allow origins' option to chrome driver

### DIFF
--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/setup/LocalDriver.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/setup/LocalDriver.java
@@ -74,7 +74,7 @@ public class LocalDriver {
             // --ignore-certifcate-errors".
             // #14319
             ChromeOptions options = new ChromeOptions();
-            options.addArguments("--test-type ");
+            options.addArguments("--test-type ", "--remote-allow-origins=*");
             options.setHeadless(Parameters.isHeadless());
             driver = new ChromeDriver(options);
         } else if (BrowserUtil.isSafari(desiredCapabilities)) {


### PR DESCRIPTION
Fixes status code=403 errors when running tests with chrome driver described here https://stackoverflow.com/questions/75678572/java-io-ioexception-invalid-status-code-403-text-forbidden

