### PR TITLE
feat: Add variable hub port capabilities

### DIFF
--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -125,7 +125,8 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             return SauceLabsIntegration.getHubUrl();
         } else {
-            return "http://" + getHubHostname(testClass) + ":4444/wd/hub";
+            return "http://" + getHubHostname(testClass) + ":"
+                    + Parameters.getHubPort() + "/wd/hub";
         }
     }
 

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -125,8 +125,7 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             return SauceLabsIntegration.getHubUrl();
         } else {
-            return "http://" + getHubHostname(testClass) + ":"
-                    + Parameters.getHubPort() + "/wd/hub";
+            return String.format("http://%s:%d/wd/hub", getHubHostname(testClass), Parameters.getHubPort();
         }
     }
 

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -125,7 +125,7 @@ public class BrowserExtension implements Extension, BeforeEachCallback,
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             return SauceLabsIntegration.getHubUrl();
         } else {
-            return String.format("http://%s:%d/wd/hub", getHubHostname(testClass), Parameters.getHubPort();
+            return String.format("http://%s:%d/wd/hub", getHubHostname(testClass), Parameters.getHubPort());
         }
     }
 

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/browser/BrowserHubTest.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.testbench.browser;
 
+import com.vaadin.testbench.Parameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import com.vaadin.testbench.annotations.RunOnHub;
 public class BrowserHubTest extends BrowserExtension {
 
     private static final String HUB_HOSTNAME_PROPERTY = "com.vaadin.testbench.Parameters.hubHostname";
+    private static final String HUB_PORT_PROPERTY = "com.vaadin.testbench.Parameters.hubPort";
 
     public BrowserHubTest() {
         super(null);
@@ -41,6 +43,39 @@ public class BrowserHubTest extends BrowserExtension {
                 System.setProperty(HUB_HOSTNAME_PROPERTY, oldProperty);
             }
         }
+    }
+
+    @Test
+    public void hubPortFromDefaultValueOrParametersSetter() {
+        String oldPortProperty = System.getProperty(HUB_PORT_PROPERTY);
+        String oldHostnameProperty = System.getProperty(HUB_HOSTNAME_PROPERTY);
+
+        try {
+            // Reset the hub hostname property (removes the saucelab url in CI)
+            System.clearProperty(HUB_HOSTNAME_PROPERTY);
+
+            // Default must be the "official" 4444 port for backwards
+            // compatibility
+            Assertions.assertEquals(getExpectedHubUrl(4444),
+                    getHubURL(getClass()));
+
+            // Modified at runtime
+            Parameters.setHubPort(4445);
+            Assertions.assertEquals(getExpectedHubUrl(4445),
+                    getHubURL(getClass()));
+        } finally {
+            if (oldPortProperty != null) {
+                System.setProperty(HUB_PORT_PROPERTY, oldPortProperty);
+            }
+
+            if (oldHostnameProperty != null) {
+                System.setProperty(HUB_HOSTNAME_PROPERTY, oldHostnameProperty);
+            }
+        }
+    }
+
+    private String getExpectedHubUrl(int port) {
+        return "http://" + getHubHostname(getClass()) + ":" + port + "/wd/hub";
     }
 
 }

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
@@ -35,6 +35,7 @@ public class Parameters {
     private static String testbenchGridBrowsers;
     private static boolean headless;
     private static int readTimeout;
+    private static int hubPort;
     static {
         isDebug = getSystemPropertyBoolean("debug", false);
 
@@ -64,6 +65,7 @@ public class Parameters {
         headless = getSystemPropertyBoolean("headless", false);
         readTimeout = getSystemPropertyInt("readTimeout",
                 (int) ClientConfig.defaultConfig().readTimeout().toSeconds());
+        hubPort = getSystemPropertyInt("hubPort", 4444);
     }
 
     /**
@@ -317,6 +319,29 @@ public class Parameters {
      */
     public static String getHubHostname() {
         return getSystemPropertyString("hubHostname", null);
+    }
+
+    /**
+     * Gets the port of the hub to run tests on.
+     * <p>
+     * Allows to get a variable port for the selenium hub at runtime and can be
+     * modified from either via {@link #setHubPort(int)} or by setting the
+     * system property {@code com.vaadin.testbench.Parameters.hubPort}.
+     *
+     * @return the port of the hub, defaults to 4444 if nothing is set
+     */
+    public static int getHubPort() {
+        return hubPort;
+    }
+
+    /**
+     * Changes the port on which the selenium hub is reachable.
+     *
+     * @param port
+     *            The new port to use
+     */
+    public static void setHubPort(int port) {
+        hubPort = port;
     }
 
     /**


### PR DESCRIPTION
In some scenarios it is not possible or hard to set a fixed port for the selenium hub. For example if the hub is run dynamically in the CI pipeline through testcontainers.
This change allows to specify a different port from the default 4444 and thus, in the docker case, does not force to map the hub port fixed to 4444 on the host, which may lead to conflicting port mappings.

Fixes: https://github.com/vaadin/testbench/issues/1657

Rebases https://github.com/vaadin/testbench/pull/1658 on main branch.

Many thanks to @ErrorProne for contribution!
