### PR TITLE
fix: Disable Chrome's search engine selection dialogue in LocalDriver

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/LocalDriver.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/parallel/setup/LocalDriver.java
@@ -69,6 +69,7 @@ public class LocalDriver {
             // #14319
             ChromeOptions options = new ChromeOptions();
             options.addArguments("--test-type ");
+            options.addArguments("--disable-search-engine-choice-screen");
             driver = new ChromeDriver(options);
         } else if (BrowserUtil.isSafari(desiredCapabilities)) {
             driver = new SafariDriver();


### PR DESCRIPTION
The search engine selection dialogue doesn't affect testing, or show up in screenshots, but it makes local debugging difficult by hiding content visually.