### PR TITLE
fix: Register UI to VaadinSession

### DIFF
--- a/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/MockVaadin.kt
+++ b/vaadin-testbench-unit-shared/src/main/kotlin/com/vaadin/testbench/unit/internal/MockVaadin.kt
@@ -260,7 +260,7 @@ object MockVaadin {
         ui.internals.session = session
         UI.setCurrent(ui)
         ui.doInit(request, 1, "ROOT")
-        vaadinSession.addUI(ui)
+        session.addUI(ui)
         strongRefUI.set(ui)
 
         session.addUI(ui)


### PR DESCRIPTION
Without this VaadinSession.getCurrent().getUIs() returns a wrong value.

fixes https://github.com/vaadin/testbench/issues/2099