### PR TITLE
upgrade failsafe/surefire plugin, selenium-jupiter version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
         <vaadin.version>24.4-SNAPSHOT</vaadin.version>
         <flow.version>${vaadin.version}</flow.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <failsafe.version>3.1.0</failsafe.version>
-        <surefire.version>3.1.0</surefire.version>
+        <failsafe.version>3.5.2</failsafe.version>
+        <surefire.version>3.5.2</surefire.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <currentYear>2023</currentYear>
     </properties>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -30,7 +30,7 @@
     </repositories>
 
     <properties>
-        <junit5.version>5.9.1</junit5.version>
+        <junit5.version>5.11.3</junit5.version>
         <mockito.version>4.8.1</mockito.version>
     </properties>
 

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -251,6 +251,8 @@
                             <systemPropertyVariables>
                                 <browsers.include>chrome</browsers.include>
                             </systemPropertyVariables>
+                            <forkCount>2</forkCount>
+                            <reuseForks>false</reuseForks>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -251,7 +251,7 @@
                             <systemPropertyVariables>
                                 <browsers.include>chrome</browsers.include>
                             </systemPropertyVariables>
-                            <forkCount>2</forkCount>
+                            <forkCount>5</forkCount>
                             <reuseForks>false</reuseForks>
                         </configuration>
                     </plugin>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>selenium-jupiter</artifactId>
-            <version>4.3.1</version>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -251,7 +251,7 @@
                             <systemPropertyVariables>
                                 <browsers.include>chrome</browsers.include>
                             </systemPropertyVariables>
-                            <forkCount>5</forkCount>
+                            <forkCount>2</forkCount>
                             <reuseForks>false</reuseForks>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
in the Junit5 IT test module, all test classes are queued in saucelab, which leads to 'flaky' test result with timeout. 
so adding the `forkCount` setting seems make it more stable.