### PR TITLE
Add variable hub port capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <Implementation-Version>${project.version}</Implementation-Version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium.version>4.10.0</selenium.version>
+        <selenium.version>4.11.0</selenium.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring.version>6.0.9</spring.version>

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -125,7 +125,7 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             return SauceLabsIntegration.getHubUrl();
         } else {
-            return "http://" + getHubHostname(testClass) + ":4444/wd/hub";
+            return "http://" + getHubHostname(testClass) + ":" + Parameters.getHubPort() + "/wd/hub";
         }
     }
 

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
@@ -47,8 +47,13 @@ public class BrowserHubTest extends BrowserExtension {
 
     @Test
     public void hubPortFromDefaultValueOrParametersSetter() {
-        String oldProperty = System.getProperty(HUB_PORT_PROPERTY);
+        String oldPortProperty = System.getProperty(HUB_PORT_PROPERTY);
+        String oldHostnameProperty = System.getProperty(HUB_HOSTNAME_PROPERTY);
+
         try {
+            // Reset the hub hostname property (removes the saucelab url in CI)
+            System.clearProperty(HUB_HOSTNAME_PROPERTY);
+
             // Default must be the "official" 4444 port for backwards compatibility
             Assertions.assertEquals(getExpectedHubUrl(4444), getHubURL(getClass()));
 
@@ -56,8 +61,12 @@ public class BrowserHubTest extends BrowserExtension {
             Parameters.setHubPort(4445);
             Assertions.assertEquals(getExpectedHubUrl(4445), getHubURL(getClass()));
         } finally {
-            if (oldProperty != null) {
-                System.setProperty(HUB_PORT_PROPERTY, oldProperty);
+            if (oldPortProperty != null) {
+                System.setProperty(HUB_PORT_PROPERTY, oldPortProperty);
+            }
+
+            if (oldHostnameProperty != null) {
+                System.setProperty(HUB_HOSTNAME_PROPERTY, oldHostnameProperty);
             }
         }
     }

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
@@ -63,7 +63,7 @@ public class BrowserHubTest extends BrowserExtension {
     }
 
     private String getExpectedHubUrl(int port) {
-        return "http://hub-in-annotation:" + port + "/wd/hub";
+        return "http://" + getHubHostname(getClass()) + ":" + port + "/wd/hub";
     }
 
 }

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.testbench.browser;
 
+import com.vaadin.testbench.Parameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import com.vaadin.testbench.annotations.RunOnHub;
 public class BrowserHubTest extends BrowserExtension {
 
     private static final String HUB_HOSTNAME_PROPERTY = "com.vaadin.testbench.Parameters.hubHostname";
+    private static final String HUB_PORT_PROPERTY = "com.vaadin.testbench.Parameters.hubPort";
 
     public BrowserHubTest() {
         super(null);
@@ -41,6 +43,27 @@ public class BrowserHubTest extends BrowserExtension {
                 System.setProperty(HUB_HOSTNAME_PROPERTY, oldProperty);
             }
         }
+    }
+
+    @Test
+    public void hubPortFromDefaultValueOrParametersSetter() {
+        String oldProperty = System.getProperty(HUB_PORT_PROPERTY);
+        try {
+            // Default must be the "official" 4444 port for backwards compatibility
+            Assertions.assertEquals(getExpectedHubUrl(4444), getHubURL(getClass()));
+
+            // Modified at runtime
+            Parameters.setHubPort(4445);
+            Assertions.assertEquals(getExpectedHubUrl(4445), getHubURL(getClass()));
+        } finally {
+            if (oldProperty != null) {
+                System.setProperty(HUB_PORT_PROPERTY, oldProperty);
+            }
+        }
+    }
+
+    private String getExpectedHubUrl(int port) {
+        return "http://hub-in-annotation:" + port + "/wd/hub";
     }
 
 }

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
@@ -35,6 +35,7 @@ public class Parameters {
     private static String testbenchGridBrowsers;
     private static boolean headless;
     private static int readTimeout;
+    private static int hubPort;
     static {
         isDebug = getSystemPropertyBoolean("debug", false);
 
@@ -64,6 +65,7 @@ public class Parameters {
         headless = getSystemPropertyBoolean("headless", false);
         readTimeout = getSystemPropertyInt("readTimeout",
                 (int) ClientConfig.defaultConfig().readTimeout().toSeconds());
+        hubPort = getSystemPropertyInt("hubPort", 4444);
     }
 
     /**
@@ -317,6 +319,28 @@ public class Parameters {
      */
     public static String getHubHostname() {
         return getSystemPropertyString("hubHostname", null);
+    }
+
+    /**
+     * Gets the port of the hub to run tests on.
+     * <p />
+     * Allows to get a variable port for the selenium hub at runtime and can be modified
+     * from either via {@link #setHubPort(int)} or by setting the environment
+     * variable {@code com.vaadin.testbench.Parameters.hubPort}
+     *
+     * @return the port of the hub, defaults to 4444 if nothing is set
+     */
+    public static int getHubPort() {
+        return hubPort;
+    }
+
+    /**
+     * Changes the port on which the selenium hub is reachable.
+     *
+     * @param port  The new port to use
+     */
+    public static void setHubPort(int port) {
+        hubPort = port;
     }
 
     /**

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
@@ -325,8 +325,8 @@ public class Parameters {
      * Gets the port of the hub to run tests on.
      * <p />
      * Allows to get a variable port for the selenium hub at runtime and can be modified
-     * from either via {@link #setHubPort(int)} or by setting the environment
-     * variable {@code com.vaadin.testbench.Parameters.hubPort}
+     * from either via {@link #setHubPort(int)} or by setting the system property
+     * {@code com.vaadin.testbench.Parameters.hubPort}.
      *
      * @return the port of the hub, defaults to 4444 if nothing is set
      */


### PR DESCRIPTION
feat/enhancement: Variable hub port

## Description

In some scenarios it is not possible or hard to set a fixed port for the selenium hub. For example if the hub is run dynamically in the CI pipeline through testcontainers. 
This change allows to specify a different port from the default 4444 and thus, in the docker case, does not force to map the hub port fixed to 4444 on the host, which may lead to conflicting port mappings.

Fixes: https://github.com/vaadin/testbench/issues/1657

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
