### PR TITLE
Add getHeaderTitle() method to DialogTester

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/vaadin/flow/component/dialog/DialogTesterTest.java
@@ -88,4 +88,15 @@ class DialogTesterTest extends UIUnitTest {
                 "Non-modal dialog should not block button");
     }
 
+    @Test
+    void headerTitle_getHeaderTitleReturnsCorrect() {
+        String title = "Test Title";
+        view.dialog.setHeaderTitle(title);
+
+        dialog_.open();
+
+        Assertions.assertEquals(title, dialog_.getHeaderTitle(),
+                "Dialog header title should match");
+    }
+
 }

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
@@ -37,4 +37,13 @@ public class DialogTester extends ComponentTester<Dialog> {
     public void close() {
         getComponent().close();
     }
+
+    /**
+     * Gets the title set for the dialog header.
+     *
+     * @return the header title or an empty string if not defined
+     */
+    public String getHeaderTitle() {
+        return getComponent().getHeaderTitle();
+    }
 }


### PR DESCRIPTION
Adds support for retrieving the header title from Dialog components during unit testing.

## Changes
- Added `getHeaderTitle()` method to `DialogTester` class
- Added test case `headerTitle_getHeaderTitleReturnsCorrect()` to verify functionality

## Implementation
The method delegates to the underlying `Dialog.getHeaderTitle()` method, following the same pattern as other tester classes like `ConfirmDialogTester.getHeader()`.

Fixes #1880