### PR TITLE
fix: limit pull_request_target to main branch only

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The workflow was triggering for PRs targeting any branch, causing PRs to 9.5 branch to run main's spotless:check instead of 9.5's formatter:validate.

