### PR TITLE
test: rename test classes to match containing file

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/accordion/AccordionTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/accordion/AccordionTesterTest.java
@@ -17,7 +17,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class AccordionWrapTest extends UIUnitTest {
+class AccordionTesterTest extends UIUnitTest {
 
     AccordionView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
@@ -23,7 +23,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ViewPackages
-class ConfirmDialogWrapTest extends UIUnitTest {
+class ConfirmDialogTesterTest extends UIUnitTest {
 
     ConfirmDialogView view;
     ConfirmDialogTester wrap;

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTesterTest.java
@@ -24,7 +24,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ViewPackages
-class DatePickerWrapTest extends UIUnitTest {
+class DatePickerTesterTest extends UIUnitTest {
 
     DatePickerView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTesterTest.java
@@ -26,7 +26,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ViewPackages
-class DateTimePickerWrapTest extends UIUnitTest {
+class DateTimePickerTesterTest extends UIUnitTest {
 
     DateTimePickerView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/details/DetailsTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/details/DetailsTesterTest.java
@@ -21,7 +21,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class DetailsWrapTest extends UIUnitTest {
+class DetailsTesterTest extends UIUnitTest {
 
     DetailsView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
@@ -19,7 +19,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class DialogWrapTest extends UIUnitTest {
+class DialogTesterTest extends UIUnitTest {
 
     DialogView view;
     DialogTester dialog_;

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTesterTest.java
@@ -19,7 +19,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 @ViewPackages
-class MultiSelectListBoxWrapTest extends UIUnitTest {
+class MultiSelectListBoxTesterTest extends UIUnitTest {
     ListBoxView view;
 
     @BeforeEach

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/menubar/MenuBarTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/menubar/MenuBarTesterTest.java
@@ -19,7 +19,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class MenuBarWrapTest extends UIUnitTest {
+class MenuBarTesterTest extends UIUnitTest {
 
     MenuBarView view;
     MenuBarTester<MenuBar> menu_;

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/messages/MessageInputTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/messages/MessageInputTesterTest.java
@@ -19,7 +19,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class MessageInputWrapTest extends UIUnitTest {
+class MessageInputTesterTest extends UIUnitTest {
 
     MessagesView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
@@ -17,7 +17,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class NotificationWrapTest extends UIUnitTest {
+class NotificationTesterTest extends UIUnitTest {
 
     @BeforeEach
     public void registerView() {

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/NumberFieldTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/NumberFieldTesterTest.java
@@ -23,7 +23,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ViewPackages
-class NumberFieldWrapTest extends UIUnitTest {
+class NumberFieldTesterTest extends UIUnitTest {
 
     private NumberFieldView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/textfield/TextAreaTesterTest.java
@@ -21,7 +21,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class TextAreaWrapTest extends UIUnitTest {
+class TextAreaTesterTest extends UIUnitTest {
 
     private TextAreaView view;
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTesterTest.java
@@ -24,7 +24,7 @@ import com.vaadin.testbench.unit.ViewPackages;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ViewPackages
-class TimePickerWrapTest extends UIUnitTest {
+class TimePickerTesterTest extends UIUnitTest {
 
     TimePickerView view;
     TimePickerTester<TimePicker> pick_;

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/upload/UploadTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/upload/UploadTesterTest.java
@@ -31,7 +31,7 @@ import com.vaadin.testbench.unit.UIUnitTest;
 import com.vaadin.testbench.unit.ViewPackages;
 
 @ViewPackages
-class UploadWrapTest extends UIUnitTest {
+class UploadTesterTest extends UIUnitTest {
 
     private static final String FIRST_FILE_CONTENTS = "First file";
     private static final String SECOND_FILE_CONTENTS = "Second file";


### PR DESCRIPTION
Some of the UI Unit Test tests classes still contain the old `Wrap` suffix in the name, and the class does not match the containing file name.
This change renames the test classes to replace the `Wrap` part with the correct `Tester` word.