### PR TITLE
chore: upgrade javassist to 3.30.2-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <slf4j.version>2.0.7</slf4j.version>
         <failsafe.version>3.1.0</failsafe.version>
         <surefire.version>3.1.0</surefire.version>
+        <javassist.version>3.30.2-GA</javassist.version>
         <currentYear>2023</currentYear>
     </properties>
     <modules>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.28.0-GA</version>
+            <version>${javassist.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.28.0-GA</version>
+            <version>${javassist.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.28.0-GA</version>
+            <version>${javassist.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Description

This upgrade is needed to resolve the failure in dependency convergence check in Hilla.
