### PR TITLE
Added tester for RouterLink.

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/AbstractTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/AbstractTargetView.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2000-2025 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.html.Span;
+
+abstract class AbstractTargetView extends Component implements HasComponents {
+
+    final Span message;
+
+    public AbstractTargetView() {
+        message = new Span();
+        add(message);
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkQueryParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkQueryParameterTargetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,36 +8,32 @@
  */
 package com.vaadin.flow.component.routerlink;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasComponents;
+import java.util.stream.Collectors;
+
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
 
-import java.util.stream.Collectors;
-
 @Tag(Tag.DIV)
 @Route(value = RouterLinkQueryParameterTargetView.ROUTE, registerAtStartup = false)
-public class RouterLinkQueryParameterTargetView extends Component
-        implements HasComponents, BeforeEnterObserver {
+public class RouterLinkQueryParameterTargetView extends AbstractTargetView
+        implements BeforeEnterObserver {
 
     public static final String ROUTE = "router-link-query-parameter-target";
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         var queryParameters = event.getLocation().getQueryParameters();
-
-        add(new Span("Query Parameter Target View: { " +
-                queryParameters.getParameters().entrySet().stream()
-                        .map(entry -> entry.getKey() + " = [" +
-                                entry.getValue().stream()
-                                        .sorted()
-                                        .collect(Collectors.joining(", ")) +
-                                "]")
-                        .sorted()
-                        .collect(Collectors.joining("; ")) +
-                " }"));
+        message.setText(
+                "Query Parameter Target View: { "
+                        + queryParameters.getParameters().entrySet().stream()
+                                .map(entry -> entry.getKey() + " = ["
+                                        + entry.getValue().stream().sorted()
+                                                .collect(Collectors
+                                                        .joining(", "))
+                                        + "]")
+                                .sorted().collect(Collectors.joining("; "))
+                        + " }");
     }
 }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkQueryParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkQueryParameterTargetView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+import java.util.stream.Collectors;
+
+@Tag(Tag.DIV)
+@Route(value = RouterLinkQueryParameterTargetView.ROUTE, registerAtStartup = false)
+public class RouterLinkQueryParameterTargetView extends Component
+        implements HasComponents, BeforeEnterObserver {
+
+    public static final String ROUTE = "router-link-query-parameter-target";
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        var queryParameters = event.getLocation().getQueryParameters();
+
+        add(new Span("Query Parameter Target View: { " +
+                queryParameters.getParameters().entrySet().stream()
+                        .map(entry -> entry.getKey() + " = [" +
+                                entry.getValue().stream()
+                                        .sorted()
+                                        .collect(Collectors.joining(", ")) +
+                                "]")
+                        .sorted()
+                        .collect(Collectors.joining("; ")) +
+                " }"));
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkRouteParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkRouteParameterTargetView.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+import java.util.stream.Collectors;
+
+@Tag(Tag.DIV)
+@Route(value = RouterLinkRouteParameterTargetView.ROUTE + RouterLinkRouteParameterTargetView.ROUTE_PARAMETERS,
+        registerAtStartup = false)
+public class RouterLinkRouteParameterTargetView extends Component
+        implements HasComponents, BeforeEnterObserver {
+
+    public static final String ROUTE = "router-link-route-parameter-target";
+    public static final String ROUTE_PARAMETERS = "/:segment1?/static/:segment2/:segment3*";
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        var routeParameters = event.getRouteParameters();
+
+        add(new Span("Route Parameter Target View: { " +
+                routeParameters.getParameterNames().stream()
+                        .map(name -> name + " = " + routeParameters.get(name).orElse(""))
+                        .sorted()
+                        .collect(Collectors.joining("; ")) +
+                " }"));
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkRouteParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkRouteParameterTargetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,21 +8,18 @@
  */
 package com.vaadin.flow.component.routerlink;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasComponents;
+import java.util.stream.Collectors;
+
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
 
-import java.util.stream.Collectors;
-
 @Tag(Tag.DIV)
-@Route(value = RouterLinkRouteParameterTargetView.ROUTE + RouterLinkRouteParameterTargetView.ROUTE_PARAMETERS,
-        registerAtStartup = false)
-public class RouterLinkRouteParameterTargetView extends Component
-        implements HasComponents, BeforeEnterObserver {
+@Route(value = RouterLinkRouteParameterTargetView.ROUTE
+        + RouterLinkRouteParameterTargetView.ROUTE_PARAMETERS, registerAtStartup = false)
+public class RouterLinkRouteParameterTargetView extends AbstractTargetView
+        implements BeforeEnterObserver {
 
     public static final String ROUTE = "router-link-route-parameter-target";
     public static final String ROUTE_PARAMETERS = "/:segment1?/static/:segment2/:segment3*";
@@ -31,11 +28,12 @@ public class RouterLinkRouteParameterTargetView extends Component
     public void beforeEnter(BeforeEnterEvent event) {
         var routeParameters = event.getRouteParameters();
 
-        add(new Span("Route Parameter Target View: { " +
-                routeParameters.getParameterNames().stream()
-                        .map(name -> name + " = " + routeParameters.get(name).orElse(""))
-                        .sorted()
-                        .collect(Collectors.joining("; ")) +
-                " }"));
+        message.setText(
+                "Route Parameter Target View: { "
+                        + routeParameters.getParameterNames().stream()
+                                .map(name -> name + " = "
+                                        + routeParameters.get(name).orElse(""))
+                                .sorted().collect(Collectors.joining("; "))
+                        + " }");
     }
 }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkStaticTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkStaticTargetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,20 +8,18 @@
  */
 package com.vaadin.flow.component.routerlink;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 @Tag(Tag.DIV)
 @Route(value = RouterLinkStaticTargetView.ROUTE, registerAtStartup = false)
-public class RouterLinkStaticTargetView extends Component
+public class RouterLinkStaticTargetView extends AbstractTargetView
         implements HasComponents {
 
     public static final String ROUTE = "router-link-static-target";
 
     public RouterLinkStaticTargetView() {
-        add(new Span("Static Target View"));
+        message.setText("Static Target View");
     }
 }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkStaticTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkStaticTargetView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Tag(Tag.DIV)
+@Route(value = RouterLinkStaticTargetView.ROUTE, registerAtStartup = false)
+public class RouterLinkStaticTargetView extends Component
+        implements HasComponents {
+
+    public static final String ROUTE = "router-link-static-target";
+
+    public RouterLinkStaticTargetView() {
+        add(new Span("Static Target View"));
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkTesterTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.testbench.unit.ComponentTester;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ViewPackages
+class RouterLinkTesterTest extends UIUnitTest {
+
+    private ComponentTester<RouterLinkView> $routerLinkView;
+
+    @BeforeEach
+    void init() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RouterLinkView.class);
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RouterLinkStaticTargetView.class);
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RouterLinkUrlParameterTargetView.class);
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RouterLinkQueryParameterTargetView.class);
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(RouterLinkRouteParameterTargetView.class);
+
+        var routerLinkView = navigate(RouterLinkView.class);
+        $routerLinkView = test(routerLinkView);
+    }
+
+    @Test
+    void routerLink_targetless() {
+        // get router link
+        var targetlessRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("No Target")
+                .single();
+        var $targetlessRouterLink = test(targetlessRouterLink);
+        Assertions.assertNotNull($targetlessRouterLink,
+                "Tester for targetless RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals("",
+                $targetlessRouterLink.getHref());
+
+        // verify its click action fails due to no navigation target
+        Assertions.assertThrows(IllegalStateException.class, $targetlessRouterLink::click);
+    }
+
+    @Test
+    void routerLink_static() {
+        // get router link
+        var staticRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("Static Target")
+                .single();
+        var $staticRouterLink = test(staticRouterLink);
+        Assertions.assertNotNull($staticRouterLink,
+                "Tester for static RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals(RouterLinkStaticTargetView.ROUTE,
+                $staticRouterLink.getHref());
+
+        // verify its click action returns correct target
+        var targetView = $staticRouterLink.click();
+        Assertions.assertInstanceOf(RouterLinkStaticTargetView.class, targetView);
+
+        // verify navigation target is correct
+        var $targetView = test(targetView);
+        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
+                .withText("Static Target View")
+                .single());
+    }
+
+    @Test
+    void routerLink_emptyUrlParameter() {
+        var emptyUrlParameterRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("Empty URL Parameter Target")
+                .single();
+        var $emptyUrlParameterRouterLink = test(emptyUrlParameterRouterLink);
+        Assertions.assertNotNull($emptyUrlParameterRouterLink,
+                "Tester for empty URL parameter RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals(RouterLinkUrlParameterTargetView.ROUTE,
+                $emptyUrlParameterRouterLink.getHref());
+
+        // verify its click action returns correct target
+        var targetView = $emptyUrlParameterRouterLink.click();
+        Assertions.assertInstanceOf(RouterLinkUrlParameterTargetView.class, targetView);
+
+        // verify navigation target is correct
+        var $targetView = test(targetView);
+        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
+                .withText("URL Parameter Target View: {  }")
+                .single());
+    }
+
+    @Test
+    void routerLink_urlParameter() {
+        var urlParameterRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("URL Parameter Target")
+                .single();
+        var $urlParameterRouterLink = test(urlParameterRouterLink);
+        Assertions.assertNotNull($urlParameterRouterLink,
+                "Tester for URL parameter RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals(RouterLinkUrlParameterTargetView.ROUTE + "/parameter-value",
+                $urlParameterRouterLink.getHref());
+
+        // verify its click action returns correct target
+        var targetView = $urlParameterRouterLink.click();
+        Assertions.assertInstanceOf(RouterLinkUrlParameterTargetView.class, targetView);
+
+        // verify navigation target is correct
+        var $targetView = test(targetView);
+        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
+                .withText("URL Parameter Target View: { parameter-value }")
+                .single());
+    }
+
+    @Test
+    void routerLink_queryParameter() {
+        var queryParameterRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("Query Parameter Target")
+                .single();
+        var $queryParameterRouterLink = test(queryParameterRouterLink);
+        Assertions.assertNotNull($queryParameterRouterLink,
+                "Tester for QueryParameter RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals(RouterLinkQueryParameterTargetView.ROUTE +
+                        "?parameter2=parameter2-value1&parameter2=parameter2-value2&parameter1=parameter1-value",
+                $queryParameterRouterLink.getHref());
+
+        // verify its click action returns correct target
+        var targetView = $queryParameterRouterLink.click();
+        Assertions.assertInstanceOf(RouterLinkQueryParameterTargetView.class, targetView);
+
+        // verify navigation target is correct
+        var $targetView = test(targetView);
+        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
+                .withText("Query Parameter Target View: { parameter1 = [parameter1-value]; parameter2 = [parameter2-value1, parameter2-value2] }")
+                .single());
+    }
+
+    @Test
+    void routerLink_routeParameter() {
+        var routeParameterRouterLink = $routerLinkView.find(RouterLink.class)
+                .withText("Route Parameter Target")
+                .single();
+        var $routeParameterRouterLink = test(routeParameterRouterLink);
+        Assertions.assertNotNull($routeParameterRouterLink,
+                "Tester for RouteParameter RouterLink not initialized.");
+
+        // verify its href
+        Assertions.assertEquals(RouterLinkRouteParameterTargetView.ROUTE +
+                        "/static/segment2-value/segment3-value1/segment3-value2",
+                $routeParameterRouterLink.getHref());
+
+        // verify its click action returns correct target
+        var targetView = $routeParameterRouterLink.click();
+        Assertions.assertInstanceOf(RouterLinkRouteParameterTargetView.class, targetView);
+
+        // verify navigation target is correct
+        var $targetView = test(targetView);
+        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
+                .withText("Route Parameter Target View: { segment2 = segment2-value; segment3 = segment3-value1/segment3-value2 }")
+                .single());
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkTesterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,20 +8,19 @@
  */
 package com.vaadin.flow.component.routerlink;
 
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.router.RouteConfiguration;
-import com.vaadin.flow.router.RouterLink;
-import com.vaadin.testbench.unit.ComponentTester;
-import com.vaadin.testbench.unit.UIUnitTest;
-import com.vaadin.testbench.unit.ViewPackages;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.testbench.unit.UIUnitTest;
+import com.vaadin.testbench.unit.ViewPackages;
+
 @ViewPackages
 class RouterLinkTesterTest extends UIUnitTest {
 
-    private ComponentTester<RouterLinkView> $routerLinkView;
+    private RouterLinkView routerLinkView;
 
     @BeforeEach
     void init() {
@@ -36,35 +35,28 @@ class RouterLinkTesterTest extends UIUnitTest {
         RouteConfiguration.forApplicationScope()
                 .setAnnotatedRoute(RouterLinkRouteParameterTargetView.class);
 
-        var routerLinkView = navigate(RouterLinkView.class);
-        $routerLinkView = test(routerLinkView);
+        routerLinkView = navigate(RouterLinkView.class);
     }
 
     @Test
     void routerLink_targetless() {
         // get router link
-        var targetlessRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("No Target")
-                .single();
-        var $targetlessRouterLink = test(targetlessRouterLink);
+        var $targetlessRouterLink = test(routerLinkView.targetlessRouterLink);
         Assertions.assertNotNull($targetlessRouterLink,
                 "Tester for targetless RouterLink not initialized.");
 
         // verify its href
-        Assertions.assertEquals("",
-                $targetlessRouterLink.getHref());
+        Assertions.assertEquals("", $targetlessRouterLink.getHref());
 
         // verify its click action fails due to no navigation target
-        Assertions.assertThrows(IllegalStateException.class, $targetlessRouterLink::click);
+        Assertions.assertThrows(IllegalStateException.class,
+                $targetlessRouterLink::click);
     }
 
     @Test
     void routerLink_static() {
         // get router link
-        var staticRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("Static Target")
-                .single();
-        var $staticRouterLink = test(staticRouterLink);
+        var $staticRouterLink = test(routerLinkView.staticRouterLink);
         Assertions.assertNotNull($staticRouterLink,
                 "Tester for static RouterLink not initialized.");
 
@@ -72,23 +64,14 @@ class RouterLinkTesterTest extends UIUnitTest {
         Assertions.assertEquals(RouterLinkStaticTargetView.ROUTE,
                 $staticRouterLink.getHref());
 
-        // verify its click action returns correct target
-        var targetView = $staticRouterLink.click();
-        Assertions.assertInstanceOf(RouterLinkStaticTargetView.class, targetView);
-
-        // verify navigation target is correct
-        var $targetView = test(targetView);
-        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
-                .withText("Static Target View")
-                .single());
+        assertNavigationSucceeded($staticRouterLink,
+                RouterLinkStaticTargetView.class, "Static Target View");
     }
 
     @Test
     void routerLink_emptyUrlParameter() {
-        var emptyUrlParameterRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("Empty URL Parameter Target")
-                .single();
-        var $emptyUrlParameterRouterLink = test(emptyUrlParameterRouterLink);
+        var $emptyUrlParameterRouterLink = test(
+                routerLinkView.emptyUrlParameterRouterLink);
         Assertions.assertNotNull($emptyUrlParameterRouterLink,
                 "Tester for empty URL parameter RouterLink not initialized.");
 
@@ -96,88 +79,72 @@ class RouterLinkTesterTest extends UIUnitTest {
         Assertions.assertEquals(RouterLinkUrlParameterTargetView.ROUTE,
                 $emptyUrlParameterRouterLink.getHref());
 
-        // verify its click action returns correct target
-        var targetView = $emptyUrlParameterRouterLink.click();
-        Assertions.assertInstanceOf(RouterLinkUrlParameterTargetView.class, targetView);
-
-        // verify navigation target is correct
-        var $targetView = test(targetView);
-        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
-                .withText("URL Parameter Target View: {  }")
-                .single());
+        assertNavigationSucceeded($emptyUrlParameterRouterLink,
+                RouterLinkUrlParameterTargetView.class,
+                "URL Parameter Target View: {  }");
     }
 
     @Test
     void routerLink_urlParameter() {
-        var urlParameterRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("URL Parameter Target")
-                .single();
-        var $urlParameterRouterLink = test(urlParameterRouterLink);
+        var $urlParameterRouterLink = test(
+                routerLinkView.urlParameterRouterLink);
         Assertions.assertNotNull($urlParameterRouterLink,
                 "Tester for URL parameter RouterLink not initialized.");
 
         // verify its href
-        Assertions.assertEquals(RouterLinkUrlParameterTargetView.ROUTE + "/parameter-value",
+        Assertions.assertEquals(
+                RouterLinkUrlParameterTargetView.ROUTE + "/parameter-value",
                 $urlParameterRouterLink.getHref());
 
-        // verify its click action returns correct target
-        var targetView = $urlParameterRouterLink.click();
-        Assertions.assertInstanceOf(RouterLinkUrlParameterTargetView.class, targetView);
-
-        // verify navigation target is correct
-        var $targetView = test(targetView);
-        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
-                .withText("URL Parameter Target View: { parameter-value }")
-                .single());
+        assertNavigationSucceeded($urlParameterRouterLink,
+                RouterLinkUrlParameterTargetView.class,
+                "URL Parameter Target View: { parameter-value }");
     }
 
     @Test
     void routerLink_queryParameter() {
-        var queryParameterRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("Query Parameter Target")
-                .single();
-        var $queryParameterRouterLink = test(queryParameterRouterLink);
+        var $queryParameterRouterLink = test(
+                routerLinkView.queryParameterRouterLink);
         Assertions.assertNotNull($queryParameterRouterLink,
                 "Tester for QueryParameter RouterLink not initialized.");
 
         // verify its href
-        Assertions.assertEquals(RouterLinkQueryParameterTargetView.ROUTE +
-                        "?parameter2=parameter2-value1&parameter2=parameter2-value2&parameter1=parameter1-value",
+        Assertions.assertEquals(RouterLinkQueryParameterTargetView.ROUTE
+                + "?parameter2=parameter2-value1&parameter2=parameter2-value2&parameter1=parameter1-value",
                 $queryParameterRouterLink.getHref());
 
-        // verify its click action returns correct target
-        var targetView = $queryParameterRouterLink.click();
-        Assertions.assertInstanceOf(RouterLinkQueryParameterTargetView.class, targetView);
-
-        // verify navigation target is correct
-        var $targetView = test(targetView);
-        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
-                .withText("Query Parameter Target View: { parameter1 = [parameter1-value]; parameter2 = [parameter2-value1, parameter2-value2] }")
-                .single());
+        assertNavigationSucceeded($queryParameterRouterLink,
+                RouterLinkQueryParameterTargetView.class,
+                "Query Parameter Target View: { parameter1 = [parameter1-value]; parameter2 = [parameter2-value1, parameter2-value2] }");
     }
 
     @Test
     void routerLink_routeParameter() {
-        var routeParameterRouterLink = $routerLinkView.find(RouterLink.class)
-                .withText("Route Parameter Target")
-                .single();
-        var $routeParameterRouterLink = test(routeParameterRouterLink);
+        var $routeParameterRouterLink = test(
+                routerLinkView.routeParameterRouterLink);
         Assertions.assertNotNull($routeParameterRouterLink,
                 "Tester for RouteParameter RouterLink not initialized.");
 
         // verify its href
-        Assertions.assertEquals(RouterLinkRouteParameterTargetView.ROUTE +
-                        "/static/segment2-value/segment3-value1/segment3-value2",
+        Assertions.assertEquals(RouterLinkRouteParameterTargetView.ROUTE
+                + "/static/segment2-value/segment3-value1/segment3-value2",
                 $routeParameterRouterLink.getHref());
 
+        assertNavigationSucceeded($routeParameterRouterLink,
+                RouterLinkRouteParameterTargetView.class,
+                "Route Parameter Target View: { segment2 = segment2-value; segment3 = segment3-value1/segment3-value2 }");
+    }
+
+    private void assertNavigationSucceeded(RouterLinkTester<RouterLink> tester,
+            Class<? extends AbstractTargetView> expectedTarget,
+            String expectedMessage) {
         // verify its click action returns correct target
-        var targetView = $routeParameterRouterLink.click();
-        Assertions.assertInstanceOf(RouterLinkRouteParameterTargetView.class, targetView);
+        var targetView = tester.click();
+        Assertions.assertInstanceOf(expectedTarget, targetView);
+        Assertions.assertSame(targetView, getCurrentView());
 
         // verify navigation target is correct
-        var $targetView = test(targetView);
-        Assertions.assertDoesNotThrow(() -> $targetView.find(Span.class)
-                .withText("Route Parameter Target View: { segment2 = segment2-value; segment3 = segment3-value1/segment3-value2 }")
-                .single());
+        Assertions.assertEquals(expectedMessage,
+                expectedTarget.cast(targetView).message.getText());
     }
 }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkUrlParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkUrlParameterTargetView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+
+@Tag(Tag.DIV)
+@Route(value = RouterLinkUrlParameterTargetView.ROUTE, registerAtStartup = false)
+public class RouterLinkUrlParameterTargetView extends Component
+        implements HasComponents, HasUrlParameter<String> {
+
+    public static final String ROUTE = "router-link-url-parameter-target";
+
+    @Override
+    public void setParameter(BeforeEvent event, @OptionalParameter String parameter) {
+        add(new Span("URL Parameter Target View: { " + (parameter != null ? parameter : "") + " }"));
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkUrlParameterTargetView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkUrlParameterTargetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,10 +8,8 @@
  */
 package com.vaadin.flow.component.routerlink;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.OptionalParameter;
@@ -19,13 +17,15 @@ import com.vaadin.flow.router.Route;
 
 @Tag(Tag.DIV)
 @Route(value = RouterLinkUrlParameterTargetView.ROUTE, registerAtStartup = false)
-public class RouterLinkUrlParameterTargetView extends Component
+public class RouterLinkUrlParameterTargetView extends AbstractTargetView
         implements HasComponents, HasUrlParameter<String> {
 
     public static final String ROUTE = "router-link-url-parameter-target";
 
     @Override
-    public void setParameter(BeforeEvent event, @OptionalParameter String parameter) {
-        add(new Span("URL Parameter Target View: { " + (parameter != null ? parameter : "") + " }"));
+    public void setParameter(BeforeEvent event,
+            @OptionalParameter String parameter) {
+        message.setText("URL Parameter Target View: { "
+                + (parameter != null ? parameter : "") + " }");
     }
 }

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkView.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.RouterLink;
+
+import java.util.Map;
+
+@Tag(Tag.DIV)
+@Route(value = RouterLinkView.ROUTE, registerAtStartup = false)
+public class RouterLinkView extends Component implements HasComponents {
+
+    public static final String ROUTE = "router-link-test";
+
+    public RouterLinkView() {
+        // targetless router link
+        var targetlessRouterLink = new RouterLink();
+        targetlessRouterLink.setText("No Target");
+
+        // static router link
+        var staticRouterLink = new RouterLink("Static Target",
+                RouterLinkStaticTargetView.class);
+
+        // url parameter router link - empty
+        var emptyUrlParameterRouterLink = new RouterLink("Empty URL Parameter Target",
+                RouterLinkUrlParameterTargetView.class);
+
+        // url parameter router link - non-empty
+        var urlParameterRouterLink = new RouterLink("URL Parameter Target",
+                RouterLinkUrlParameterTargetView.class,
+                "parameter-value");
+
+        // query parameter router link
+        var queryParameterRouterLink = new RouterLink("Query Parameter Target",
+                RouterLinkQueryParameterTargetView.class);
+        queryParameterRouterLink.setQueryParameters(
+                QueryParameters.empty()
+                        .merging("parameter1", "parameter1-value")
+                        .merging("parameter2", "parameter2-value1", "parameter2-value2"));
+
+        // route parameter router link
+        var routeParameterRouterLink = new RouterLink("Route Parameter Target",
+                RouterLinkRouteParameterTargetView.class,
+                new RouteParameters(Map.ofEntries(
+                        Map.entry("segment2", "segment2-value"),
+                        Map.entry("segment3", "segment3-value1/segment3-value2"))));
+
+        add(targetlessRouterLink);
+        add(staticRouterLink);
+        add(emptyUrlParameterRouterLink);
+        add(urlParameterRouterLink);
+        add(queryParameterRouterLink);
+        add(routeParameterRouterLink);
+    }
+}

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/routerlink/RouterLinkView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -7,6 +7,8 @@
  * license.
  */
 package com.vaadin.flow.component.routerlink;
+
+import java.util.Map;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
@@ -16,52 +18,54 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouterLink;
 
-import java.util.Map;
-
 @Tag(Tag.DIV)
 @Route(value = RouterLinkView.ROUTE, registerAtStartup = false)
 public class RouterLinkView extends Component implements HasComponents {
 
     public static final String ROUTE = "router-link-test";
 
+    final RouterLink targetlessRouterLink;
+    final RouterLink staticRouterLink;
+    final RouterLink emptyUrlParameterRouterLink;
+    final RouterLink urlParameterRouterLink;
+    final RouterLink queryParameterRouterLink;
+    final RouterLink routeParameterRouterLink;
+
     public RouterLinkView() {
         // targetless router link
-        var targetlessRouterLink = new RouterLink();
+        targetlessRouterLink = new RouterLink();
         targetlessRouterLink.setText("No Target");
 
         // static router link
-        var staticRouterLink = new RouterLink("Static Target",
+        staticRouterLink = new RouterLink("Static Target",
                 RouterLinkStaticTargetView.class);
 
         // url parameter router link - empty
-        var emptyUrlParameterRouterLink = new RouterLink("Empty URL Parameter Target",
+        emptyUrlParameterRouterLink = new RouterLink(
+                "Empty URL Parameter Target",
                 RouterLinkUrlParameterTargetView.class);
 
         // url parameter router link - non-empty
-        var urlParameterRouterLink = new RouterLink("URL Parameter Target",
-                RouterLinkUrlParameterTargetView.class,
-                "parameter-value");
+        urlParameterRouterLink = new RouterLink("URL Parameter Target",
+                RouterLinkUrlParameterTargetView.class, "parameter-value");
 
         // query parameter router link
-        var queryParameterRouterLink = new RouterLink("Query Parameter Target",
+        queryParameterRouterLink = new RouterLink("Query Parameter Target",
                 RouterLinkQueryParameterTargetView.class);
-        queryParameterRouterLink.setQueryParameters(
-                QueryParameters.empty()
-                        .merging("parameter1", "parameter1-value")
-                        .merging("parameter2", "parameter2-value1", "parameter2-value2"));
+        queryParameterRouterLink.setQueryParameters(QueryParameters.empty()
+                .merging("parameter1", "parameter1-value").merging("parameter2",
+                        "parameter2-value1", "parameter2-value2"));
 
         // route parameter router link
-        var routeParameterRouterLink = new RouterLink("Route Parameter Target",
+        routeParameterRouterLink = new RouterLink("Route Parameter Target",
                 RouterLinkRouteParameterTargetView.class,
-                new RouteParameters(Map.ofEntries(
-                        Map.entry("segment2", "segment2-value"),
-                        Map.entry("segment3", "segment3-value1/segment3-value2"))));
+                new RouteParameters(
+                        Map.ofEntries(Map.entry("segment2", "segment2-value"),
+                                Map.entry("segment3",
+                                        "segment3-value1/segment3-value2"))));
 
-        add(targetlessRouterLink);
-        add(staticRouterLink);
-        add(emptyUrlParameterRouterLink);
-        add(urlParameterRouterLink);
-        add(queryParameterRouterLink);
-        add(routeParameterRouterLink);
+        add(targetlessRouterLink, staticRouterLink, emptyUrlParameterRouterLink,
+                urlParameterRouterLink, queryParameterRouterLink,
+                routeParameterRouterLink);
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2000-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.flow.component.routerlink;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.testbench.unit.ComponentTester;
+import com.vaadin.testbench.unit.Tests;
+
+import java.net.URI;
+import java.util.Optional;
+
+/**
+ *
+ * Tester for RouterLink components.
+ *
+ * @param <T>
+ *            component type
+ */
+@Tests(RouterLink.class)
+public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
+
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component target component
+     */
+    public RouterLinkTester(T component) {
+        super(component);
+    }
+
+    /**
+     * Gets the URL that the router-link links to.
+     *
+     * @return the href value, or empty string if no href has been set
+     */
+    public String getHref() {
+        ensureComponentIsUsable();
+
+        return getComponent().getHref();
+    }
+
+    /**
+     * Gets the path for the router-link.
+     * Returns an empty {@link String} if there is no corresponding navigation target.
+     *
+     * @return a {@link String} containing the navigation target path or empty if not present
+     */
+    public String getPath() {
+        return URI.create(getHref()).getPath();
+    }
+
+    /**
+     * Gets the query parameters for the router-link.
+     *
+     * @return a {@link QueryParameters} containing the navigation target's query parameters
+     */
+    public QueryParameters getQueryParameters() {
+        return QueryParameters.fromString(URI.create(getHref()).getQuery());
+    }
+
+    /**
+     * Gets the registered route class for the router-link.
+     * Returns an empty optional if there is no corresponding navigation target.
+     *
+     * @return an {@link Optional} containing the navigation target class or empty if not found
+     */
+    public Optional<Class<? extends Component>> getRoute() {
+        return RouteConfiguration.forSessionScope().getRoute(getPath());
+    }
+
+    /**
+     * Click the router-link for navigation.
+     *
+     * @return navigated view
+     */
+    public Component click() {
+        if (getRoute().isEmpty()) {
+            throw new IllegalStateException();
+        }
+
+        UI.getCurrent().navigate(getPath(), getQueryParameters());
+        return (Component) UI.getCurrent().getInternals()
+                .getActiveRouterTargetsChain().get(0);
+    }
+}

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000-2024 Vaadin Ltd
+ * Copyright (C) 2000-2025 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -8,16 +8,17 @@
  */
 package com.vaadin.flow.component.routerlink;
 
+import java.net.URI;
+import java.util.Optional;
+
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
-
-import java.net.URI;
-import java.util.Optional;
 
 /**
  *
@@ -32,7 +33,8 @@ public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
     /**
      * Wrap given component for testing.
      *
-     * @param component target component
+     * @param component
+     *            target component
      */
     public RouterLinkTester(T component) {
         super(component);
@@ -50,10 +52,11 @@ public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
     }
 
     /**
-     * Gets the path for the router-link.
-     * Returns an empty {@link String} if there is no corresponding navigation target.
+     * Gets the path for the router-link. Returns an empty {@link String} if
+     * there is no corresponding navigation target.
      *
-     * @return a {@link String} containing the navigation target path or empty if not present
+     * @return a {@link String} containing the navigation target path or empty
+     *         if not present
      */
     public String getPath() {
         return URI.create(getHref()).getPath();
@@ -62,17 +65,19 @@ public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
     /**
      * Gets the query parameters for the router-link.
      *
-     * @return a {@link QueryParameters} containing the navigation target's query parameters
+     * @return a {@link QueryParameters} containing the navigation target's
+     *         query parameters
      */
     public QueryParameters getQueryParameters() {
         return QueryParameters.fromString(URI.create(getHref()).getQuery());
     }
 
     /**
-     * Gets the registered route class for the router-link.
-     * Returns an empty optional if there is no corresponding navigation target.
+     * Gets the registered route class for the router-link. Returns an empty
+     * optional if there is no corresponding navigation target.
      *
-     * @return an {@link Optional} containing the navigation target class or empty if not found
+     * @return an {@link Optional} containing the navigation target class or
+     *         empty if not found
      */
     public Optional<Class<? extends Component>> getRoute() {
         return RouteConfiguration.forSessionScope().getRoute(getPath());
@@ -83,13 +88,16 @@ public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
      *
      * @return navigated view
      */
-    public Component click() {
+    public HasElement click() {
+        ensureComponentIsUsable();
+        String path = getPath();
         if (getRoute().isEmpty()) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(
+                    "Application route not found for path " + path);
         }
 
-        UI.getCurrent().navigate(getPath(), getQueryParameters());
-        return (Component) UI.getCurrent().getInternals()
-                .getActiveRouterTargetsChain().get(0);
+        UI.getCurrent().navigate(path, getQueryParameters());
+        return UI.getCurrent().getInternals().getActiveRouterTargetsChain()
+                .get(0);
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/TesterWrappers.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/TesterWrappers.java
@@ -100,6 +100,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.NotificationTester;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroupTester;
+import com.vaadin.flow.component.routerlink.RouterLinkTester;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.select.SelectTester;
 import com.vaadin.flow.component.sidenav.SideNav;
@@ -124,6 +125,7 @@ import com.vaadin.flow.component.upload.Upload;
 import com.vaadin.flow.component.upload.UploadTester;
 import com.vaadin.flow.component.virtuallist.VirtualList;
 import com.vaadin.flow.component.virtuallist.VirtualListTester;
+import com.vaadin.flow.router.RouterLink;
 
 import java.math.BigDecimal;
 
@@ -136,6 +138,10 @@ public interface TesterWrappers {
 
     default ButtonTester<Button> test(Button button) {
         return BaseUIUnitTest.internalWrap(ButtonTester.class, button);
+    }
+
+    default ChartTester<Chart> test(Chart chart) {
+        return BaseUIUnitTest.internalWrap(ChartTester.class, chart);
     }
 
     default CheckboxTester<Checkbox> test(Checkbox checkbox) {
@@ -265,6 +271,10 @@ public interface TesterWrappers {
 
     // RadioButton is package protected so no autowrap.
 
+    default RouterLinkTester<RouterLink> test(RouterLink routerLink) {
+        return BaseUIUnitTest.internalWrap(RouterLinkTester.class, routerLink);
+    }
+
     default <V> SelectTester<Select<V>, V> test(Select<V> select) {
         return BaseUIUnitTest.internalWrap(SelectTester.class, select);
     }
@@ -272,6 +282,10 @@ public interface TesterWrappers {
     default <V> SelectTester<Select<V>, V> test(Select select,
             Class<V> valueType) {
         return BaseUIUnitTest.internalWrap(SelectTester.class, select);
+    }
+
+    default SideNavTester<SideNav> test(SideNav sideNav) {
+        return BaseUIUnitTest.internalWrap(SideNavTester.class, sideNav);
     }
 
     default TabsTester<Tabs> test(Tabs tabs) {
@@ -326,7 +340,16 @@ public interface TesterWrappers {
         return BaseUIUnitTest.internalWrap(UploadTester.class, upload);
     }
 
+    default <V> VirtualListTester<VirtualList<V>, V> test(VirtualList<V> virtualList) {
+        return BaseUIUnitTest.internalWrap(VirtualListTester.class, virtualList);
+    }
+
+    default <V> VirtualListTester<VirtualList<V>, V> test(VirtualList virtualList, Class<V> itemType) {
+        return BaseUIUnitTest.internalWrap(VirtualListTester.class, virtualList);
+    }
+
     /* HTML components */
+
     default AnchorTester test(Anchor anchor) {
         return BaseUIUnitTest.internalWrap(AnchorTester.class, anchor);
     }
@@ -426,21 +449,5 @@ public interface TesterWrappers {
     default UnorderedListTester test(UnorderedList unorderedList) {
         return BaseUIUnitTest.internalWrap(UnorderedListTester.class,
                 unorderedList);
-    }
-
-    default ChartTester<Chart> test(Chart chart) {
-        return BaseUIUnitTest.internalWrap(ChartTester.class, chart);
-    }
-
-    default SideNavTester<SideNav> test(SideNav sideNav) {
-        return BaseUIUnitTest.internalWrap(SideNavTester.class, sideNav);
-    }
-
-    default <V> VirtualListTester<VirtualList<V>, V> test(VirtualList<V> virtualList) {
-        return BaseUIUnitTest.internalWrap(VirtualListTester.class, virtualList);
-    }
-
-    default <V> VirtualListTester<VirtualList<V>, V> test(VirtualList virtualList, Class<V> itemType) {
-        return BaseUIUnitTest.internalWrap(VirtualListTester.class, virtualList);
     }
 }


### PR DESCRIPTION
## Description

Adds missing `ComponentTester` for `RouterLink`. (Attempting to use `AnchorTester` in its place results in an error due to `Anchor` and `RouterLink` being different `Components`.

Tester methods include

- `getHref`
- `getPath`
- `getQueryParameters`
- `getRoute`
- `click`

Fixes #1805

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
