### PR TITLE
chore: use regex to assert component state

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/TestUtils.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/TestUtils.kt
@@ -9,6 +9,8 @@
  */
 package com.vaadin.testbench.unit
 
+import kotlin.reflect.KClass
+import kotlin.test.assertFailsWith
 import com.vaadin.testbench.unit.internal.allViews
 import kotlin.test.expect
 
@@ -18,6 +20,38 @@ import kotlin.test.expect
 fun <T> expectList(vararg expected: T, actual: ()->List<T>) {
     expect(expected.toList(), actual)
 }
+
+
+/**
+ * Expects that given block fails with an exception of type [clazz] (or its subtype).
+ *
+ * Note that this is different from [assertFailsWith] since this function
+ * also asserts on [Throwable.message].
+ * @param expectMessage regular expression which the [Throwable.message] must match.
+ * @throws AssertionError if the block completed successfully or threw some other exception.
+ * @return the exception thrown, so that you can assert on it.
+ */
+fun <T: Throwable> expectThrows(clazz: KClass<out T>, expectMessage: Regex, block: ()->Unit): T {
+    // tests for this function are present in the dynatest-engine project
+    val ex = assertFailsWith(clazz, block)
+    if (!(ex.message ?: "").contains(expectMessage)) {
+        throw AssertionError("${clazz.javaObjectType.name} message: Expected '$expectMessage' but was '${ex.message}'", ex)
+    }
+    return ex
+}
+
+/**
+ * Expects that given block fails with an exception of type [T] (or its subtype).
+ *
+ * Note that this is different from [assertFailsWith] since this function
+ * also asserts on [Throwable.message].
+ * @param expectMessage regular expression which the [Throwable.message] must match.
+ * @throws AssertionError if the block completed successfully or threw some other exception.
+ * @return the exception thrown, so that you can assert on it.
+ */
+inline fun <reified T: Throwable> expectThrows(expectMessage: Regex, noinline block: ()->Unit): T =
+    expectThrows(T::class, expectMessage, block)
+
 
 object TestRoutes {
     val views = allViews;

--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/BasicUtilsTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/BasicUtilsTest.kt
@@ -20,20 +20,21 @@ import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.dom.DomEvent
 import elemental.json.Json
 import kotlin.test.expect
+import com.vaadin.testbench.unit.expectThrows
 
 @DynaTestDsl
 internal fun DynaNodeGroup.basicUtilsTestbatch() {
 
     group("checkEditableByUser") {
         test("disabled textfield fails") {
-            expectThrows(java.lang.IllegalStateException::class, "The AttachedTextField[DISABLED, value=''] is not enabled") {
+            expectThrows(java.lang.IllegalStateException::class, "The AttachedTextField\\[DISABLED,.*] is not enabled".toRegex()) {
                 AttachedTextField().apply { isEnabled = false }.checkEditableByUser()
             }
         }
         test("invisible textfield fails") {
             expectThrows(
                 java.lang.IllegalStateException::class,
-                "The AttachedTextField[INVIS, value=''] is not effectively visible"
+                "The AttachedTextField\\[INVIS,.*] is not effectively visible".toRegex()
             ) {
                 AttachedTextField().apply { isVisible = false }.checkEditableByUser()
             }
@@ -41,13 +42,13 @@ internal fun DynaNodeGroup.basicUtilsTestbatch() {
         test("non attached textfield fails") {
             expectThrows(
                 java.lang.IllegalStateException::class,
-                "The TextField[value=''] is not attached"
+                "The TextField\\[.*] is not attached".toRegex()
             ) {
                 TextField().checkEditableByUser()
             }
         }
         test("textfield in invisible layout fails") {
-            expectThrows(java.lang.IllegalStateException::class, "The TextField[value=''] is not effectively visible") {
+            expectThrows(java.lang.IllegalStateException::class, "The TextField\\[.*] is not effectively visible".toRegex()) {
                 VerticalLayout().apply {
                     isVisible = false
                     textField().also { it.checkEditableByUser() }
@@ -73,7 +74,7 @@ internal fun DynaNodeGroup.basicUtilsTestbatch() {
             }
         }
         test("textfield succeeds") {
-            expectThrows(AssertionError::class, "The AttachedTextField[value=''] is editable") {
+            expectThrows(AssertionError::class, "The AttachedTextField\\[.*] is editable".toRegex()) {
                 AttachedTextField().expectNotEditableByUser()
             }
         }

--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
@@ -73,16 +73,10 @@ internal fun DynaNodeGroup.prettyPrintTreeTest() {
         }
     }
     test("toPrettyStringTextField()") {
-        expect("TextField[#25, value='']") {
-            TextField().apply { id_ = "25" }.toPrettyString()
-        }
-        expect("TextArea[label='label', value='some text']") { TextArea("label").apply { value = "some text" }.toPrettyString() }
-        expect("TextField[#25, value='', errorMessage='failed validation']") {
-            TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString()
-        }
-        expect("TextField[label='foobar', value='']") {
-            TextField("foobar").toPrettyString()
-        }
+        assertContains(TextField().apply { id_ = "25" }.toPrettyString(),"TextField\\[#25, value=''.*]".toRegex())
+        assertContains(TextArea("label").apply { value = "some text" }.toPrettyString(),"TextArea\\[label='label', value='some text'.*]".toRegex())
+        assertContains(TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString(),"TextField\\[#25, value='', errorMessage='failed validation'.*]".toRegex())
+        assertContains(TextField("foobar").toPrettyString(), "TextField\\[label='foobar', value=''.*]".toRegex() )
     }
     test("toPrettyStringButton()") {
         expect("Button[caption='click me']") { Button("click me").toPrettyString() }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/TestUtils.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/TestUtils.kt
@@ -9,6 +9,8 @@
  */
 package com.vaadin.testbench.unit
 
+import kotlin.reflect.KClass
+import kotlin.test.assertFailsWith
 import com.vaadin.testbench.unit.internal.allViews
 import kotlin.test.expect
 
@@ -18,6 +20,37 @@ import kotlin.test.expect
 fun <T> expectList(vararg expected: T, actual: ()->List<T>) {
     expect(expected.toList(), actual)
 }
+
+/**
+ * Expects that given block fails with an exception of type [clazz] (or its subtype).
+ *
+ * Note that this is different from [assertFailsWith] since this function
+ * also asserts on [Throwable.message].
+ * @param expectMessage regular expression which the [Throwable.message] must match.
+ * @throws AssertionError if the block completed successfully or threw some other exception.
+ * @return the exception thrown, so that you can assert on it.
+ */
+fun <T: Throwable> expectThrows(clazz: KClass<out T>, expectMessage: Regex, block: ()->Unit): T {
+    // tests for this function are present in the dynatest-engine project
+    val ex = assertFailsWith(clazz, block)
+    if (!(ex.message ?: "").contains(expectMessage)) {
+        throw AssertionError("${clazz.javaObjectType.name} message: Expected '$expectMessage' but was '${ex.message}'", ex)
+    }
+    return ex
+}
+
+/**
+ * Expects that given block fails with an exception of type [T] (or its subtype).
+ *
+ * Note that this is different from [assertFailsWith] since this function
+ * also asserts on [Throwable.message].
+ * @param expectMessage regular expression which the [Throwable.message] must match.
+ * @throws AssertionError if the block completed successfully or threw some other exception.
+ * @return the exception thrown, so that you can assert on it.
+ */
+inline fun <reified T: Throwable> expectThrows(expectMessage: Regex, noinline block: ()->Unit): T =
+    expectThrows(T::class, expectMessage, block)
+
 
 object TestRoutes {
     val views = allViews;

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/BasicUtilsTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/BasicUtilsTest.kt
@@ -20,20 +20,21 @@ import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.dom.DomEvent
 import elemental.json.Json
 import kotlin.test.expect
+import com.vaadin.testbench.unit.expectThrows
 
 @DynaTestDsl
 internal fun DynaNodeGroup.basicUtilsTestbatch() {
 
     group("checkEditableByUser") {
         test("disabled textfield fails") {
-            expectThrows(java.lang.IllegalStateException::class, "The AttachedTextField[DISABLED, value=''] is not enabled") {
+            expectThrows(java.lang.IllegalStateException::class, "The AttachedTextField\\[DISABLED,.*] is not enabled".toRegex()) {
                 AttachedTextField().apply { isEnabled = false }.checkEditableByUser()
             }
         }
         test("invisible textfield fails") {
             expectThrows(
                 java.lang.IllegalStateException::class,
-                "The AttachedTextField[INVIS, value=''] is not effectively visible"
+                "The AttachedTextField\\[INVIS,.*] is not effectively visible".toRegex()
             ) {
                 AttachedTextField().apply { isVisible = false }.checkEditableByUser()
             }
@@ -41,13 +42,13 @@ internal fun DynaNodeGroup.basicUtilsTestbatch() {
         test("non attached textfield fails") {
             expectThrows(
                 java.lang.IllegalStateException::class,
-                "The TextField[value=''] is not attached"
+                "The TextField\\[.*] is not attached".toRegex()
             ) {
                 TextField().checkEditableByUser()
             }
         }
         test("textfield in invisible layout fails") {
-            expectThrows(java.lang.IllegalStateException::class, "The TextField[value=''] is not effectively visible") {
+            expectThrows(java.lang.IllegalStateException::class, "The TextField\\[.*] is not effectively visible".toRegex()) {
                 VerticalLayout().apply {
                     isVisible = false
                     textField().also { it.checkEditableByUser() }
@@ -73,7 +74,7 @@ internal fun DynaNodeGroup.basicUtilsTestbatch() {
             }
         }
         test("textfield succeeds") {
-            expectThrows(AssertionError::class, "The AttachedTextField[value=''] is editable") {
+            expectThrows(AssertionError::class, "The AttachedTextField\\[.*] is editable".toRegex()) {
                 AttachedTextField().expectNotEditableByUser()
             }
         }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/PrettyPrintTreeTest.kt
@@ -73,16 +73,10 @@ internal fun DynaNodeGroup.prettyPrintTreeTest() {
         }
     }
     test("toPrettyStringTextField()") {
-        expect("TextField[#25, value='']") {
-            TextField().apply { id_ = "25" }.toPrettyString()
-        }
-        expect("TextArea[label='label', value='some text']") { TextArea("label").apply { value = "some text" }.toPrettyString() }
-        expect("TextField[#25, value='', errorMessage='failed validation']") {
-            TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString()
-        }
-        expect("TextField[label='foobar', value='']") {
-            TextField("foobar").toPrettyString()
-        }
+        assertContains(TextField().apply { id_ = "25" }.toPrettyString(),"TextField\\[#25, value=''.*]".toRegex())
+        assertContains(TextArea("label").apply { value = "some text" }.toPrettyString(),"TextArea\\[label='label', value='some text'.*]".toRegex())
+        assertContains(TextField().apply { id_ = "25"; errorMessage = "failed validation" }.toPrettyString(),"TextField\\[#25, value='', errorMessage='failed validation'.*]".toRegex())
+        assertContains(TextField("foobar").toPrettyString(), "TextField\\[label='foobar', value=''.*]".toRegex() )
     }
     test("toPrettyStringButton()") {
         expect("Button[caption='click me']") { Button("click me").toPrettyString() }


### PR DESCRIPTION
In flow-components 24.8 a new property has been added to some field components causing test failures because assertions are based on the textual representation of the component and the introduced attribute is not expected. This change updates the assertion to use a regular expression to check only the relevant part of the component representation.