### PR TITLE
chore: Fix isChrome to work with newer Chrome versions

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
@@ -187,7 +187,7 @@ public class BrowserUtil {
         if (capabilities == null) {
             return false;
         }
-        return BrowserType.CHROME.equals(capabilities.getBrowserName());
+        return capabilities.getBrowserName().startsWith(BrowserType.CHROME);
     }
 
     /**


### PR DESCRIPTION
The newer Chrome versions report different browser name depending on being headless mode or not. Both are prefixed with "chrome", hence altering checking from equals to startsWith.

fixes #1741