### PR TITLE
refactor: auto-remove overlay components with closed event

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
@@ -58,6 +58,8 @@ class ConfirmDialogTesterTest extends UIUnitTest {
 
         Assertions.assertEquals(1, close.get());
         Assertions.assertFalse(view.dialog.isOpened());
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Confirm dialog should be detached");
     }
 
     @Test
@@ -71,6 +73,8 @@ class ConfirmDialogTesterTest extends UIUnitTest {
 
         Assertions.assertEquals(1, rejects.get());
         Assertions.assertFalse(view.dialog.isOpened());
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Confirm dialog should be detached");
     }
 
     @Test
@@ -83,6 +87,8 @@ class ConfirmDialogTesterTest extends UIUnitTest {
 
         Assertions.assertEquals(1, confirm.get());
         Assertions.assertFalse(view.dialog.isOpened());
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Confirm dialog should be detached");
     }
 
     @Test

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTesterTest.java
@@ -92,6 +92,16 @@ class ConfirmDialogTesterTest extends UIUnitTest {
     }
 
     @Test
+    void programmaticallyClose_dialogIsDetached() {
+        wrap.open();
+
+        view.dialog.close();
+
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Confirm dialog should be detached");
+    }
+
+    @Test
     void headerText_getHeaderReturnsCorrect() {
         String header = "Test String";
         view.dialog.setHeader(header);

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/contextmenu/ContextMenuTesterTest.java
@@ -44,6 +44,16 @@ class ContextMenuTesterTest extends UIUnitTest {
     }
 
     @Test
+    void programmaticallyClose_menuIsDetached() {
+        test(view.menu).open();
+
+        view.menu.close();
+
+        Assertions.assertFalse(view.menu.isAttached(),
+                "context menu should be detached from the UI, but was not");
+    }
+
+    @Test
     void openMenu_alreadyOpen_throws() {
         ContextMenuTester<ContextMenu> menu_ = test(view.menu);
         menu_.open();

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
@@ -46,6 +46,16 @@ class DialogTesterTest extends UIUnitTest {
     }
 
     @Test
+    void programmaticallyClose_dialogIsDetached() {
+        dialog_.open();
+
+        view.dialog.close();
+
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Dialog should be detached on close");
+    }
+
+    @Test
     void modalDialog_blocksUIComponents() {
         dialog_.open();
         ButtonTester<Button> button_ = test(view.button);

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
@@ -33,10 +33,16 @@ class DialogTesterTest extends UIUnitTest {
     }
 
     @Test
-    void dialogOpen_dialogIsUsable() {
+    void openAndClose_dialogIsAttachedAndDetached() {
         dialog_.open();
         Assertions.assertTrue(dialog_.isUsable(),
                 "Dialog should be attached on open");
+
+        dialog_.close();
+        Assertions.assertFalse(dialog_.isUsable(),
+                "Dialog should not be usable after close");
+        Assertions.assertFalse(view.dialog.isAttached(),
+                "Dialog should be detached on close");
     }
 
     @Test

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
@@ -43,6 +43,17 @@ class NotificationTesterTest extends UIUnitTest {
     }
 
     @Test
+    void programmaticallyClose_notificationIsDetached() {
+        Notification notification = Notification.show("Some text");
+        roundTrip();
+
+        notification.close();
+
+        Assertions.assertFalse(notification.isAttached(),
+                "Notification should not be attached after close");
+    }
+
+    @Test
     void notOpenedNotification_isNotUsable() {
         Notification notification = new Notification("Not Opened");
 

--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/notification/NotificationTesterTest.java
@@ -27,6 +27,22 @@ class NotificationTesterTest extends UIUnitTest {
     }
 
     @Test
+    void showAndAutoClose_attachedAndDetached() {
+        Notification notification = Notification.show("Some text");
+        roundTrip();
+
+        Assertions.assertTrue(notification.isAttached(),
+                "Notification should be attached after show");
+
+        NotificationTester<?> notification_ = test(NotificationTester.class,
+                notification);
+        notification_.autoClose();
+
+        Assertions.assertFalse(notification.isAttached(),
+                "Notification should not be attached after auto-close");
+    }
+
+    @Test
     void notOpenedNotification_isNotUsable() {
         Notification notification = new Notification("Not Opened");
 

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
@@ -44,6 +44,7 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.ConfirmEvent(getComponent(), true));
         getComponent().close();
+        fireDomEvent("closed");
     }
 
     /**
@@ -61,6 +62,7 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.CancelEvent(getComponent(), true));
         getComponent().close();
+        fireDomEvent("closed");
     }
 
     /**
@@ -78,6 +80,7 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.RejectEvent(getComponent(), true));
         getComponent().close();
+        fireDomEvent("closed");
     }
 
     /**

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
@@ -44,7 +44,6 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.ConfirmEvent(getComponent(), true));
         getComponent().close();
-        fireDomEvent("closed");
     }
 
     /**
@@ -62,7 +61,6 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.CancelEvent(getComponent(), true));
         getComponent().close();
-        fireDomEvent("closed");
     }
 
     /**
@@ -80,7 +78,6 @@ public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {
         ComponentUtil.fireEvent(getComponent(),
                 new ConfirmDialog.RejectEvent(getComponent(), true));
         getComponent().close();
-        fireDomEvent("closed");
     }
 
     /**

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
@@ -65,7 +65,6 @@ public class ContextMenuTester<T extends ContextMenu>
     public void close() {
         ensureComponentIsUsable();
         getComponent().getElement().setProperty("opened", false);
-        fireDomEvent("closed");
     }
 
     /**

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
@@ -56,7 +56,6 @@ public class ContextMenuTester<T extends ContextMenu>
         attachMenuToUI();
         roundTrip();
         getComponent().getElement().setProperty("opened", true);
-        fireDomEvent("opened-changed");
         ensureComponentIsUsable();
     }
 
@@ -66,7 +65,7 @@ public class ContextMenuTester<T extends ContextMenu>
     public void close() {
         ensureComponentIsUsable();
         getComponent().getElement().setProperty("opened", false);
-        fireDomEvent("opened-changed");
+        fireDomEvent("closed");
     }
 
     /**

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
@@ -36,6 +36,7 @@ public class DialogTester extends ComponentTester<Dialog> {
      */
     public void close() {
         getComponent().close();
+        fireDomEvent("closed");
         roundTrip();
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
@@ -36,7 +36,5 @@ public class DialogTester extends ComponentTester<Dialog> {
      */
     public void close() {
         getComponent().close();
-        fireDomEvent("closed");
-        roundTrip();
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
@@ -70,8 +70,6 @@ public class NotificationTester<T extends Notification>
             throw new IllegalStateException("Auto-close is not enabled");
         }
         getComponent().close();
-        fireDomEvent("closed");
-        roundTrip();
     }
 
     @Override

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
@@ -70,7 +70,7 @@ public class NotificationTester<T extends Notification>
             throw new IllegalStateException("Auto-close is not enabled");
         }
         getComponent().close();
-        fireOpenChangedDomEvent();
+        fireDomEvent("closed");
         roundTrip();
     }
 
@@ -93,12 +93,5 @@ public class NotificationTester<T extends Notification>
         if (component.isOpened()) {
             collector.accept("not opened");
         }
-    }
-
-    // Simulate browser event fired when notification is closed
-    private void fireOpenChangedDomEvent() {
-        Element element = getComponent().getElement();
-        element.getNode().getFeature(ElementListenerMap.class).fireEvent(
-                new DomEvent(element, "open-changed", Json.createObject()));
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
@@ -27,11 +27,15 @@ import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.checkbox.Checkbox
 import com.vaadin.flow.component.checkbox.CheckboxGroup
 import com.vaadin.flow.component.combobox.ComboBox
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog
+import com.vaadin.flow.component.contextmenu.ContextMenu
 import com.vaadin.flow.component.datepicker.DatePicker
+import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.formlayout.FormLayout
 import com.vaadin.flow.component.grid.Grid
-import com.vaadin.flow.component.html.Input
 import com.vaadin.flow.component.listbox.ListBoxBase
+import com.vaadin.flow.component.login.LoginOverlay
+import com.vaadin.flow.component.notification.Notification
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup
 import com.vaadin.flow.component.select.Select
 import com.vaadin.flow.component.sidenav.SideNav
@@ -371,6 +375,29 @@ var Component.caption: String
             else -> label = value
         }
     }
+
+/**
+ * Sets up an event listener for overlay components that fires a `closed` DOM
+ * event when the component is closed. This simulates the event being fired
+ * from the browser after the closing animation has finished.
+ */
+fun Component.setupClosedEventMock() {
+    if (this !is Dialog && this !is ConfirmDialog && this !is LoginOverlay && this !is ContextMenu && this !is Notification) {
+        return
+    }
+
+    if (ComponentUtil.getData(this, "hasClosedEventMock") != null) {
+        return
+    }
+
+    ComponentUtil.setData(this, "hasClosedEventMock", true)
+
+    element.addPropertyChangeListener("opened") { event ->
+        if (event.value == false) {
+            _fireDomEvent("closed")
+        }
+    }
+}
 
 /**
  * The Button's caption. Alias for [Button.getText].

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/ComponentUtils.kt
@@ -10,7 +10,6 @@
 package com.vaadin.testbench.unit.internal
 
 import java.lang.reflect.Method
-import kotlin.streams.toList
 import com.vaadin.flow.component.ClickEvent
 import com.vaadin.flow.component.ClickNotifier
 import com.vaadin.flow.component.Component
@@ -381,20 +380,18 @@ var Component.caption: String
  * event when the component is closed. This simulates the event being fired
  * from the browser after the closing animation has finished.
  */
-fun Component.setupClosedEventMock() {
-    if (this !is Dialog && this !is ConfirmDialog && this !is LoginOverlay && this !is ContextMenu && this !is Notification) {
+fun Component.simulateClosedEvent() {
+    if (ComponentUtil.getData(this, "hasSimulatedClosedEvent") != null) {
         return
     }
-
-    if (ComponentUtil.getData(this, "hasClosedEventMock") != null) {
-        return
-    }
-
-    ComponentUtil.setData(this, "hasClosedEventMock", true)
-
-    element.addPropertyChangeListener("opened") { event ->
-        if (event.value == false) {
-            _fireDomEvent("closed")
+    when (this) {
+        is Dialog, is ConfirmDialog, is LoginOverlay, is ContextMenu, is Notification -> {
+            ComponentUtil.setData(this, "hasSimulatedClosedEvent", true)
+            element.addPropertyChangeListener("opened") { event ->
+                if (event.value == false) {
+                    _fireDomEvent("closed")
+                }
+            }
         }
     }
 }

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference
 import com.vaadin.flow.router.NavigationTrigger
 import com.vaadin.flow.router.QueryParameters
 import com.vaadin.flow.router.Location
+import com.vaadin.testbench.unit.internal.setupClosedEventMock
 
 
 /**
@@ -36,6 +37,12 @@ open class MockedUI : UI() {
             }))
         }
         roundTrip();
+    }
+
+    override fun addToModalComponent(component: Component?) {
+        super.addToModalComponent(component)
+
+        component?.setupClosedEventMock()
     }
 
     override fun navigate(locationString: String, queryParameters: QueryParameters) {

--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/mocks/MockedUI.kt
@@ -9,7 +9,6 @@
  */
 package com.vaadin.testbench.unit.mocks
 
-import java.lang.reflect.Method
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.ComponentEventListener
 import com.vaadin.flow.component.UI
@@ -18,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference
 import com.vaadin.flow.router.NavigationTrigger
 import com.vaadin.flow.router.QueryParameters
 import com.vaadin.flow.router.Location
-import com.vaadin.testbench.unit.internal.setupClosedEventMock
+import com.vaadin.testbench.unit.internal.simulateClosedEvent
 
 
 /**
@@ -41,8 +40,7 @@ open class MockedUI : UI() {
 
     override fun addToModalComponent(component: Component?) {
         super.addToModalComponent(component)
-
-        component?.setupClosedEventMock()
+        component?.simulateClosedEvent()
     }
 
     override fun navigate(locationString: String, queryParameters: QueryParameters) {


### PR DESCRIPTION
## Description

In v25 overlay components such as Dialog, ConfirmDialog, etc. have been refactored to wait for the `closed` event before removing themselves from the UI, which is required to wait for the overlays closing animation for finish.

This updates `MockedUI` so that it registers a listener on overlay components that automatically fires the event when the `opened` property changes to `false`, which simulates what would happen when using the component in a browser.

## Type of change

- Refactoring