### PR TITLE
chore: Ensure TestBench is initialized for SeleniumJupiter tests

### DIFF
--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
@@ -47,6 +47,10 @@ import com.vaadin.testbench.commands.TestBenchCommands;
 public abstract class AbstractBrowserTestBase
         implements HasDriver, HasTestBenchCommandExecutor, HasElementQuery {
 
+    static {
+        TestBench.ensureLoaded();
+    }
+
     /**
      * When an error occurs during establishing a WebSocket connection, a severe
      * error is added to the console by the browser. We can't prevent it, so we


### PR DESCRIPTION
E.g. SeleniumHubPageObjectIT in this project is run without TestBench being properly initialized
