### PR TITLE
fix: Remove parent from BOM

### DIFF
--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -1,11 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.vaadin</groupId>
-        <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
-    </parent>
+    <groupId>com.vaadin</groupId>
+    <version>10.0-SNAPSHOT</version>
     <artifactId>vaadin-testbench-bom</artifactId>
     <packaging>pom</packaging>
     <name>Vaadin Testbench (Bill of Materials)</name>


### PR DESCRIPTION
A bom must not include the parent as the parent defines dependencies for the TestBench project and they will leak into the bom
