### PR TITLE
fix: remove duplicate opened changed event

### DIFF
--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
@@ -85,8 +85,6 @@ public class DetailsTester<T extends Details> extends ComponentTester<T> {
                     "Details are already " + (opened ? "open" : "close"));
         }
         component.setOpened(opened);
-        ComponentUtil.fireEvent(component,
-                new Details.OpenedChangeEvent(component, false));
     }
 
 }


### PR DESCRIPTION
## Description

It looks like since https://github.com/vaadin/flow-components/pull/4909 the `Details` component now properly dispatches an opened changed event when changing the `opened` property, so the faked event from `DetailsTester` can be removed.