### PR TITLE
fix: fix date/time/datetime picker tester validation

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
@@ -39,12 +39,18 @@ internal fun DynaNodeGroup.locatorTest2() {
         _expectNoDialogs() // should succeed on no dialogs
         val dlg = Dialog()
         dlg.open()
-        expectThrows(AssertionError::class,
-            """Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0: [Dialog[opened='true', virtualChildNodeIds='[]']]. Component tree:
-└── MockedUI[]
-    └── Dialog[opened='true', virtualChildNodeIds='[]']
-""") {
+        val exception = expectThrows(AssertionError::class,
+            "Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0:") {
             _expectNoDialogs()
+        }
+        expect(true) {
+            val msg = exception.message!!
+            println(msg)
+            msg.matches(""".*Too many visible Dialogs \(1\) in MockedUI\[] matching Dialog and count=0\.\.0: \[Dialog\[.*]]\. Component tree:
+└── MockedUI\[]
+\s+└── Dialog\[.*].*
+""".toRegex(RegexOption.MULTILINE)
+            )
         }
         dlg.close()
         _expectNoDialogs()

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
@@ -47,17 +47,30 @@ public class DatePickerTester<T extends DatePicker> extends ComponentTester<T> {
     public void setValue(LocalDate date) {
         ensureComponentIsUsable();
 
-        final Method isInvalid = getMethod("isInvalid", LocalDate.class);
         try {
-            if ((boolean) isInvalid.invoke(getComponent(), date)) {
+            if (isInvalid(date)) {
                 throw new IllegalArgumentException(
                         "Given date is not a valid value");
             }
-
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
 
         getComponent().setValue(date);
+    }
+
+    private boolean isInvalid(LocalDate date)
+            throws InvocationTargetException, IllegalAccessException {
+        try {
+            // Vaadin 24.4
+            final Method isInvalid = getMethod("isInvalid", LocalDate.class);
+            return (boolean) isInvalid.invoke(getComponent(), date);
+        } catch (RuntimeException ex) {
+            if (!(ex.getCause() instanceof NoSuchMethodException)) {
+                throw ex;
+            }
+        }
+        // Vaadin 24.5+
+        return getComponent().getDefaultValidator().apply(date, null).isError();
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.datetimepicker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.vaadin.testbench.unit.ComponentTester;
@@ -47,9 +48,8 @@ public class DateTimePickerTester<T extends DateTimePicker>
     public void setValue(LocalDateTime dateTime) {
         ensureComponentIsUsable();
 
-        final Method isInvalid = getMethod("isInvalid", LocalDateTime.class);
         try {
-            if ((boolean) isInvalid.invoke(getComponent(), dateTime)) {
+            if (isInvalid(dateTime)) {
                 throw new IllegalArgumentException(
                         "Given date is not a valid value");
             }
@@ -58,6 +58,21 @@ public class DateTimePickerTester<T extends DateTimePicker>
         }
 
         getComponent().setValue(dateTime);
+    }
+
+    private boolean isInvalid(LocalDateTime date)
+            throws InvocationTargetException, IllegalAccessException {
+        try {
+            // Vaadin 24.4
+            final Method isInvalid = getMethod("isInvalid", LocalDate.class);
+            return (boolean) isInvalid.invoke(getComponent(), date);
+        } catch (RuntimeException ex) {
+            if (!(ex.getCause() instanceof NoSuchMethodException)) {
+                throw ex;
+            }
+        }
+        // Vaadin 24.5+
+        return getComponent().getDefaultValidator().apply(date, null).isError();
     }
 
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.timepicker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.vaadin.testbench.unit.ComponentTester;
@@ -46,9 +47,8 @@ public class TimePickerTester<T extends TimePicker> extends ComponentTester<T> {
     public void setValue(LocalTime time) {
         ensureComponentIsUsable();
 
-        final Method isInvalid = getMethod("isInvalid", LocalTime.class);
         try {
-            if ((boolean) isInvalid.invoke(getComponent(), time)) {
+            if (isInvalid(time)) {
                 throw new IllegalArgumentException(
                         "Given time is not a valid value");
             }
@@ -57,6 +57,21 @@ public class TimePickerTester<T extends TimePicker> extends ComponentTester<T> {
         }
 
         getComponent().setValue(time);
+    }
+
+    private boolean isInvalid(LocalTime date)
+            throws InvocationTargetException, IllegalAccessException {
+        try {
+            // Vaadin 24.4
+            final Method isInvalid = getMethod("isInvalid", LocalDate.class);
+            return (boolean) isInvalid.invoke(getComponent(), date);
+        } catch (RuntimeException ex) {
+            if (!(ex.getCause() instanceof NoSuchMethodException)) {
+                throw ex;
+            }
+        }
+        // Vaadin 24.5+
+        return getComponent().getDefaultValidator().apply(date, null).isError();
     }
 
 }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/LocatorTest.kt
@@ -39,12 +39,18 @@ internal fun DynaNodeGroup.locatorTest2() {
         _expectNoDialogs() // should succeed on no dialogs
         val dlg = Dialog()
         dlg.open()
-        expectThrows(AssertionError::class,
-            """Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0: [Dialog[opened='true', virtualChildNodeIds='[]']]. Component tree:
-└── MockedUI[]
-    └── Dialog[opened='true', virtualChildNodeIds='[]']
-""") {
+        val exception = expectThrows(AssertionError::class,
+            "Too many visible Dialogs (1) in MockedUI[] matching Dialog and count=0..0:") {
             _expectNoDialogs()
+        }
+        expect(true) {
+            val msg = exception.message!!
+            println(msg)
+            msg.matches(""".*Too many visible Dialogs \(1\) in MockedUI\[] matching Dialog and count=0\.\.0: \[Dialog\[.*]]\. Component tree:
+└── MockedUI\[]
+\s+└── Dialog\[.*].*
+""".toRegex(RegexOption.MULTILINE)
+            )
         }
         dlg.close()
         _expectNoDialogs()


### PR DESCRIPTION
Validation API of Date/Time/DateTime picker has been changed since Vaadin 24.5, and the UI Unit testers are failing with recent Vaadin version. This change makes the testers compatible with all Vaadin 24 series.

Fixes #1840