### PR TITLE
feat: add download method to AnchorTester

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/html/testbench/AnchorTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/html/testbench/AnchorTesterTest.java
@@ -91,7 +91,8 @@ class AnchorTesterTest extends UIUnitTest {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         test(anchor).download(outputStream);
 
-        Assertions.assertEquals("Hello world", outputStream.toString());
+        Assertions.assertEquals("Hello world",
+                outputStream.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/html/testbench/AnchorTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/html/testbench/AnchorTesterTest.java
@@ -9,6 +9,7 @@
 package com.vaadin.flow.component.html.testbench;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Assertions;
@@ -43,6 +44,15 @@ class AnchorTesterTest extends UIUnitTest {
     }
 
     @Test
+    void anchorClick_disabled_throws() {
+        Anchor anchor = new Anchor("anchor", "Home");
+        anchor.setEnabled(false);
+        UI.getCurrent().add(anchor);
+
+        assertThrows(IllegalStateException.class, () -> test(anchor).click());
+    }
+
+    @Test
     void anchorClick_notARegisteredRoute_throws() {
         Anchor anchor = new Anchor("error", "Home");
         UI.getCurrent().add(anchor);
@@ -69,4 +79,47 @@ class AnchorTesterTest extends UIUnitTest {
                 exception.getMessage());
     }
 
+    @Test
+    void anchorDownload_writesResourceToOutputStream() {
+        StreamResource resource = new StreamResource("filename",
+                () -> new ByteArrayInputStream(
+                        "Hello world".getBytes(StandardCharsets.UTF_8)));
+
+        Anchor anchor = new Anchor(resource, "Download");
+        UI.getCurrent().add(anchor);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        test(anchor).download(outputStream);
+
+        Assertions.assertEquals("Hello world", outputStream.toString());
+    }
+
+    @Test
+    void anchorDownload_disabled_throws() {
+        StreamResource resource = new StreamResource("filename",
+                () -> new ByteArrayInputStream(
+                        "Hello world".getBytes(StandardCharsets.UTF_8)));
+
+        Anchor anchor = new Anchor(resource, "Download");
+        anchor.setEnabled(false);
+        UI.getCurrent().add(anchor);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        assertThrows(IllegalStateException.class,
+                () -> test(anchor).download(outputStream));
+    }
+
+    @Test
+    void anchorDownload_noStreamRegistration_throws() {
+        Anchor anchor = new Anchor("anchor", "Download");
+        UI.getCurrent().add(anchor);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> test(anchor).download(outputStream));
+
+        Assertions.assertEquals("Anchor target does not seem to be a resource",
+                exception.getMessage());
+    }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.testbench.unit.Tests;
 
@@ -86,9 +87,9 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
     public void download(OutputStream outputStream) {
         ensureComponentIsUsable();
 
-        var anchor = getComponent();
-        var session = VaadinSession.getCurrent();
-        var registry = session.getResourceRegistry();
+        Anchor anchor = getComponent();
+        VaadinSession session = VaadinSession.getCurrent();
+        StreamResourceRegistry registry = session.getResourceRegistry();
 
         Optional<AbstractStreamResource> maybeResource = Optional.empty();
         try {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
@@ -8,12 +8,20 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
 
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.testbench.unit.Tests;
 
 @Tests(Anchor.class)
@@ -67,4 +75,38 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
         throw new IllegalStateException("Anchor target seems to be a resource");
     }
 
+    /**
+     * Download the stream resource linked by the anchor.
+     *
+     * @param outputStream
+     *            output stream to write the stream resource to
+     * @throws IllegalStateException
+     *             if the anchor does not link to a stream resource
+     */
+    public void download(OutputStream outputStream) {
+        ensureComponentIsUsable();
+
+        var anchor = getComponent();
+        var session = VaadinSession.getCurrent();
+        var registry = session.getResourceRegistry();
+
+        Optional<AbstractStreamResource> maybeResource = Optional.empty();
+        try {
+            maybeResource = registry.getResource(new URI(anchor.getHref()));
+        } catch (URISyntaxException e) {
+            // Ignore, throws below if resource is empty
+        }
+
+        if (maybeResource.isEmpty() || !(maybeResource
+                .get() instanceof StreamResource streamResource)) {
+            throw new IllegalStateException(
+                    "Anchor target does not seem to be a resource");
+        }
+
+        try {
+            streamResource.getWriter().accept(outputStream, session);
+        } catch (IOException e) {
+            throw new RuntimeException("Download failed", e);
+        }
+    }
 }


### PR DESCRIPTION
Adds a `download` method to `AnchorTester` that allows testing that downloads for an anchor work properly.