### PR TITLE
fix: Focus on click

### DIFF
--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
@@ -33,6 +33,8 @@ public class BasicElementIT extends AbstractBrowserTB9Test {
 
     @BrowserTest
     public void clickingButtonWillFocusIt() {
+        TestBenchElement buttonElement = $(NativeButtonElement.class)
+                .waitForFirst();
         buttonElement.click();
         Assertions.assertTrue(buttonElement.isFocused());
     }

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
@@ -32,6 +32,12 @@ public class BasicElementIT extends AbstractBrowserTB9Test {
     }
 
     @BrowserTest
+    public void clickingButtonWillFocusIt() {
+        buttonElement.click();
+        Assertions.assertTrue(buttonElement.isFocused());
+    }
+
+    @BrowserTest
     public void getSetStringProperty() {
         TestBenchElement buttonElement = $(NativeButtonElement.class)
                 .waitForFirst();

--- a/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
+++ b/vaadin-testbench-integration-tests-junit5/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
@@ -37,6 +37,10 @@ public class BasicElementIT extends AbstractBrowserTB9Test {
                 .waitForFirst();
         buttonElement.click();
         Assertions.assertTrue(buttonElement.isFocused());
+    }
+
+    @BrowserTest
+    public void getChildrenTest() {
         TestBenchElement element = $(TestBenchElement.class).id("element-query-view");
         Assertions.assertEquals(10, element.getChildren().size());
         TestBenchElement firstChild = element.getChildren().get(0);

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
@@ -39,6 +39,10 @@ public class BasicElementIT extends AbstractTB6Test {
     public void clickingButtonWillFocusIt() {
         buttonElement.click();
         Assert.assertTrue(buttonElement.isFocused());
+    }
+
+    @Test
+    public void getChildrenTest() {
         TestBenchElement element = $(TestBenchElement.class).id("element-query-view");
         Assert.assertEquals(10, element.getChildren().size());
         TestBenchElement firstChild = element.getChildren().get(0);

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/BasicElementIT.java
@@ -36,6 +36,12 @@ public class BasicElementIT extends AbstractTB6Test {
     }
 
     @Test
+    public void clickingButtonWillFocusIt() {
+        buttonElement.click();
+        Assert.assertTrue(buttonElement.isFocused());
+    }
+
+    @Test
     public void getSetStringProperty() {
         Assert.assertNull(buttonElement.getPropertyString("foo"));
         buttonElement.setProperty("foo", "12");

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
@@ -181,8 +181,21 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
         setProperty("scrollLeft", scrollLeft);
     }
 
+    /**
+     * Checks if the current element is the focused element on the page.
+     *
+     * @return {@code true} if this element is the currently focused element,
+     *         {@code false} otherwise.
+     */
+    public boolean isFocused() {
+        return this.getWrappedElement()
+                .equals(getDriver().switchTo().activeElement());
+    }
+
     @Override
     public void click() {
+        // JS call to click does to focus element, hence ensure focus
+        focus();
         try {
             // Avoid strange "element not clickable at point" problems
             callFunction("click");

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
@@ -194,7 +194,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
 
     @Override
     public void click() {
-        // JS call to click does to focus element, hence ensure focus
+        // JS call to click does not focus element, hence ensure focus
         focus();
         try {
             // Avoid strange "element not clickable at point" problems


### PR DESCRIPTION
Mere JS call to click does not focus the element. Real life action of clicking element always focuses it. This is important if in the test story it is important that clicking Button e.g. blurs TextField, which in turn triggers value change in TextField.