### PR TITLE
fix: GridTester.sortByColumn(): consider the value of MultiSortPriority as well.

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/grid/GridTesterSortTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/grid/GridTesterSortTest.java
@@ -241,4 +241,23 @@ class GridTesterSortTest extends UIUnitTest {
                 List.of(grid_.getRow(0), grid_.getRow(1), grid_.getRow(2)));
 
     }
+
+    @Test
+    void sortByColumn_multisort_append_gridIsSorted() {
+        view.grid.setMultiSort(true, Grid.MultiSortPriority.APPEND);
+        view.first.setFirstName("G");
+        view.first.setAge(20);
+        view.second.setFirstName("G");
+        view.second.setAge(25);
+        view.third.setFirstName("A");
+        view.third.setAge(25);
+        view.grid.setMultiSort(true);
+
+        grid_.sortByColumn(0);
+        grid_.sortByColumn(1);
+        Assertions.assertIterableEquals(
+                List.of(view.third, view.first, view.second),
+                List.of(grid_.getRow(0), grid_.getRow(1), grid_.getRow(2)));
+
+    }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
@@ -538,6 +538,13 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
         }
     }
 
+    private Grid.MultiSortPriority getMultiSortPriority() {
+        return "append".equals(
+                getComponent().getElement().getAttribute("multi-sort-priority"))
+                        ? Grid.MultiSortPriority.APPEND
+                        : Grid.MultiSortPriority.PREPEND;
+    }
+
     private void doSort(SortDirection currentDirection, Grid.Column<Y> col) {
         List<GridSortOrder<Y>> sortOrders = new ArrayList<>(
                 getComponent().getSortOrder());
@@ -546,10 +553,14 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
         } else {
             sortOrders.clear();
         }
+        final Grid.MultiSortPriority multiSortPriority = getMultiSortPriority();
+        final int insertIndex = multiSortPriority == Grid.MultiSortPriority.PREPEND
+                ? 0
+                : sortOrders.size();
         if (currentDirection == null) {
-            sortOrders.add(0, GridSortOrder.asc(col).build().get(0));
+            sortOrders.add(insertIndex, GridSortOrder.asc(col).build().get(0));
         } else if (currentDirection == SortDirection.ASCENDING) {
-            sortOrders.add(0, GridSortOrder.desc(col).build().get(0));
+            sortOrders.add(insertIndex, GridSortOrder.desc(col).build().get(0));
         }
         getComponent().sort(sortOrders);
     }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

GridTester.sortByColumn(): consider the value of MultiSortPriority as well.

Fixes #1695

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
