### PR TITLE
test: add tests for waitForVaadin

### DIFF
--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/WaitForVaadinIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/WaitForVaadinIT.java
@@ -8,7 +8,10 @@
  */
 package com.vaadin.tests;
 
+import java.lang.reflect.Field;
+
 import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.JavascriptExecutor;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.testUI.PageObjectView;
@@ -39,6 +42,18 @@ public class WaitForVaadinIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
+    public void waitForVaadin_activeConnector_waitsUtilReady() {
+        openTestURL();
+        assertDevServerIsNotLoaded();
+        getCommandExecutor().executeScript(
+                "window.Vaadin.Flow.clients[\"blocker\"] = {isActive: () => true};");
+        setWaitForVaadinLoopHook(500,
+                "window.Vaadin.Flow.clients[\"blocker\"] = {isActive: () => false};");
+        getCommandExecutor().waitForVaadin();
+        assertClientIsActive();
+    }
+
+    @BrowserTest
     public void waitForVaadin_noConnectors_returnsImmediately() {
         openTestURL();
         getCommandExecutor()
@@ -57,10 +72,37 @@ public class WaitForVaadinIT extends AbstractBrowserTB9Test {
     @BrowserTest
     public void waitForVaadin_devModeNotReady_waits() {
         openTestURL();
-
         getCommandExecutor().executeScript(
                 "window.Vaadin = {Flow: {devServerIsNotLoaded: true}};");
         assertExecutionBlocked(() -> getCommandExecutor().waitForVaadin());
+    }
+
+    @BrowserTest
+    public void waitForVaadin_devModeNotReady_waitsUntilReady() {
+        openTestURL();
+        assertDevServerIsNotLoaded();
+        getCommandExecutor().executeScript(
+                "window.Vaadin = {Flow: {devServerIsNotLoaded: true}};");
+        setWaitForVaadinLoopHook(500,
+                "window.Vaadin.Flow.devServerIsNotLoaded = false;");
+        getCommandExecutor().waitForVaadin();
+        assertDevServerIsNotLoaded();
+    }
+
+    private void assertDevServerIsNotLoaded() {
+        Object devServerIsNotLoaded = executeScript(
+                "return window.Vaadin.Flow.devServerIsNotLoaded;");
+        Assertions.assertTrue(
+                devServerIsNotLoaded == null
+                        || devServerIsNotLoaded == Boolean.FALSE,
+                "devServerIsNotLoaded should be null or false");
+    }
+
+    private void assertClientIsActive() {
+        Object active = executeScript(
+                "return window.Vaadin.Flow.clients[\"blocker\"].isActive();");
+        Assertions.assertSame(active, Boolean.FALSE,
+                "clients[\"blocker\"].isActive() should return false");
     }
 
     private void assertExecutionNoLonger(Runnable command) {
@@ -79,5 +121,30 @@ public class WaitForVaadinIT extends AbstractBrowserTB9Test {
         long timeout = after - before;
         Assertions.assertTrue(timeout >= BLOCKING_EXECUTION_TIMEOUT,
                 "Unexpected execution time, waiting time = " + timeout);
+    }
+
+    private void setWaitForVaadinLoopHook(long timeout,
+            String scriptToRunAfterTimeout) {
+        long systemCurrentTimeMillis = System.currentTimeMillis();
+        setWaitForVaadinLoopHook(() -> {
+            if (System.currentTimeMillis()
+                    - systemCurrentTimeMillis > timeout) {
+                ((JavascriptExecutor) getCommandExecutor().getDriver()
+                        .getWrappedDriver())
+                                .executeScript(scriptToRunAfterTimeout);
+                setWaitForVaadinLoopHook(null);
+            }
+        });
+    }
+
+    private void setWaitForVaadinLoopHook(Runnable action) {
+        try {
+            Field field = getCommandExecutor().getClass()
+                    .getDeclaredField("waitForVaadinLoopHook");
+            field.setAccessible(true);
+            field.set(getCommandExecutor(), action);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
@@ -64,6 +64,9 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
             + "}";
     // @formatter:on
 
+    // A hook for testing purposes
+    private Runnable waitForVaadinLoopHook;
+
     public TestBenchCommandExecutor(ImageComparison imageComparison,
             ReferenceNameGenerator referenceNameGenerator) {
         this.imageComparison = imageComparison;
@@ -113,6 +116,9 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
         long timeoutTime = System.currentTimeMillis() + 40000;
         Boolean finished = false;
         while (System.currentTimeMillis() < timeoutTime && !finished) {
+            if (waitForVaadinLoopHook != null) {
+                waitForVaadinLoopHook.run();
+            }
             // Must use the wrapped driver here to avoid calling waitForVaadin
             // again
             finished = (Boolean) ((JavascriptExecutor) getDriver()


### PR DESCRIPTION
Adds a new hook in waitForVaadin while loop for tests. New tests verifies that waiting stops properly after client flag `devServerIsNotLoaded` is changed or client's `isActive()` return value changes.

Related to: #1705