### PR TITLE
fix: Remove click() from CheckboxTester

### DIFF
--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
@@ -54,6 +54,6 @@ public class CheckboxTester<T extends Checkbox> extends ComponentTester<T> {
     public void click(int button, MetaKeys metaKeys) {
         super.click(button, metaKeys);
         T checkbox = getComponent();
-        checkbox.setValue(!checkbox.getValue());
+        setValueAsUser(!checkbox.getValue());
     }
 }


### PR DESCRIPTION
CheckboxTester inherits correctly implemented click() method already.

fixes #2078 