### PR TITLE
feat: add UI Unit test base class for Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <module>vaadin-testbench-unit-shared</module>
         <module>vaadin-testbench-unit</module>
         <module>vaadin-testbench-unit-junit5</module>
+        <module>vaadin-testbench-unit-quarkus</module>
     </modules>
     <repositories>
         <repository>

--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -47,6 +47,11 @@
                 <artifactId>vaadin-testbench-unit-junit5</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-testbench-unit-quarkus</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-testbench-parent</artifactId>
+        <version>9.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>vaadin-testbench-unit-quarkus</artifactId>
+    <packaging>jar</packaging>
+    <name>Vaadin Testbench UI Unit Test for Quarkus</name>
+    <description>Vaadin Testbench UI Unit Tests for Quarkus</description>
+    <url>http://vaadin.com</url>
+    <inceptionYear>2024</inceptionYear>
+
+    <repositories>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+        </repository>
+    </repositories>
+
+    <licenses>
+        <license>
+            <name>Vaadin Commercial License and Service Terms</name>
+            <url>https://vaadin.com/commercial-license-and-service-terms</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Using the same version as in vaadin-quarkus extension -->
+        <quarkus.version>3.0.1.Final</quarkus.version>
+        <junit5.version>5.9.1</junit5.version>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.2.2</version>
+                        <configuration>
+                            <archive>
+                                <index>true</index>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <!-- Implementation-Title and Implementation-Version
+                                        come from the POM by default -->
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <!-- Package format version - do not
+                                        change -->
+                                    <Vaadin-Package-Version>1</Vaadin-Package-Version>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.9.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Using same version as vaadin-quarkus extension -->
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-quarkus-extension</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-unit-junit5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit5.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitTest.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.testbench.unit.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.internal.MockVaadin;
+import com.vaadin.testbench.unit.mocks.MockedUI;
+import com.vaadin.testbench.unit.quarkus.mocks.MockQuarkusServlet;
+
+/**
+ * Base JUnit 5 class for UI unit testing applications based on Quarkus stack.
+ *
+ * This class sets up a mock Vaadin Quarkus environment, so that views and
+ * components built upon dependency injection and AOP can be correctly be
+ * handled during unit testing. A CDI container is required for the test to
+ * work.
+ *
+ * With Quarkus testing framework, setting up the CDI environment can be
+ * achieved by annotating the {@link UIUnitTest} class with
+ * {@code @QuarkusTest}. The annotation registers a JUnit extension that deploys
+ * and starts the whole application, including the initialization of the CDI
+ * container. The drawback of this approach is that the application also starts
+ * the HTTP server, effectively initializing the entire Vaadin application.
+ * Tests are still performed in a mocked environment, but it is not possible
+ * out-of-the-box to run them in isolation, with only the components needed by
+ * the test.
+ *
+ * <pre>
+ * {
+ *     &#64;QuarkusTest
+ *     class MainViewTest extends QuarkusUIUnitTest {
+ *
+ *         &#64;Test
+ *         void accessView() {
+ *             MainView mainView = navigate(MainView.class);
+ *             Assertions.assertNotNull(mainView);
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * An alternative since Quarkus 3.2 could be the usage of (<a href=
+ * "https://quarkus.io/guides/getting-started-testing#testing-components">@QuarkusComponentTest
+ * annotation</a>), that targets testing of single CDI components. However, this
+ * kind of tests require a lot of manual setup, because every component involved
+ * in the test must be explicitly defined (including Vaadin Quarkus extension
+ * classes, since deployment augmentation is not performed). In addition, beans
+ * may still be removed by the CDI container because considered unused or not
+ * found because of missing bean defining annotations. For the above reasons,
+ * currently, using {@code @QuarkusComponentTest} is not recommended.
+ */
+
+public abstract class QuarkusUIUnitTest extends UIUnitTest {
+
+    @BeforeEach
+    protected void initVaadinEnvironment() {
+        scanTesters();
+        MockQuarkusServlet servlet = new MockQuarkusServlet(discoverRoutes(),
+                CDI.current().getBeanManager(), MockedUI::new);
+        MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+    }
+}

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServlet.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServlet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.testbench.unit.quarkus.mocks;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.servlet.ServletException;
+
+import java.lang.reflect.Field;
+
+import kotlin.jvm.functions.Function0;
+import org.jetbrains.annotations.NotNull;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.quarkus.QuarkusVaadinServlet;
+import com.vaadin.testbench.unit.internal.Routes;
+import com.vaadin.testbench.unit.mocks.MockVaadinHelper;
+
+/**
+ * Makes sure that the {@link #routes} are properly registered, and that
+ * {@link MockQuarkusServletService} is used instead of vanilla
+ * {@link com.vaadin.quarkus.QuarkusVaadinServletService}.
+ */
+public class MockQuarkusServlet extends QuarkusVaadinServlet {
+
+    /**
+     * Configuration object of all routes and error routes for test.
+     */
+    protected final Routes routes;
+    /**
+     * Factory used to build Flow UIs.
+     */
+    protected final transient Function0<UI> uiFactory;
+    /**
+     * The CDI bean manager.
+     */
+    protected final transient BeanManager beanManager;
+
+    /**
+     * Creates a {@link QuarkusVaadinServlet} for testing environment.
+     *
+     * @param routes
+     *            routes available for testing.
+     * @param beanManager
+     *            the CDI bean manager
+     * @param uiFactory
+     *            the factory used to build Flow UIs.
+     */
+    public MockQuarkusServlet(Routes routes, BeanManager beanManager,
+            @NotNull Function0<UI> uiFactory) {
+        this.routes = routes;
+        this.uiFactory = uiFactory;
+        this.beanManager = beanManager;
+        injectBeanManager();
+    }
+
+    private void injectBeanManager() {
+        Field beanManagerField;
+        try {
+            beanManagerField = QuarkusVaadinServlet.class
+                    .getDeclaredField("beanManager");
+            ReflectTools.setJavaFieldValue(this, beanManagerField,
+                    this.beanManager);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Cannot inject BeanManager field", e);
+        }
+    }
+
+    @Override
+    protected DeploymentConfiguration createDeploymentConfiguration()
+            throws ServletException {
+        MockVaadinHelper.mockFlowBuildInfo(this);
+        return super.createDeploymentConfiguration();
+    }
+
+    @Override
+    protected VaadinServletService createServletService(
+            DeploymentConfiguration deploymentConfiguration)
+            throws ServiceException {
+        final VaadinServletService service = new MockQuarkusServletService(this,
+                deploymentConfiguration, beanManager, uiFactory);
+        service.init();
+        routes.register(service.getContext());
+        return service;
+    }
+
+}

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServletService.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServletService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.testbench.unit.quarkus.mocks;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import kotlin.jvm.functions.Function0;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.quarkus.QuarkusVaadinServlet;
+import com.vaadin.quarkus.QuarkusVaadinServletService;
+import com.vaadin.testbench.unit.mocks.MockInstantiator;
+import com.vaadin.testbench.unit.mocks.MockVaadinSession;
+
+/**
+ * A mocking service that performs three very important tasks:
+ * <ul>
+ * <li>Overrides {@link #isAtmosphereAvailable} to tell Vaadin that we don't
+ * have Atmosphere (otherwise Vaadin will crash)</li>
+ * <li>Provides some dummy value as a root ID via {@link #getMainDivId}
+ * (otherwise the mocked servlet env will crash).</li>
+ * <li>Provides a {@link MockVaadinSession} instead of
+ * {@link com.vaadin.flow.server.VaadinSession}.</li>
+ * </ul>
+ * The class is intentionally opened, to be extensible in user's library.
+ */
+public class MockQuarkusServletService extends QuarkusVaadinServletService {
+
+    private final transient Function0<UI> uiFactory;
+
+    /**
+     * Creates a new QuarkusVaadinServletService for testing.
+     *
+     * @param servlet
+     *            the Quarkus Vaadin servlet.
+     * @param configuration
+     *            the deployment configuration.
+     * @param beanManager
+     *            the CDI bean manager.
+     * @param uiFactory
+     *            the factory used to build Flow UIs.
+     */
+    public MockQuarkusServletService(QuarkusVaadinServlet servlet,
+            DeploymentConfiguration configuration, BeanManager beanManager,
+            Function0<UI> uiFactory) {
+        super(servlet, configuration, beanManager);
+        this.uiFactory = uiFactory;
+    }
+
+    @Override
+    protected boolean isAtmosphereAvailable() {
+        return false;
+    }
+
+    @Override
+    public String getMainDivId(VaadinSession session, VaadinRequest request) {
+        return "ROOT-1";
+    }
+
+    @Override
+    protected VaadinSession createVaadinSession(VaadinRequest request) {
+        return new MockVaadinSession(this, uiFactory);
+    }
+
+    @Override
+    public Instantiator getInstantiator() {
+        return MockInstantiator.create(super.getInstantiator());
+    }
+
+}

--- a/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/DummyService.java
+++ b/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/DummyService.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.example.base;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DummyService {
+}

--- a/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/HelloWorldView.java
+++ b/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/HelloWorldView.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2000-2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.example.base;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("helloworld")
+public class HelloWorldView extends VerticalLayout {
+
+    public final DummyService service;
+
+    public HelloWorldView(DummyService service) {
+        this.service = service;
+        add(new Button("Hello, World!"));
+    }
+}

--- a/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/WelcomeView.java
+++ b/vaadin-testbench-unit-quarkus/src/test/java/com/example/base/WelcomeView.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2000-2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.example.base;
+
+import jakarta.inject.Inject;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
+
+@Route("welcome")
+@RouteAlias("")
+public class WelcomeView extends VerticalLayout {
+
+    @Inject
+    public DummyService service;
+
+    public WelcomeView() {
+        setWidth(null);
+        add(new Text("Welcome!"));
+    }
+
+}

--- a/vaadin-testbench-unit-quarkus/src/test/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitBaseClassTest.java
+++ b/vaadin-testbench-unit-quarkus/src/test/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitBaseClassTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.testbench.unit.quarkus;
+
+import com.example.base.HelloWorldView;
+import com.example.base.WelcomeView;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.testbench.unit.ViewPackages;
+import com.vaadin.testbench.unit.mocks.MockVaadinSession;
+import com.vaadin.testbench.unit.quarkus.mocks.MockQuarkusServletService;
+
+@QuarkusTest
+@ViewPackages(packages = "com.example")
+class QuarkusUIUnitBaseClassTest extends QuarkusUIUnitTest {
+
+    @Test
+    void extendingBaseClass_runTest_vaadinMockingIsSetup() {
+        Assertions.assertNotNull(VaadinService.getCurrent(),
+                "Expecting VaadinService to be available up, but was not");
+        Assertions.assertInstanceOf(MockQuarkusServletService.class,
+                VaadinService.getCurrent(), "Expecting VaadinService to be "
+                        + MockQuarkusServletService.class);
+
+        Assertions.assertNotNull(VaadinSession.getCurrent(),
+                "Expecting VaadinSession to be available up, but was not");
+        Assertions.assertInstanceOf(MockVaadinSession.class,
+                VaadinSession.getCurrent(),
+                "Expecting VaadinService to be " + MockVaadinSession.class);
+
+        Assertions.assertNotNull(VaadinRequest.getCurrent(),
+                "Expecting VaadinSession to be available up, but was not");
+    }
+
+    @Test
+    void extendingBaseClass_runTest_viewDependencyInjectionWorks() {
+        HelloWorldView view = navigate(HelloWorldView.class);
+        Assertions.assertNotNull(view.service,
+                "Expected service to be injected but field is null");
+
+        WelcomeView view2 = navigate(WelcomeView.class);
+        Assertions.assertNotNull(view2.service,
+                "Expected service to be injected but field is null");
+    }
+
+}

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -124,7 +124,7 @@ public abstract class BaseUIUnitTest {
         }
     }
 
-    synchronized Routes discoverRoutes() {
+    protected synchronized Routes discoverRoutes() {
         return discoverRoutes(scanPackages());
     }
 


### PR DESCRIPTION
## Description

Adds a base class for UI Unit testing on Quarkus.
Provides mocks for QuarkusVaadinServlet and QuarkusVaadinServletService integrated with Quarkus CDI.

Fixes vaadin/quarkus#140
Part of #1655 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
