### PR TITLE
fix: fallback to context classloader when loading class

### DIFF
--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -42,6 +42,7 @@ import com.vaadin.testbench.unit.internal.MockInternalSeverError;
 import com.vaadin.testbench.unit.internal.MockVaadin;
 import com.vaadin.testbench.unit.internal.Routes;
 import com.vaadin.testbench.unit.internal.ShortcutsKt;
+import com.vaadin.testbench.unit.internal.UtilsKt;
 import com.vaadin.testbench.unit.mocks.MockedUI;
 
 /**
@@ -93,8 +94,8 @@ public abstract class BaseUIUnitTest {
                             .extendsSuperclass(ComponentTester.class))
                     .forEach(classInfo -> {
                         try {
-                            final Class<?> tester = Class
-                                    .forName(classInfo.getName());
+                            final Class<?> tester = UtilsKt
+                                    .findClassOrThrow(classInfo.getName());
                             final Class<? extends Component>[] annotation = tester
                                     .getAnnotation(Tests.class).value();
                             for (Class<? extends Component> component : annotation) {
@@ -108,7 +109,7 @@ public abstract class BaseUIUnitTest {
 
                             Arrays.stream(classes).map(clazz -> {
                                 try {
-                                    return Class.forName(clazz);
+                                    return UtilsKt.findClassOrThrow(clazz);
                                 } catch (ClassNotFoundException e) {
                                     throw new RuntimeException(e);
                                 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServlet.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServlet.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.spring.SpringServlet;
 import com.vaadin.testbench.unit.internal.Routes;
+import com.vaadin.testbench.unit.internal.UtilsKt;
 
 /**
  * Makes sure that the {@link #routes} are properly registered, and that
@@ -142,19 +143,13 @@ public class MockSpringServlet extends SpringServlet {
         }
 
         private static boolean hasSpringSecurity() {
-            try {
-                Class.forName(
-                        "org.springframework.security.core.context.SecurityContextHolder");
-                return true;
-            } catch (ClassNotFoundException e) {
-                // Ignore error
-            }
-            return false;
+            return UtilsKt.findClass(
+                    "org.springframework.security.core.context.SecurityContextHolder") != null;
         }
 
         private static UnaryOperator<HttpServletRequest> springSecurityRequestWrapper() {
             try {
-                Constructor<?> constructor = Class.forName(
+                Constructor<?> constructor = UtilsKt.findClassOrThrow(
                         "org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper")
                         .getConstructor(HttpServletRequest.class, String.class);
                 return req -> {

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/component/Grid.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/component/Grid.kt
@@ -62,6 +62,7 @@ import java.util.stream.Stream
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.streams.toList
+import com.vaadin.testbench.unit.internal.findClassOrThrow
 
 /**
  * Returns the item on given row. Fails if the row index is invalid. The data provider is
@@ -483,8 +484,8 @@ public fun Grid<*>.expectRow(rowIndex: Int, vararg row: String) {
 internal val HeaderRow.HeaderCell.column: Any
     get() = _AbstractCell_getColumn.invoke(this)
 
-private val abstractCellClass: Class<*> = Class.forName("com.vaadin.flow.component.grid.AbstractRow\$AbstractCell")
-private val abstractColumnClass: Class<*> = Class.forName("com.vaadin.flow.component.grid.AbstractColumn")
+private val abstractCellClass: Class<*> = findClassOrThrow("com.vaadin.flow.component.grid.AbstractRow\$AbstractCell")
+private val abstractColumnClass: Class<*> = findClassOrThrow("com.vaadin.flow.component.grid.AbstractColumn")
 private val _AbstractCell_getColumn: Method by lazy(LazyThreadSafetyMode.PUBLICATION) {
     val m: Method = abstractCellClass.getDeclaredMethod("getColumn")
     m.isAccessible = true
@@ -495,7 +496,7 @@ internal val <T> ColumnPathRenderer<T>.provider: ValueProvider<T, *>
     get() = _ColumnPathRenderer_provider.get(this) as (ValueProvider<T,*>)
 
 private val _ColumnPathRenderer_provider: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {
-    val f: Field = Class.forName("com.vaadin.flow.component.grid.ColumnPathRenderer").getDeclaredField("provider")
+    val f: Field = findClassOrThrow("com.vaadin.flow.component.grid.ColumnPathRenderer").getDeclaredField("provider")
     f.isAccessible = true
     f
 }

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
@@ -305,11 +305,7 @@ val FormLayout.FormItem.label: String get() {
  * The `HasLabel` interface has been introduced in Vaadin 21 but is missing in Vaadin 14.
  * Use reflection.
  */
-private val _HasLabel: Class<*>? = try {
-    Class.forName("com.vaadin.flow.component.HasLabel")
-} catch (ex: ClassNotFoundException) {
-    null
-}
+private val _HasLabel: Class<*>? = findClass("com.vaadin.flow.component.HasLabel")
 private val _HasLabel_getLabel: Method? = _HasLabel?.getDeclaredMethod("getLabel")
 private val _HasLabel_setLabel: Method? = _HasLabel?.getDeclaredMethod("setLabel", String::class.java)
 

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/Routes.kt
@@ -79,10 +79,10 @@ data class Routes(
                 .acceptPackages(*(packageNames.map { it ?: "" }.toTypedArray()))
         classGraph.scan().use { scanResult: ScanResult ->
             scanResult.getClassesWithAnnotation(Route::class.java.name).mapTo(routes) { info: ClassInfo ->
-                Class.forName(info.name).asSubclass(Component::class.java)
+                findClassOrThrow(info.name).asSubclass(Component::class.java)
             }
             scanResult.getClassesImplementing(HasErrorParameter::class.java.name).mapTo(errorRoutes) { info: ClassInfo ->
-                Class.forName(info.name).asSubclass(HasErrorParameter::class.java)
+                findClassOrThrow(info.name).asSubclass(HasErrorParameter::class.java)
             }
         }
 

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/TestingLifecycleHook.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/TestingLifecycleHook.kt
@@ -132,11 +132,8 @@ val Component.isTemplate: Boolean
  */
 var testingLifecycleHook: TestingLifecycleHook = TestingLifecycleHook.default
 
-private val _ConfirmDialog_Class: Class<*>? = try {
-    Class.forName("com.vaadin.flow.component.confirmdialog.ConfirmDialog")
-} catch (e: ClassNotFoundException) {
-    null
-}
+private val _ConfirmDialog_Class: Class<*>? = findClass("com.vaadin.flow.component.confirmdialog.ConfirmDialog")
+
 private val _ConfirmDialog_isOpened: Method? =
     _ConfirmDialog_Class?.getMethod("isOpened")
 


### PR DESCRIPTION
## Description

Currently classes are loaded with Class.forName, that uses the classloader from the calling class. However, this might not work on all environments because of different class loading setup (e.g in Quarkus testing). This change uses the current thread context class loader as fallback when Class.forName is not able to load a class.

Fixes vaadin/quarkus#139
Part of #1655

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
