### PR TITLE
chore: Update license-checker version to 2.0.0-beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>2.0.0-alpha3</version>
+                <version>2.0.0-beta2</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>2.0.0-beta2</version>
+                <version>2.0.0-beta4</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBench.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBench.java
@@ -21,6 +21,8 @@ import javassist.util.proxy.ProxyFactory;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.pro.licensechecker.Capabilities;
+import com.vaadin.pro.licensechecker.Capability;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 import com.vaadin.testbench.commands.TestBenchCommandExecutor;
 import com.vaadin.testbench.screenshot.ImageComparison;
@@ -32,7 +34,8 @@ public class TestBench {
 
     static {
         LicenseChecker.checkLicenseFromStaticBlock("vaadin-testbench",
-                TestBenchVersion.testbenchVersion, null);
+                TestBenchVersion.testbenchVersion, null,
+                Capabilities.of(Capability.PRE_TRIAL));
         // Enable the Java 11+ HTTP client
         System.setProperty("webdriver.http.factory", "jdk-http-client");
     }

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchVersion.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchVersion.java
@@ -14,6 +14,8 @@ import org.openqa.selenium.BuildInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.pro.licensechecker.Capabilities;
+import com.vaadin.pro.licensechecker.Capability;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 
 public class TestBenchVersion {
@@ -42,7 +44,7 @@ public class TestBenchVersion {
         }
 
         LicenseChecker.checkLicenseFromStaticBlock("vaadin-testbench",
-                testbenchVersion, null);
+                testbenchVersion, null, Capabilities.of(Capability.PRE_TRIAL));
     }
 
     private static Logger getLogger() {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -37,6 +37,8 @@ import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.pro.licensechecker.Capabilities;
+import com.vaadin.pro.licensechecker.Capability;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 import com.vaadin.testbench.unit.internal.MockInternalSeverError;
 import com.vaadin.testbench.unit.internal.MockVaadin;
@@ -79,7 +81,8 @@ public abstract class BaseUIUnitTest {
         }
 
         LicenseChecker.checkLicenseFromStaticBlock("vaadin-testbench",
-                properties.getProperty("testbench.version"), null);
+                properties.getProperty("testbench.version"), null,
+                Capabilities.of(Capability.PRE_TRIAL));
     }
 
     private static Map<Class<?>, Class<? extends ComponentTester>> scanForTesters(


### PR DESCRIPTION
Updates to latest LC 2.0 and uses pre-trial for TestBench so that it can be used once the pre-trial is started by user.