### PR TITLE
chore: Add GitHub Actions workflow for PR validation (#2038)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Tests and Generate Javadoc
         run: |
           mvn javadoc:javadoc verify \
-            -P verify-only-phantom,validation \
+            -P validation \
             -Dvaadin.testbench.developer.license=${{ secrets.TB8_LICENSE }} \
             -Dtestbench.javadocs \
             -Dsystem.com.vaadin.testbench.Parameters.testsInParallel=5 \

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -243,7 +243,7 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>verify-only-phantom</id>
+            <id>validation</id>
             <build>
                 <plugins>
                     <plugin>
@@ -251,7 +251,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <browsers.include>phantomjs2</browsers.include>
+                                <browsers.include>chrome</browsers.include>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/VaadinBrowserFactory.java
+++ b/vaadin-testbench-integration-tests/src/test/java/com/vaadin/tests/elements/VaadinBrowserFactory.java
@@ -28,7 +28,7 @@ public class VaadinBrowserFactory extends DefaultBrowserFactory {
 
     private static Map<Browser, String> defaultBrowserVersion = new HashMap<Browser, String>();
     static {
-        defaultBrowserVersion.put(Browser.CHROME, "40");
+        defaultBrowserVersion.put(Browser.CHROME, "141");
         defaultBrowserVersion.put(Browser.PHANTOMJS, "1");
         defaultBrowserVersion.put(Browser.SAFARI, "7");
         defaultBrowserVersion.put(Browser.IE11, "11");
@@ -37,7 +37,7 @@ public class VaadinBrowserFactory extends DefaultBrowserFactory {
 
     private static Map<Browser, Platform> defaultBrowserPlatform = new HashMap<Browser, Platform>();
     static {
-        defaultBrowserPlatform.put(Browser.CHROME, Platform.VISTA);
+        defaultBrowserPlatform.put(Browser.CHROME, Platform.ANY);
         defaultBrowserPlatform.put(Browser.PHANTOMJS, Platform.LINUX);
         defaultBrowserPlatform.put(Browser.SAFARI, Platform.MAC);
         defaultBrowserPlatform.put(Browser.IE11, Platform.WINDOWS);


### PR DESCRIPTION
* chore: Add GitHub Actions workflow for PR validation (#2007)

* chore: Add GitHub Actions workflow for PR validation

Replaces TeamCity PR validation build with GitHub Actions workflow. Includes Maven build, test execution with Sauce Labs integration, and artifact collection for test failures.

🤖 Generated with [Claude Code](https://claude.ai/code)



* Update validation.yml

* fix: Update Sauce Connect to v5.x and configure PRO_KEY environment variable

- Upgrade Sauce Connect from 4.9.2 to 5.2.0
- Update command-line arguments to use new v5 syntax (--username, --access-key, --tunnel-name)
- Configure TB_LICENSE secret as PRO_KEY environment variable
- Remove inline license parameter from Maven command

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Correct Sauce Connect 5.x download URL format

- Fix URL to include version in path: /sauce-connect/{VERSION}/sauce-connect-{VERSION}_linux.x86_64.tar.gz
- Update to latest version 5.2.3
- Fix extracted directory path (./sauce-connect/sc instead of ./sauce-connect-{VERSION}/sc)

🤖 Generated with [Claude Code](https://claude.ai/code)



* refactor: Merge format-check workflow into validation workflow

- Add format-check job to validation workflow to run in parallel with build-and-test
- Remove separate format-check.yml workflow file
- Format validation now runs as part of the main PR validation pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)



* feat: Add Maven cache to format-check job

- Add Maven dependency caching to format-check job
- Uses same cache key as build-and-test job for artifact sharing
- Prevents redundant downloads between parallel jobs

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Run format-check and build-and-test jobs sequentially

- Add 'needs: format-check' to build-and-test job
- Ensures proper cache sharing between jobs
- Prevents cache conflicts and race conditions
- Format check must pass before build and tests run

🤖 Generated with [Claude Code](https://claude.ai/code)



* chore: set TB License

* fix: Correct Sauce Connect binary path for version 5.x

The extracted directory structure for Sauce Connect 5.x is sc-${VERSION}-linux/bin/sc, not sauce-connect/sc

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Improve Sauce Connect setup and monitoring

- Use hardcoded version in path (5.2.3) instead of variable expansion
- Wait for specific "Sauce Connect is up" message instead of sleeping
- Fail fast if SC process dies or doesn't start within 2 minutes
- Save PID for proper cleanup
- Include SC logs in failure artifacts for debugging

🤖 Generated with [Claude Code](https://claude.ai/code)



* Fix version

* refactor: Use official sauce-connect-action v3 instead of manual setup

- Replace manual Sauce Connect download and setup with saucelabs/sauce-connect-action@v3
- Remove manual cleanup step as the action handles it automatically
- Simplify tunnel ID management
- Remove sc.log from artifacts as it's not generated with the action

🤖 Generated with [Claude Code](https://claude.ai/code)



* use existing version, see https://github.com/saucelabs/sauce-connect-action/issues/101

* Secrets

* .

* region

* fix: Separate error screenshots into their own artifact

Split test artifacts into two separate uploads:
- error-screenshots: Contains only screenshot files from test failures
- test-reports: Contains surefire and failsafe reports

This makes it easier to find and download just the screenshots when debugging failures.

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Enable localhost proxying for Sauce Connect tunnel

Add --proxy-localhost flag to allow Sauce Labs to connect to localhost addresses, which is required for the test setup.

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Use correct proxyLocalhost parameter for Sauce Connect

Replace scArgs with the proper proxyLocalhost: allow parameter to enable localhost proxying in Sauce Connect tunnel.

🤖 Generated with [Claude Code](https://claude.ai/code)



* no phantomjs

* fix: Exclude failsafe-summary.xml from test result parsing

Change file patterns to only include TEST-*.xml files, excluding failsafe-summary.xml which is not in JUnit XML format and causes the test result publisher to fail.

🤖 Generated with [Claude Code](https://claude.ai/code)



* upgrade java version to 21 and remove master branch

---------






* chore: cherry pick the Github Action configuration to 5.4

* add TB license

---------

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
