### PR TITLE
chore: bump Quarkus to 3.2

### DIFF
--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -164,6 +164,20 @@
             <version>${junit5.version}</version>
         </dependency>
 
+        <!-- Pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.14.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.14.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <!-- Using the same version as in vaadin-quarkus extension -->
-        <quarkus.version>3.0.1.Final</quarkus.version>
+        <quarkus.version>3.2.12.Final</quarkus.version>
         <junit5.version>5.9.1</junit5.version>
     </properties>
 


### PR DESCRIPTION
Aligns version with vaadin-quarkys add-on.