### PR TITLE
fix: Wait for frontend compilation before Flow client init

### DIFF
--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
@@ -49,7 +49,9 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
     private boolean autoScrollIntoView = true;
     // @formatter:off
     String WAIT_FOR_VAADIN_SCRIPT =
-            "if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.clients) {"
+            "if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded) {"
+            + "  return false;"
+            + "} else if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.clients) {"
             + "  var clients = window.Vaadin.Flow.clients;"
             + "  for (var client in clients) {"
             + "    if (clients[client].isActive()) {"
@@ -57,8 +59,6 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
             + "    }"
             + "  }"
             + "  return true;"
-            + "} else if (window.Vaadin && window.Vaadin.Flow && window.Vaadin.Flow.devServerIsNotLoaded) {"
-            + "  return false;"
             + "} else {"
             + "  return true;"
             + "}";


### PR DESCRIPTION
Waits for frontend compilation before waiting for Flow client initialisation to cover the custom dev bundle compilation case.

Fixes https://github.com/vaadin/testbench/issues/1705