### PR TITLE
fix: prevent fetching virtual childred for Composite

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/AllTests.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/AllTests.kt
@@ -64,6 +64,10 @@ class AllTests : DynaTest({
         }
     }
 
+    group("Composite") {
+        compositeTests()
+    }
+
     group("search spec") {
         searchSpecTest()
     }

--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/CompositeTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/CompositeTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.testbench.unit.internal
+
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.Composite
+import com.vaadin.flow.component.Tag
+import com.vaadin.flow.component.html.Span
+import com.github.mvysny.dynatest.DynaNodeGroup
+import com.github.mvysny.dynatest.DynaTestDsl
+
+@DynaTestDsl
+internal fun DynaNodeGroup.compositeTests() {
+    beforeEach { MockVaadin.setup() }
+    afterEach { MockVaadin.tearDown() }
+
+    test("Composite<*> causes virtual children to be fetched twice") {
+        class MyDialog : Composite<VirtualChildComponent>() {
+        }
+
+        val dlg = MyDialog()
+        dlg._expectOne<Span> { text = "virtual child" }
+    }
+}
+
+@Tag("my-test")
+class VirtualChildComponent : Component() {
+    init {
+        val child = Span("virtual child")
+        element.appendVirtualChild(child.element)
+    }
+}

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/TestingLifecycleHook.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/TestingLifecycleHook.kt
@@ -11,6 +11,7 @@ package com.vaadin.testbench.unit.internal
 
 import java.lang.reflect.Method
 import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.Composite
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.contextmenu.MenuItemBase
 import com.vaadin.flow.component.dialog.Dialog
@@ -105,6 +106,13 @@ interface TestingLifecycleHook {
         component is Grid.Column<*> -> {
             // don't include virtual children since that would include the header/footer components
             // which would clash with Grid.Column later on
+            component.children.toList()
+        }
+        component is Composite<*> -> {
+            // The Composite class overrides getChildren() to return a stream with the wrapped component,
+            // but also getElement() returning the Element of the wrapped component.
+            // The latter causes the virtual child to be fetched as Composite direct child,
+            // thus duplicating any virtual children the child component might have.
             component.children.toList()
         }
         // Also include virtual children.

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/AllTests.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/AllTests.kt
@@ -63,6 +63,10 @@ class AllTests : DynaTest({
         }
     }
 
+    group("Composite") {
+        compositeTests()
+    }
+
     group("search spec") {
         searchSpecTest()
     }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/CompositeTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/CompositeTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.testbench.unit.internal
+
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.Composite
+import com.vaadin.flow.component.Tag
+import com.vaadin.flow.component.html.Span
+import com.github.mvysny.dynatest.DynaNodeGroup
+import com.github.mvysny.dynatest.DynaTestDsl
+
+@DynaTestDsl
+internal fun DynaNodeGroup.compositeTests() {
+    beforeEach { MockVaadin.setup() }
+    afterEach { MockVaadin.tearDown() }
+
+    test("Composite<*> causes virtual children to be fetched twice") {
+        class MyDialog : Composite<VirtualChildComponent>() {
+        }
+
+        val dlg = MyDialog()
+        dlg._expectOne<Span> { text = "virtual child" }
+    }
+}
+
+@Tag("my-test")
+class VirtualChildComponent : Component() {
+    init {
+        val child = Span("virtual child")
+        element.appendVirtualChild(child.element)
+    }
+}


### PR DESCRIPTION
## Description

The Composite class overrides getChildren() to return a stream with the encapsulated component, but also getElement() returning the Element of the wrapped component. The latter causes the virtual children to be fetched as Composite direct children, thus duplicating any virtual children the encapsulated component might have.

Fixes #1738

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
