### PR TITLE
chore: upgrade servlet-api to 6.0.0

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSessionTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSessionTest.kt
@@ -90,11 +90,5 @@ class MockHttpSessionTest : DynaTest({
                 session.attributeNames
             }
         }
-        test("getValueNames() fails on invalidated session") {
-            session.invalidate()
-            expectThrows(IllegalStateException::class) {
-                session.valueNames
-            }
-        }
     }
 })

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -335,7 +335,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>6.0.0</version>
         </dependency>
 
 

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockContext.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockContext.kt
@@ -31,11 +31,6 @@ import jakarta.servlet.descriptor.JspConfigDescriptor
 import org.slf4j.LoggerFactory
 
 open class MockContext : ServletContext, Serializable {
-    override fun getServlet(name: String): Servlet? {
-        // this method is deprecated since servlet spec 2.1 and should always return null.
-        // see javadoc for more details.
-        return null
-    }
 
     override fun <T : Servlet?> createServlet(clazz: Class<T>?): T {
         throw UnsupportedOperationException("not implemented")
@@ -111,10 +106,6 @@ open class MockContext : ServletContext, Serializable {
         log.error(msg)
     }
 
-    override fun log(exception: Exception, msg: String) {
-        log.error(msg, exception)
-    }
-
     override fun log(message: String, throwable: Throwable) {
         log.error(message, throwable)
     }
@@ -138,8 +129,6 @@ open class MockContext : ServletContext, Serializable {
     override fun getFilterRegistrations(): MutableMap<String, out FilterRegistration> {
         throw UnsupportedOperationException("not implemented")
     }
-
-    override fun getServletNames(): Enumeration<String> = Collections.emptyEnumeration()
 
     override fun getDefaultSessionTrackingModes(): Set<SessionTrackingMode> = setOf(SessionTrackingMode.COOKIE, SessionTrackingMode.URL)
 
@@ -267,8 +256,6 @@ open class MockContext : ServletContext, Serializable {
     override fun addJspFile(servletName: String, jspFile: String): ServletRegistration.Dynamic {
         throw UnsupportedOperationException("not implemented")
     }
-
-    override fun getServlets(): Enumeration<Servlet> = Collections.emptyEnumeration()
 
     override fun getEffectiveMinorVersion(): Int = 0
 

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSession.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSession.kt
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import jakarta.servlet.ServletContext
 import jakarta.servlet.http.HttpSession
-import jakarta.servlet.http.HttpSessionContext
 
 /**
  * A standalone implementation of the [HttpSession] interface.
@@ -63,38 +62,24 @@ open class MockHttpSession(
 
     override fun getMaxInactiveInterval(): Int = maxInactiveInterval
 
-    override fun getSessionContext(): HttpSessionContext? = null
-
     override fun getAttribute(name: String): Any? {
         checkValid()
         return attributes[name]
     }
-
-    override fun getValue(name: String): Any? = getAttribute(name)
 
     override fun getAttributeNames(): Enumeration<String> {
         checkValid()
         return attributes.keys()
     }
 
-    override fun getValueNames(): Array<String> = attributeNames.toList().toTypedArray()
-
     override fun setAttribute(name: String, value: Any?) {
         checkValid()
         attributes.putOrRemove(name, value)
     }
 
-    override fun putValue(name: String, value: Any?) {
-        setAttribute(name, value)
-    }
-
     override fun removeAttribute(name: String) {
         checkValid()
         attributes.remove(name)
-    }
-
-    override fun removeValue(name: String) {
-        removeAttribute(name)
     }
 
     fun copyAttributes(httpSession: HttpSession): MockHttpSession {

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockRequest.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockRequest.kt
@@ -9,15 +9,10 @@
  */
 package com.vaadin.testbench.unit.mocks
 
-import java.io.BufferedReader
-import java.security.Principal
-import java.util.Collections
-import java.util.Enumeration
-import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
 import jakarta.servlet.AsyncContext
 import jakarta.servlet.DispatcherType
 import jakarta.servlet.RequestDispatcher
+import jakarta.servlet.ServletConnection
 import jakarta.servlet.ServletContext
 import jakarta.servlet.ServletInputStream
 import jakarta.servlet.ServletRequest
@@ -28,6 +23,12 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpSession
 import jakarta.servlet.http.HttpUpgradeHandler
 import jakarta.servlet.http.Part
+import java.io.BufferedReader
+import java.security.Principal
+import java.util.Collections
+import java.util.Enumeration
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 open class MockRequest(private var session: HttpSession) : HttpServletRequest {
 
@@ -60,10 +61,6 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
     override fun isAsyncStarted(): Boolean = false
 
     override fun getContentLengthLong(): Long = -1
-
-    override fun getRealPath(path: String?): String {
-        throw UnsupportedOperationException("not implemented")
-    }
 
     override fun login(username: String?, password: String?) {
         throw UnsupportedOperationException("not implemented")
@@ -116,13 +113,22 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
      */
     override fun getLocalPort(): Int = MockHttpEnvironment.localPort
 
-    override fun isRequestedSessionIdFromUrl(): Boolean = false
-
     override fun getServletContext(): ServletContext = session.servletContext
 
     override fun getQueryString(): String? = null
 
     override fun getDispatcherType(): DispatcherType = DispatcherType.REQUEST
+    override fun getRequestId(): String {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun getProtocolRequestId(): String {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun getServletConnection(): ServletConnection {
+        throw UnsupportedOperationException("not implemented")
+    }
 
     override fun getParts(): MutableCollection<Part> {
         return partsInt

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockResponse.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockResponse.kt
@@ -21,8 +21,6 @@ import jakarta.servlet.http.HttpServletResponse
 open class MockResponse : HttpServletResponse {
     override fun encodeURL(url: String): String = url
 
-    override fun encodeUrl(url: String): String = encodeURL(url)
-
     val headers: ConcurrentHashMap<String, Array<String>> = ConcurrentHashMap<String, Array<String>>()
 
     override fun addIntHeader(name: String, value: Int) {
@@ -40,8 +38,6 @@ open class MockResponse : HttpServletResponse {
     }
 
     fun findCookie(name: String): Cookie? = cookies.firstOrNull { it.name == name }
-
-    override fun encodeRedirectUrl(url: String): String = encodeRedirectURL(url)
 
     override fun flushBuffer() {
         // not needed at the moment
@@ -125,10 +121,6 @@ open class MockResponse : HttpServletResponse {
     }
 
     override fun setStatus(sc: Int) {
-        _status = sc
-    }
-
-    override fun setStatus(sc: Int, sm: String?) {
         _status = sc
     }
 

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSessionTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/mocks/MockHttpSessionTest.kt
@@ -90,11 +90,5 @@ class MockHttpSessionTest : DynaTest({
                 session.attributeNames
             }
         }
-        test("getValueNames() fails on invalidated session") {
-            session.invalidate()
-            expectThrows(IllegalStateException::class) {
-                session.valueNames
-            }
-        }
     }
 })


### PR DESCRIPTION
- upgrade servlet-api dependency
- remove deprecated apis/overwrites
reference servlet-api docs https://tomcat.apache.org/tomcat-10.0-doc/servletapi/jakarta/servlet/ServletContext.html and https://tomcat.apache.org/tomcat-11.0-doc/servletapi/jakarta/servlet/ServletContext.html