### PR TITLE
chore: simplify spring dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
         <selenium.version>4.28.0</selenium.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring.version>6.0.9</spring.version>
-        <spring.security.version>6.1.0</spring.security.version>
+        <spring.boot.version>3.4.1</spring.boot.version>
         <vaadin.version>24.7-SNAPSHOT</vaadin.version>
         <flow.version>${vaadin.version}</flow.version>
         <slf4j.version>2.0.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <selenium.version>4.28.0</selenium.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring.boot.version>3.4.1</spring.boot.version>
+        <spring.boot.version>3.4.2</spring.boot.version>
         <vaadin.version>24.7-SNAPSHOT</vaadin.version>
         <flow.version>${vaadin.version}</flow.version>
         <slf4j.version>2.0.7</slf4j.version>

--- a/vaadin-testbench-unit-junit5/pom.xml
+++ b/vaadin-testbench-unit-junit5/pom.xml
@@ -312,25 +312,34 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>

--- a/vaadin-testbench-unit-junit5/pom.xml
+++ b/vaadin-testbench-unit-junit5/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <kotlin.version>1.9.20</kotlin.version>
         <dokka.version>1.9.20</dokka.version>
-        <junit5.version>5.9.1</junit5.version>
     </properties>
 
     <profiles>
@@ -288,13 +287,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit5.version}</version>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
         </dependency>
 
         <dependency>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <!-- Using the same version as in vaadin-quarkus extension -->
         <quarkus.version>3.2.12.Final</quarkus.version>
-        <junit5.version>5.9.1</junit5.version>
     </properties>
 
     <profiles>
@@ -155,13 +154,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit5.version}</version>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
         </dependency>
 
         <!-- Pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -256,6 +256,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -342,21 +349,18 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/vaadin-testbench-unit/pom.xml
+++ b/vaadin-testbench-unit/pom.xml
@@ -307,25 +307,34 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${spring.security.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>


### PR DESCRIPTION
- upgrade the outdated spring.version
- use spring-boot-dependencies bom to simplify the spring versions
- remove spring.version and spring.security.version usage