### PR TITLE
Fix performance data fetching

### DIFF
--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -153,18 +153,18 @@
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
-<plugin>
-    <groupId>org.eclipse.jetty</groupId>
-    <artifactId>jetty-maven-plugin</artifactId>
-    <version>${jetty.version}</version>
-    <configuration>
-        <scan>-1</scan>
-        <stopKey>foo</stopKey>
-        <stopPort>9999</stopPort>
-        <systemProperties>
-            <vaadin.requestTiming>true</vaadin.requestTiming>
-        </systemProperties>
-    </configuration>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <scan>-1</scan>
+                    <stopKey>foo</stopKey>
+                    <stopPort>9999</stopPort>
+                    <systemProperties>
+                        <vaadin.requestTiming>true</vaadin.requestTiming>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running
                         integration tests -->

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -153,21 +153,18 @@
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <scanIntervalSeconds>-1</scanIntervalSeconds>
-                    <stopKey>foo</stopKey>
-                    <stopPort>9999</stopPort>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.requestTiming</name>
-                            <value>true</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
+<plugin>
+    <groupId>org.eclipse.jetty</groupId>
+    <artifactId>jetty-maven-plugin</artifactId>
+    <version>${jetty.version}</version>
+    <configuration>
+        <scan>-1</scan>
+        <stopKey>foo</stopKey>
+        <stopPort>9999</stopPort>
+        <systemProperties>
+            <vaadin.requestTiming>true</vaadin.requestTiming>
+        </systemProperties>
+    </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running
                         integration tests -->

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/PerformanceIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/PerformanceIT.java
@@ -24,36 +24,35 @@ public class PerformanceIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
-    @Disabled("timeSpentServicingLastRequest test is unstable")
     public void serverTime() {
         openTestURL();
-        $(NativeButtonElement.class).first().click();
 
-        Assertions.assertEquals(1250.0,
-                testBench().timeSpentServicingLastRequest(), 250.0);
         $(NativeButtonElement.class).first().click();
-        Assertions.assertEquals(2500,
-                testBench().totalTimeSpentServicingRequests(), 500.0);
+        Assertions.assertEquals(1500.0,
+                testBench().timeSpentServicingLastRequest(), 500.0);
+
+        $(NativeButtonElement.class).first().click();
+        Assertions.assertEquals(3000.0,
+                testBench().totalTimeSpentServicingRequests(), 1000.0);
     }
 
     @BrowserTest
-    @Disabled("timeSpentServicingLastRequest does not work: https://github.com/vaadin/testbench/issues/1316")
     public void renderingTime() {
         openTestURL();
         long initialRendering = testBench().timeSpentRenderingLastRequest();
-        // Assuming initial rendering is done in 1-299ms
-        Assertions.assertEquals(150, initialRendering, 149);
-        Assertions.assertEquals(initialRendering,
-                testBench().totalTimeSpentRendering());
+        // Assert initial processing is takes 1-250 ms
+        Assertions.assertTrue(initialRendering > 0 && initialRendering <= 250);
+        // Assert total processing time is larger than initial processing time
+        long totalRendering = testBench().totalTimeSpentRendering();
+        Assertions.assertTrue(totalRendering > initialRendering,
+                "totalTimeSpentRendering() > initialRendering");
+
         $(NativeButtonElement.class).first().click();
         $(NativeButtonElement.class).first().click();
         $(NativeButtonElement.class).first().click();
 
         // Assuming rendering three poll responses is done in 50ms
-        Assertions.assertTrue(
-                testBench().totalTimeSpentRendering() > initialRendering,
-                "totalTimeSpentRendering() > initialRendering");
-        Assertions.assertEquals(initialRendering,
+        Assertions.assertEquals(totalRendering,
                 testBench().totalTimeSpentRendering(), 50);
     }
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/commands/TestBenchCommandExecutor.java
@@ -203,7 +203,9 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
                     + "  throw 'Performance data is only available when using Vaadin Flow';"
                     + "}" //
                     + "for (client in window.Vaadin.Flow.clients) {\n" //
-                    + "  window.Vaadin.Flow.clients[client].poll();\n" + "}");
+                    + "  if (typeof window.Vaadin.Flow.clients[client].poll === typeof Function) {\n"
+                    + "    window.Vaadin.Flow.clients[client].poll();\n"
+                    + "  }\n" + "}");
         }
 
         return (List<Long>) executeScript("" //
@@ -211,16 +213,18 @@ public class TestBenchCommandExecutor implements TestBenchCommands, HasDriver {
                 + "  throw 'Performance data is only available when using Vaadin Flow';"
                 + "}" //
                 + "var pd = [0,0,0,0];\n" //
+                + "var pdFound = false;\n" //
                 + "for (client in window.Vaadin.Flow.clients) {\n"
-                + "  if (!window.Vaadin.Flow.clients[client].getProfilingData) {"
-                + "    throw 'Performance data is not available in production mode';"
-                + "  }" //
-                + "  var p = window.Vaadin.Flow.clients[client].getProfilingData();\n"
-                + "  pd[0] += p[0];\n" //
-                + "  pd[1] += p[1];\n"//
-                + "  pd[2] += p[2];\n" //
-                + "  pd[3] += p[3];\n" //
-                + "}\n" + "return pd;\n");
+                + "  if (typeof window.Vaadin.Flow.clients[client].getProfilingData === typeof Function) {\n"
+                + "    var p = window.Vaadin.Flow.clients[client].getProfilingData();\n"
+                + "    pd[0] += p[0];\n" //
+                + "    pd[1] += p[1];\n"//
+                + "    pd[2] += p[2];\n" //
+                + "    pd[3] += p[3];\n" //
+                + "    pdFound = true;\n" + "  }\n" + "}\n" + "if (pdFound) {\n"
+                + "  return pd;\n" + "} else {\n"
+                + "  throw 'Performance data is not available in production mode';\n"
+                + "}");
     }
 
     @Override


### PR DESCRIPTION
Adds checks to ensure that client has `poll` and `getProfilingData` functions before calling them.
Fixes Jetty configuration in `pom.xml` to comply with Jetty version 11.
Fixes adn re-enabled `PerformanceIT`.

Fixes #1316
Fixes #1704