### PR TITLE
feat: rework "containing" selectors via addition of remaining attribute operators

### DIFF
--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/ElementQueryTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/ElementQueryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2000-2022 Vaadin Ltd
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.CONTAINS_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -264,8 +265,8 @@ class ElementQueryTest {
         findFirstInElement(query -> query
                         .withAttributeContaining("foo", "bar")
                         .first(),
-                "[foo~='bar']",
-                "Search should fail as no element containing the attribute value exists in element");
+                "[foo*='bar']",
+                "Search should fail as no element containing the attribute substring exists in element");
     }
 
     @Test
@@ -273,8 +274,26 @@ class ElementQueryTest {
         findFirstInDocument(query -> query
                         .withAttributeContaining("foo", "bar")
                         .first(),
+                "[foo*='bar']",
+                "Search should fail as no element containing the attribute substring exists in document");
+    }
+
+    @Test
+    void findInElement_byWithAttributeContainingToken() {
+        findFirstInElement(query -> query
+                        .withAttributeContainingToken("foo", "bar")
+                        .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute value exists in document");
+                "Search should fail as no element containing the attribute token exists in element");
+    }
+
+    @Test
+    void findInDocument_byWithAttributeContainingToken() {
+        findFirstInDocument(query -> query
+                        .withAttributeContainingToken("foo", "bar")
+                        .first(),
+                "[foo~='bar']",
+                "Search should fail as no element containing the attribute token exists in document");
     }
 
     @Test
@@ -318,7 +337,7 @@ class ElementQueryTest {
         findFirstInElement(query -> query
                         .withoutAttributeContaining("foo", "bar")
                         .first(),
-                ":not([foo~='bar'])",
+                ":not([foo*='bar'])",
                 null);
     }
 
@@ -326,6 +345,24 @@ class ElementQueryTest {
     void findInDocument_byWithoutAttributeContaining() {
         findFirstInDocument(query -> query
                         .withoutAttributeContaining("foo", "bar")
+                        .first(),
+                ":not([foo*='bar'])",
+                null);
+    }
+
+    @Test
+    void findInElement_byWithoutAttributeContainingToken() {
+        findFirstInElement(query -> query
+                        .withoutAttributeContainingToken("foo", "bar")
+                        .first(),
+                ":not([foo~='bar'])",
+                null);
+    }
+
+    @Test
+    void findInDocument_byWithoutAttributeContainingToken() {
+        findFirstInDocument(query -> query
+                        .withoutAttributeContainingToken("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
@@ -550,11 +587,11 @@ class ElementQueryTest {
     }
 
     @Test
-    void attributesConventionContains() {
+    void attributesConventionContainsToken() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MyFancyViewContainsElement.class);
         assertEquals(set(
-                        new AttributeMatch("class", "~=", "my-fancy-view-contains")),
+                        new AttributeMatch("class", CONTAINS_TOKEN, "my-fancy-view-contains")),
                 attributes);
     }
 
@@ -576,11 +613,11 @@ class ElementQueryTest {
     }
 
     @Test
-    void multipleAttributeAnnotations() {
+    void multipleAttributeAnnotationTokens() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MultipleAnnotationElement.class);
-        assertEquals(set(new AttributeMatch("class", "~=", "foo"),
-                new AttributeMatch("class", "~=", "bar")), attributes);
+        assertEquals(set(new AttributeMatch("class", CONTAINS_TOKEN, "foo"),
+                new AttributeMatch("class", CONTAINS_TOKEN, "bar")), attributes);
     }
 
     @SafeVarargs

--- a/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/ElementQueryTest.java
+++ b/vaadin-testbench-core-junit5/src/test/java/com/vaadin/testbench/ElementQueryTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.CONTAINS_TOKEN;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.CONTAINS_WORD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -279,21 +279,21 @@ class ElementQueryTest {
     }
 
     @Test
-    void findInElement_byWithAttributeContainingToken() {
+    void findInElement_byWithAttributeContainingWord() {
         findFirstInElement(query -> query
-                        .withAttributeContainingToken("foo", "bar")
+                        .withAttributeContainingWord("foo", "bar")
                         .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute token exists in element");
+                "Search should fail as no element containing the attribute word exists in element");
     }
 
     @Test
-    void findInDocument_byWithAttributeContainingToken() {
+    void findInDocument_byWithAttributeContainingWord() {
         findFirstInDocument(query -> query
-                        .withAttributeContainingToken("foo", "bar")
+                        .withAttributeContainingWord("foo", "bar")
                         .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute token exists in document");
+                "Search should fail as no element containing the attribute word exists in document");
     }
 
     @Test
@@ -351,18 +351,18 @@ class ElementQueryTest {
     }
 
     @Test
-    void findInElement_byWithoutAttributeContainingToken() {
+    void findInElement_byWithoutAttributeContainingWord() {
         findFirstInElement(query -> query
-                        .withoutAttributeContainingToken("foo", "bar")
+                        .withoutAttributeContainingWord("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
     }
 
     @Test
-    void findInDocument_byWithoutAttributeContainingToken() {
+    void findInDocument_byWithoutAttributeContainingWord() {
         findFirstInDocument(query -> query
-                        .withoutAttributeContainingToken("foo", "bar")
+                        .withoutAttributeContainingWord("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
@@ -587,11 +587,11 @@ class ElementQueryTest {
     }
 
     @Test
-    void attributesConventionContainsToken() {
+    void attributesConventionContainsWord() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MyFancyViewContainsElement.class);
         assertEquals(set(
-                        new AttributeMatch("class", CONTAINS_TOKEN, "my-fancy-view-contains")),
+                        new AttributeMatch("class", CONTAINS_WORD, "my-fancy-view-contains")),
                 attributes);
     }
 
@@ -613,11 +613,11 @@ class ElementQueryTest {
     }
 
     @Test
-    void multipleAttributeAnnotationTokens() {
+    void multipleAttributeAnnotationWords() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MultipleAnnotationElement.class);
-        assertEquals(set(new AttributeMatch("class", CONTAINS_TOKEN, "foo"),
-                new AttributeMatch("class", CONTAINS_TOKEN, "bar")), attributes);
+        assertEquals(set(new AttributeMatch("class", CONTAINS_WORD, "foo"),
+                new AttributeMatch("class", CONTAINS_WORD, "bar")), attributes);
     }
 
     @SafeVarargs

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ElementQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ElementQueryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2000-2022 Vaadin Ltd
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.CONTAINS_TOKEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -264,8 +265,8 @@ public class ElementQueryTest {
         findFirstInElement(query -> query
                         .withAttributeContaining("foo", "bar")
                         .first(),
-                "[foo~='bar']",
-                "Search should fail as no element containing the attribute value exists in element");
+                "[foo*='bar']",
+                "Search should fail as no element containing the attribute substring exists in element");
     }
 
     @Test
@@ -273,8 +274,26 @@ public class ElementQueryTest {
         findFirstInDocument(query -> query
                         .withAttributeContaining("foo", "bar")
                         .first(),
+                "[foo*='bar']",
+                "Search should fail as no element containing the attribute substring exists in document");
+    }
+
+    @Test
+    public void findInElement_byWithAttributeContainingToken() {
+        findFirstInElement(query -> query
+                        .withAttributeContainingToken("foo", "bar")
+                        .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute value exists in document");
+                "Search should fail as no element containing the attribute token exists in element");
+    }
+
+    @Test
+    public void findInDocument_byWithAttributeContainingToken() {
+        findFirstInDocument(query -> query
+                        .withAttributeContainingToken("foo", "bar")
+                        .first(),
+                "[foo~='bar']",
+                "Search should fail as no element containing the attribute token exists in document");
     }
 
     @Test
@@ -318,7 +337,7 @@ public class ElementQueryTest {
         findFirstInElement(query -> query
                         .withoutAttributeContaining("foo", "bar")
                         .first(),
-                ":not([foo~='bar'])",
+                ":not([foo*='bar'])",
                 null);
     }
 
@@ -326,6 +345,24 @@ public class ElementQueryTest {
     public void findInDocument_byWithoutAttributeContaining() {
         findFirstInDocument(query -> query
                         .withoutAttributeContaining("foo", "bar")
+                        .first(),
+                ":not([foo*='bar'])",
+                null);
+    }
+
+    @Test
+    public void findInElement_byWithoutAttributeContainingToken() {
+        findFirstInElement(query -> query
+                        .withoutAttributeContainingToken("foo", "bar")
+                        .first(),
+                ":not([foo~='bar'])",
+                null);
+    }
+
+    @Test
+    public void findInDocument_byWithoutAttributeContainingToken() {
+        findFirstInDocument(query -> query
+                        .withoutAttributeContainingToken("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
@@ -550,11 +587,11 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void attributesConventionContains() {
+    public void attributesConventionContainsToken() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MyFancyViewContainsElement.class);
         assertEquals(set(
-                        new AttributeMatch("class", "~=", "my-fancy-view-contains")),
+                        new AttributeMatch("class", CONTAINS_TOKEN, "my-fancy-view-contains")),
                 attributes);
     }
 
@@ -576,11 +613,11 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void multipleAttributeAnnotations() {
+    public void multipleAttributeAnnotationTokens() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MultipleAnnotationElement.class);
-        assertEquals(set(new AttributeMatch("class", "~=", "foo"),
-                new AttributeMatch("class", "~=", "bar")), attributes);
+        assertEquals(set(new AttributeMatch("class", CONTAINS_TOKEN, "foo"),
+                new AttributeMatch("class", CONTAINS_TOKEN, "bar")), attributes);
     }
 
     @SafeVarargs

--- a/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ElementQueryTest.java
+++ b/vaadin-testbench-core/src/test/java/com/vaadin/testbench/ElementQueryTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.CONTAINS_TOKEN;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.CONTAINS_WORD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -279,21 +279,21 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void findInElement_byWithAttributeContainingToken() {
+    public void findInElement_byWithAttributeContainingWord() {
         findFirstInElement(query -> query
-                        .withAttributeContainingToken("foo", "bar")
+                        .withAttributeContainingWord("foo", "bar")
                         .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute token exists in element");
+                "Search should fail as no element containing the attribute word exists in element");
     }
 
     @Test
-    public void findInDocument_byWithAttributeContainingToken() {
+    public void findInDocument_byWithAttributeContainingWord() {
         findFirstInDocument(query -> query
-                        .withAttributeContainingToken("foo", "bar")
+                        .withAttributeContainingWord("foo", "bar")
                         .first(),
                 "[foo~='bar']",
-                "Search should fail as no element containing the attribute token exists in document");
+                "Search should fail as no element containing the attribute word exists in document");
     }
 
     @Test
@@ -351,18 +351,18 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void findInElement_byWithoutAttributeContainingToken() {
+    public void findInElement_byWithoutAttributeContainingWord() {
         findFirstInElement(query -> query
-                        .withoutAttributeContainingToken("foo", "bar")
+                        .withoutAttributeContainingWord("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
     }
 
     @Test
-    public void findInDocument_byWithoutAttributeContainingToken() {
+    public void findInDocument_byWithoutAttributeContainingWord() {
         findFirstInDocument(query -> query
-                        .withoutAttributeContainingToken("foo", "bar")
+                        .withoutAttributeContainingWord("foo", "bar")
                         .first(),
                 ":not([foo~='bar'])",
                 null);
@@ -587,11 +587,11 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void attributesConventionContainsToken() {
+    public void attributesConventionContainsWord() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MyFancyViewContainsElement.class);
         assertEquals(set(
-                        new AttributeMatch("class", CONTAINS_TOKEN, "my-fancy-view-contains")),
+                        new AttributeMatch("class", CONTAINS_WORD, "my-fancy-view-contains")),
                 attributes);
     }
 
@@ -613,11 +613,11 @@ public class ElementQueryTest {
     }
 
     @Test
-    public void multipleAttributeAnnotationTokens() {
+    public void multipleAttributeAnnotationWords() {
         Set<AttributeMatch> attributes = ElementQuery
                 .getAttributes(MultipleAnnotationElement.class);
-        assertEquals(set(new AttributeMatch("class", CONTAINS_TOKEN, "foo"),
-                new AttributeMatch("class", CONTAINS_TOKEN, "bar")), attributes);
+        assertEquals(set(new AttributeMatch("class", CONTAINS_WORD, "foo"),
+                new AttributeMatch("class", CONTAINS_WORD, "bar")), attributes);
     }
 
     @SafeVarargs

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/ElementQueryIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/ElementQueryIT.java
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.BEGINS_WITH;
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.ENDS_WITH;
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.NOT_CONTAINS_PREFIX;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.BEGINS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.ENDS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.NOT_CONTAINS_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ElementQueryIT extends AbstractBrowserTB9Test {
@@ -193,14 +193,14 @@ public class ElementQueryIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
-    void withAttributeContainingToken() {
+    void withAttributeContainingWord() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
         List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
-                .withAttributeContainingToken("class", "button-1").all();
+                .withAttributeContainingWord("class", "button-1").all();
         Assertions.assertEquals(1, button1s.size());
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withAttributeContainingToken("class", "button").all();
+                .withAttributeContainingWord("class", "button").all();
         Assertions.assertEquals(10, allButtons.size());
     }
 
@@ -241,12 +241,12 @@ public class ElementQueryIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
-    void withoutAttributeContainingToken() {
+    void withoutAttributeContainingWord() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
 
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withoutAttributeContainingToken("class", "button-special-slot").all();
+                .withoutAttributeContainingWord("class", "button-special-slot").all();
         Assertions.assertEquals(9, allButtons.size());
     }
 

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/ElementQueryIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/ElementQueryIT.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2000-2022 Vaadin Ltd
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.BEGINS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.ENDS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.NOT_CONTAINS_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ElementQueryIT extends AbstractBrowserTB9Test {
@@ -157,14 +160,47 @@ public class ElementQueryIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
+    void withAttributeOperator() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+
+        List<NativeButtonElement> nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("id", "shadow", BEGINS_WITH)
+                .all();
+        Assertions.assertEquals(2, nativeButtonElements.size());
+
+        nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("class", "1", ENDS_WITH)
+                .all();
+        Assertions.assertEquals(2, nativeButtonElements.size());
+
+        nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("id", "shadow-button", NOT_CONTAINS_PREFIX)
+                .all();
+        Assertions.assertEquals(8, nativeButtonElements.size());
+    }
+
+    @BrowserTest
     void withAttributeContaining() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
         List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
-                .withAttributeContaining("class", "button-1").all();
+                .withAttributeContaining("id", "light-button-").all();
+        Assertions.assertEquals(5, button1s.size());
+        List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
+                .withAttributeContaining("class", "button-shadow-").all();
+        Assertions.assertEquals(3, allButtons.size());
+    }
+
+    @BrowserTest
+    void withAttributeContainingToken() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+        List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
+                .withAttributeContainingToken("class", "button-1").all();
         Assertions.assertEquals(1, button1s.size());
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withAttributeContaining("class", "button").all();
+                .withAttributeContainingToken("class", "button").all();
         Assertions.assertEquals(10, allButtons.size());
     }
 
@@ -200,7 +236,17 @@ public class ElementQueryIT extends AbstractBrowserTB9Test {
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
 
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withoutAttributeContaining("class", "button-special-slot").all();
+                .withoutAttributeContaining("class", "button-").all();
+        Assertions.assertEquals(1, allButtons.size());
+    }
+
+    @BrowserTest
+    void withoutAttributeContainingToken() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+
+        List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
+                .withoutAttributeContainingToken("class", "button-special-slot").all();
         Assertions.assertEquals(9, allButtons.size());
     }
 

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
@@ -17,9 +17,9 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.BEGINS_WITH;
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.ENDS_WITH;
-import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.NOT_CONTAINS_PREFIX;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.BEGINS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.ENDS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Comparison.NOT_CONTAINS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -193,14 +193,14 @@ public class ElementQueryIT extends AbstractTB6Test {
     }
 
     @Test
-    public void withAttributeContainingToken() {
+    public void withAttributeContainingWord() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
         List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
-                .withAttributeContainingToken("class", "button-1").all();
+                .withAttributeContainingWord("class", "button-1").all();
         assertEquals(1, button1s.size());
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withAttributeContainingToken("class", "button").all();
+                .withAttributeContainingWord("class", "button").all();
         assertEquals(10, allButtons.size());
     }
 
@@ -241,12 +241,12 @@ public class ElementQueryIT extends AbstractTB6Test {
     }
 
     @Test
-    public void withoutAttributeContainingToken() {
+    public void withoutAttributeContainingWord() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
 
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withoutAttributeContainingToken("class", "button-special-slot").all();
+                .withoutAttributeContainingWord("class", "button-special-slot").all();
         assertEquals(9, allButtons.size());
     }
 

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/ElementQueryIT.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2000-2022 Vaadin Ltd
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -17,6 +17,9 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.BEGINS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.ENDS_WITH;
+import static com.vaadin.testbench.ElementQuery.AttributeMatch.Operator.NOT_CONTAINS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -157,14 +160,47 @@ public class ElementQueryIT extends AbstractTB6Test {
     }
 
     @Test
+    public void withAttributeOperator() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+
+        List<NativeButtonElement> nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("id", "shadow", BEGINS_WITH)
+                .all();
+        assertEquals(2, nativeButtonElements.size());
+
+        nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("class", "1", ENDS_WITH)
+                .all();
+        assertEquals(2, nativeButtonElements.size());
+
+        nativeButtonElements = view.$(NativeButtonElement.class)
+                .withAttribute("id", "shadow-button", NOT_CONTAINS_PREFIX)
+                .all();
+        assertEquals(8, nativeButtonElements.size());
+    }
+
+    @Test
     public void withAttributeContaining() {
         openTestURL();
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
         List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
-                .withAttributeContaining("class", "button-1").all();
+                .withAttributeContaining("id", "light-button-").all();
+        assertEquals(5, button1s.size());
+        List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
+                .withAttributeContaining("class", "button-shadow-").all();
+        assertEquals(3, allButtons.size());
+    }
+
+    @Test
+    public void withAttributeContainingToken() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+        List<NativeButtonElement> button1s = view.$(NativeButtonElement.class)
+                .withAttributeContainingToken("class", "button-1").all();
         assertEquals(1, button1s.size());
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withAttributeContaining("class", "button").all();
+                .withAttributeContainingToken("class", "button").all();
         assertEquals(10, allButtons.size());
     }
 
@@ -200,7 +236,17 @@ public class ElementQueryIT extends AbstractTB6Test {
         TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
 
         List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
-                .withoutAttributeContaining("class", "button-special-slot").all();
+                .withoutAttributeContaining("class", "button-").all();
+        assertEquals(1, allButtons.size());
+    }
+
+    @Test
+    public void withoutAttributeContainingToken() {
+        openTestURL();
+        TemplateViewElement view = $(TemplateViewElement.class).waitForFirst();
+
+        List<NativeButtonElement> allButtons = view.$(NativeButtonElement.class)
+                .withoutAttributeContainingToken("class", "button-special-slot").all();
         assertEquals(9, allButtons.size());
     }
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/ElementQuery.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/ElementQuery.java
@@ -234,7 +234,9 @@ public class ElementQuery<T extends TestBenchElement> {
                     Arrays.stream(Comparison.values())
                             .filter(comp -> comp.getOperator().equals(operator))
                             .findFirst()
-                            .orElseThrow(),
+                            .orElseThrow(() -> new java.util.NoSuchElementException(
+                                    "Invalid operator \"" + operator + "\" supplied. As this constructor is unsafe and deprecated, please use AttributeMatch(String, Comparison, String) instead."
+                            )),
                     value);
         }
 
@@ -1183,12 +1185,12 @@ public class ElementQuery<T extends TestBenchElement> {
     public T waitForFirst(long timeOutInSeconds) {
         T result = new WebDriverWait(getDriver(),
                 Duration.ofSeconds(timeOutInSeconds)).until(driver -> {
-                    try {
-                        return first();
-                    } catch (NoSuchElementException e) {
-                        return null;
-                    }
-                });
+            try {
+                return first();
+            } catch (NoSuchElementException e) {
+                return null;
+            }
+        });
         if (result == null) {
             throw new NoSuchElementException(getNoSuchElementMessage(null));
         } else {
@@ -1413,7 +1415,7 @@ public class ElementQuery<T extends TestBenchElement> {
      */
     @SuppressWarnings("unchecked")
     List<T> executeSearchScript(String script, Object context, String tagName,
-            String attributePairs, JavascriptExecutor executor) {
+                                String attributePairs, JavascriptExecutor executor) {
         Object result = executor.executeScript(script, context, tagName,
                 attributePairs);
         if (result == null) {


### PR DESCRIPTION
## Description

Refactored name of "xContaining" attribute selector methods to "xContainingToken".

Added true "xContaining" attribute selector methods that match on substrings instead of on tokens.

Added remaining attribute matching operators and a corresponding selector method to utilize them. Refactored existing attribute-based selector methods to use this method.

Fixes #1554 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
