### PR TITLE
chore: change license-checker to provided scope

### DIFF
--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -210,6 +210,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -177,6 +177,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -281,6 +281,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Changes license-checker compile scope to provided to ensure that production package doesn't include transitive `license-checker` dependency via `test` scoped testbench dependency, when it's also added transitively via `optional` `vaadin-dev` dependency.

This would be breaking change for those setups that uses testbench for production package but don't have license-checker dependency directly or transitive in other manners. Fix is to add license-checker directly or via `optional` `vaadin-dev`.