### PR TITLE
test: wait for dev bundle creation before starting tests

### DIFF
--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -181,6 +181,38 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>wait-for-dev-bundle</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <mainClass>com.vaadin.tests.WaitForDevBundle</mainClass>
+                            <classpathScope>test</classpathScope>
+                            <systemProperties>
+                                <projectProperties/>
+                                <!-- Tune dev bundle creation waiter parameter if needed -->
+                                <!--
+                                <systemProperty>
+                                    <key>test.waitForDevBundle.attempts</key>
+                                    <value>5</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>test.waitForDevBundle.sleepMillis</key>
+                                    <value>500</value>
+                                </systemProperty>
+                                -->
+                            </systemProperties>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/WaitForDevBundle.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/WaitForDevBundle.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.tests;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+public class WaitForDevBundle {
+
+    public static void main(String... args) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        HttpClient client = HttpClient.newBuilder().executor(executor).build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080/PageObjectView"))
+                .timeout(Duration.of(3, SECONDS)).GET().build();
+
+        System.out.print("Wait for dev-bundle creation ");
+        int maxAttempts = Integer.getInteger("test.waitForDevBundle.attempts",
+                60);
+        long sleepTime = Long.getLong("test.waitForDevBundle.sleepMillis",
+                1000);
+        Exception exceptionHolder;
+        int remainingAttempts = maxAttempts;
+        do {
+            HttpResponse<String> response = null;
+            System.out.print(".");
+            try {
+                response = client.send(request,
+                        HttpResponse.BodyHandlers.ofString());
+                exceptionHolder = null;
+            } catch (Exception e) {
+                exceptionHolder = e;
+            } finally {
+                remainingAttempts--;
+            }
+            if (response != null && response.headers()
+                    .firstValue("X-DevModePending").isEmpty()) {
+                remainingAttempts = -1;
+            } else {
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+
+        } while (remainingAttempts > 0);
+
+        executor.shutdownNow();
+
+        System.out.println();
+        if (exceptionHolder != null) {
+            System.out.println("Error while waiting for bundle creation");
+            throw exceptionHolder;
+        }
+        if (remainingAttempts == -1) {
+            System.out.println("Dev-bundle created");
+        } else {
+            System.out.println("Dev-bundle is still under creation after "
+                    + Duration.ofMillis(maxAttempts * sleepTime).toSeconds()
+                    + " seconds. Proceed anyway.");
+        }
+    }
+
+}

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -113,9 +113,6 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
                 <version>${flow.version}</version>
-                <configuration>
-                    <bowerMode>true</bowerMode>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -151,7 +148,7 @@
                 <artifactId>jetty-ee10-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>
-                    <scanIntervalSeconds>-1</scanIntervalSeconds>
+                    <scan>-1</scan>
                     <stopKey>foo</stopKey>
                     <stopPort>9999</stopPort>
                     <systemProperties>
@@ -177,6 +174,38 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>wait-for-dev-bundle</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <mainClass>com.vaadin.tests.WaitForDevBundle</mainClass>
+                            <classpathScope>test</classpathScope>
+                            <systemProperties>
+                                <projectProperties/>
+                                <!-- Tune dev bundle creation waiter parameter if needed -->
+                                <!--
+                                <systemProperty>
+                                    <key>test.waitForDevBundle.attempts</key>
+                                    <value>5</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>test.waitForDevBundle.sleepMillis</key>
+                                    <value>500</value>
+                                </systemProperty>
+                                -->
+                            </systemProperties>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/WaitForDevBundle.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/WaitForDevBundle.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.tests;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+public class WaitForDevBundle {
+
+    public static void main(String... args) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        HttpClient client = HttpClient.newBuilder().executor(executor).build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080/PageObjectView"))
+                .timeout(Duration.of(3, SECONDS)).GET().build();
+
+        System.out.print("Wait for dev-bundle creation ");
+        int maxAttempts = Integer.getInteger("test.waitForDevBundle.attempts",
+                60);
+        long sleepTime = Long.getLong("test.waitForDevBundle.sleepMillis",
+                1000);
+        Exception exceptionHolder;
+        int remainingAttempts = maxAttempts;
+        do {
+            HttpResponse<String> response = null;
+            System.out.print(".");
+            try {
+                response = client.send(request,
+                        HttpResponse.BodyHandlers.ofString());
+                exceptionHolder = null;
+            } catch (Exception e) {
+                exceptionHolder = e;
+            } finally {
+                remainingAttempts--;
+            }
+            if (response != null && response.headers()
+                    .firstValue("X-DevModePending").isEmpty()) {
+                remainingAttempts = -1;
+            } else {
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+
+        } while (remainingAttempts > 0);
+
+        executor.shutdownNow();
+
+        System.out.println();
+        if (exceptionHolder != null) {
+            System.out.println("Error while waiting for bundle creation");
+            throw exceptionHolder;
+        }
+        if (remainingAttempts == -1) {
+            System.out.println("Dev-bundle created");
+        } else {
+            System.out.println("Dev-bundle is still under creation after "
+                    + Duration.ofMillis(maxAttempts * sleepTime).toSeconds()
+                    + " seconds. Proceed anyway.");
+        }
+    }
+
+}


### PR DESCRIPTION
Should prevent, or at least reduce flakyness, due to tests starting while dev-bundle creation is still in progress.