### PR TITLE
fix: current year from 2022 -> 2023 (used in licenses) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <slf4j.version>2.0.3</slf4j.version>
         <failsafe.version>3.0.0-M7</failsafe.version>
         <surefire.version>3.0.0-M7</surefire.version>
-        <currentYear>2022</currentYear>
+        <currentYear>2023</currentYear>
     </properties>
     <modules>
         <module>vaadin-testbench-bom</module>


### PR DESCRIPTION
## Description

I just saw this along the way I worked in this project.

This is a fix from <currentYear>2022</currentYear> to <currentYear>2023</currentYear>. This is used in
header.txt which is used in the license-maven-plugin. Not sure if we can have a problem because of 2022 legally, but better to fix this I feel.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
