### PR TITLE
fix: fix compilation errors caused by upload handling changes

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/upload/AssertingTransferProgressListener.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/upload/AssertingTransferProgressListener.java
@@ -142,8 +142,7 @@ class AssertingTransferProgressListener implements TransferProgressListener {
             UploadEvent newEvent = new UploadEvent(event.getRequest(),
                     event.getResponse(), event.getSession(),
                     event.getFileName(), event.getFileSize(),
-                    event.getContentType(), event.getOwningElement(), null,
-                    null) {
+                    event.getContentType(), event.getOwningElement(), null) {
                 @Override
                 public InputStream getInputStream() {
                     return new InputStream() {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
@@ -33,10 +33,10 @@ import com.vaadin.flow.server.StreamVariable;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.communication.TransferUtil;
 import com.vaadin.flow.server.communication.streaming.StreamingEndEventImpl;
 import com.vaadin.flow.server.communication.streaming.StreamingErrorEventImpl;
 import com.vaadin.flow.server.communication.streaming.StreamingStartEventImpl;
-import com.vaadin.flow.server.streams.TransferUtil;
 import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.testbench.unit.ComponentTester;
@@ -306,7 +306,7 @@ public class UploadTester<T extends Upload> extends ComponentTester<T> {
         UploadEvent event = new UploadEvent(VaadinRequest.getCurrent(),
                 VaadinResponse.getCurrent(), VaadinSession.getCurrent(),
                 item.fileName, contentLength, item.contentType,
-                getComponent().getElement(), null, null) {
+                getComponent().getElement(), null) {
             @Override
             public InputStream getInputStream() {
                 return inputStream;


### PR DESCRIPTION
Fixes the compilation error cause by refactoring of the upload handling API in Flow (vaadin/flow#22641). The Flow PR introduced a couple of breaking changes, like removing commons-fileupload2 API from a UploadEvent constructor and moving TransferUtil in a different package.
