### PR TITLE
chore: update license-checker version to 1.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <selenium.version>4.8.1</selenium.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <license.checker.version>1.12.2</license.checker.version>
         <spring.version>6.0.0-M6</spring.version>
         <spring.security.version>6.0.0-M7</spring.security.version>
         <slf4j.version>2.0.3</slf4j.version>
@@ -98,6 +97,15 @@
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>license-checker</artifactId>
+                <version>1.12.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -218,7 +218,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -195,7 +195,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -181,7 +181,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -281,7 +281,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>${license.checker.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
also make the dependency available for updating via `maven-versions-plugin:use-latest-versions`