### PR TITLE
test: ensure Vaadin request and response are not available in access() commands

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/AsyncTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/AsyncTest.kt
@@ -70,9 +70,10 @@ internal fun DynaNodeGroup.asyncTestbatch() {
             UI.getCurrent().access {
                 expect(true) { VaadinSession.getCurrent() != null }
                 expect(true) { VaadinService.getCurrent() != null }
-                expect(true) { VaadinRequest.getCurrent() != null }
                 expect(true) { UI.getCurrent() != null }
-                expect(true) { VaadinResponse.getCurrent() != null }
+                // Request and response are never available in access() commands
+                expect(true) { VaadinRequest.getCurrent() == null }
+                expect(true) { VaadinResponse.getCurrent() == null }
             }
             MockVaadin.clientRoundtrip()
         }
@@ -131,9 +132,10 @@ internal fun DynaNodeGroup.asyncTestbatch() {
                 ui.access {
                     expect(true) { VaadinSession.getCurrent() != null }
                     expect(true) { VaadinService.getCurrent() != null }
-                    expect(true) { VaadinRequest.getCurrent() != null }
                     expect(true) { UI.getCurrent() != null }
-                    expect(true) { VaadinResponse.getCurrent() != null }
+                    // Request and response are never available in access() commands
+                    expect(true) { VaadinRequest.getCurrent() == null }
+                    expect(true) { VaadinResponse.getCurrent() == null }
                 }
             }
             MockVaadin.clientRoundtrip()

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/AsyncTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/AsyncTest.kt
@@ -70,9 +70,10 @@ internal fun DynaNodeGroup.asyncTestbatch() {
             UI.getCurrent().access {
                 expect(true) { VaadinSession.getCurrent() != null }
                 expect(true) { VaadinService.getCurrent() != null }
-                expect(true) { VaadinRequest.getCurrent() != null }
                 expect(true) { UI.getCurrent() != null }
-                expect(true) { VaadinResponse.getCurrent() != null }
+                // Request and response are never available in access() commands
+                expect(true) { VaadinRequest.getCurrent() == null }
+                expect(true) { VaadinResponse.getCurrent() == null }
             }
             MockVaadin.clientRoundtrip()
         }
@@ -131,9 +132,10 @@ internal fun DynaNodeGroup.asyncTestbatch() {
                 ui.access {
                     expect(true) { VaadinSession.getCurrent() != null }
                     expect(true) { VaadinService.getCurrent() != null }
-                    expect(true) { VaadinRequest.getCurrent() != null }
                     expect(true) { UI.getCurrent() != null }
-                    expect(true) { VaadinResponse.getCurrent() != null }
+                    // Request and response are never available in access() commands
+                    expect(true) { VaadinRequest.getCurrent() == null }
+                    expect(true) { VaadinResponse.getCurrent() == null }
                 }
             }
             MockVaadin.clientRoundtrip()


### PR DESCRIPTION
When executing access enqueued command, Flow clears all thread locals in CurrentInstance (vaadin/flow#20255), so VaadinRequest and VaadinResponse will never be available.
