### PR TITLE
feat: Switch to use a new Selenium 4 style waitUntil method (V8)

### DIFF
--- a/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
+++ b/vaadin-testbench-core/src/main/java/com/vaadin/testbench/TestBenchTestCase.java
@@ -237,9 +237,42 @@ public abstract class TestBenchTestCase
     }
 
     /**
+     * Waits the given duration for the given condition to become neither null
+     * nor false. {@link NotFoundException}s are ignored by default.
+     * <p>
+     * Use e.g. as
+     * <code>waitUntil(ExpectedConditions.presenceOfElementLocated(by), Duration.ofSeconds(10));</code>
+     *
+     * @param <T>
+     *            The condition return type.
+     * @param condition
+     *            Models a condition that might reasonably be expected to
+     *            eventually evaluate to something that is neither null nor
+     *            false.
+     * @param duration
+     *            The timeout duration for the wait.
+     * @return The condition's return value if it returned something different
+     *         from null or false before the timeout expired.
+     *
+     * @throws TimeoutException
+     *             If the timeout expires.
+     *
+     * @see FluentWait#until
+     * @see ExpectedCondition
+     */
+    protected <T> T waitUntil(ExpectedCondition<T> condition,
+            Duration duration) {
+        return new WebDriverWait(getDriver(), duration).until(condition);
+    }
+
+    /**
      * Waits the given number of seconds for the given condition to become
      * neither null nor false. {@link NotFoundException}s are ignored by
      * default.
+     * <p>
+     * This is a compatibility method that converts the timeouts given as
+     * seconds (Selenium 3 style) into timeouts given as Durations (Selenium 4
+     * style).
      * <p>
      * Use e.g. as
      * <code>waitUntil(ExpectedConditions.presenceOfElementLocated(by), 10);</code>
@@ -254,18 +287,18 @@ public abstract class TestBenchTestCase
      *            The timeout in seconds for the wait.
      * @return The condition's return value if it returned something different
      *         from null or false before the timeout expired.
-     * 
+     *
      * @throws TimeoutException
      *             If the timeout expires.
-     * 
+     *
      * @see FluentWait#until
      * @see ExpectedCondition
+     * @deprecated Use {@link #waitUntil(ExpectedCondition, Duration)} instead
      */
+    @Deprecated
     protected <T> T waitUntil(ExpectedCondition<T> condition,
             long timeoutInSeconds) {
-        return new WebDriverWait(getDriver(),
-                Duration.ofSeconds(timeoutInSeconds))
-                .until(condition);
+        return waitUntil(condition, Duration.ofSeconds(timeoutInSeconds));
     }
 
     /**
@@ -283,15 +316,15 @@ public abstract class TestBenchTestCase
      *            false.
      * @return The condition's return value if it returned something different
      *         from null or false before the timeout expired.
-     * 
+     *
      * @throws TimeoutException
      *             If 10 seconds passed.
-     * 
+     *
      * @see FluentWait#until
      * @see ExpectedCondition
      */
     protected <T> T waitUntil(ExpectedCondition<T> condition) {
-        return waitUntil(condition, 10);
+        return waitUntil(condition, Duration.ofSeconds(10));
     }
 
 }

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/AbstractTB5Test.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/AbstractTB5Test.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.time.Duration;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
@@ -163,10 +164,11 @@ public abstract class AbstractTB5Test extends ParallelTest {
     }
 
     protected void waitForDebugMessage(final String expectedMessage) {
-        waitForDebugMessage(expectedMessage, 30);
+        waitForDebugMessage(expectedMessage, Duration.ofSeconds(30));
     }
 
-    protected void waitForDebugMessage(final String expectedMessage, int timeout) {
+    protected void waitForDebugMessage(final String expectedMessage,
+            Duration timeout) {
         waitUntil(new ExpectedCondition<Boolean>() {
 
             @Override
@@ -645,7 +647,8 @@ public abstract class AbstractTB5Test extends ParallelTest {
     protected void openDebugLogTab() {
         WebElement debugLogButton = waitUntil(
                 ExpectedConditions.presenceOfElementLocated(
-                By.xpath("//button[@title='Debug message log']")), 15);
+                        By.xpath("//button[@title='Debug message log']")),
+                Duration.ofSeconds(15));
         debugLogButton.click();
     }
 


### PR DESCRIPTION
Selenium 4 uses Durations where Selenium 3 used long timeouts. Deprecate the old method (but keep it for backward compatibility), and switch to using the Selenium 4 style with Durations by default.