### PR TITLE
chore: bump project to 10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-testbench-parent</artifactId>
     <packaging>pom</packaging>
-    <version>10.0-SNAPSHOT</version>
+    <version>10.1-SNAPSHOT</version>
     <name>Vaadin TestBench parent</name>
 
     <organization>
@@ -38,8 +38,8 @@
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <spring.boot.version>4.0.0</spring.boot.version>
-        <vaadin.version>25.0-SNAPSHOT</vaadin.version>
-        <flow.version>25.0-SNAPSHOT</flow.version>
+        <vaadin.version>25.1-SNAPSHOT</vaadin.version>
+        <flow.version>25.1-SNAPSHOT</flow.version>
         <slf4j.version>2.0.7</slf4j.version>
         <jetty.version>12.1.3</jetty.version>
         <failsafe.version>3.5.2</failsafe.version>

--- a/testing-support/uiunit-component-testers/pom.xml
+++ b/testing-support/uiunit-component-testers/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing-support/uiunit-test-components/pom.xml
+++ b/testing-support/uiunit-test-components/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-bom</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core-junit5</artifactId>

--- a/vaadin-testbench-core-junit6/pom.xml
+++ b/vaadin-testbench-core-junit6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core-junit6</artifactId>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core</artifactId>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests-junit5</artifactId>

--- a/vaadin-testbench-integration-tests-junit6/pom.xml
+++ b/vaadin-testbench-integration-tests-junit6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests-junit6</artifactId>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests</artifactId>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-shared</artifactId>

--- a/vaadin-testbench-unit-junit5/pom.xml
+++ b/vaadin-testbench-unit-junit5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-junit5</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-junit5/src/test/java/com/example/base/signals/SignalsView.java
+++ b/vaadin-testbench-unit-junit5/src/test/java/com/example/base/signals/SignalsView.java
@@ -15,8 +15,8 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
-import com.vaadin.signals.NumberSignal;
 import com.vaadin.signals.Signal;
+import com.vaadin.signals.shared.SharedNumberSignal;
 
 @Route(value = "signals")
 public class SignalsView extends Div {
@@ -27,12 +27,12 @@ public class SignalsView extends Div {
     public final Span counter;
     public final Span asyncCounter;
     public final Span asyncWithDelayCounter;
-    public final NumberSignal numberSignal;
-    public final NumberSignal asyncNumberSignal;
-    public final NumberSignal asyncWithDelayNumberSignal;
+    public final SharedNumberSignal numberSignal;
+    public final SharedNumberSignal asyncNumberSignal;
+    public final SharedNumberSignal asyncWithDelayNumberSignal;
 
     public SignalsView() {
-        numberSignal = new NumberSignal();
+        numberSignal = new SharedNumberSignal();
 
         Signal<String> computedSignal = numberSignal
                 .mapIntValue(counter -> "Counter: " + counter);
@@ -41,13 +41,13 @@ public class SignalsView extends Div {
         counter = new Span("Counter: -");
         ComponentEffect.bind(counter, computedSignal, Span::setText);
 
-        asyncNumberSignal = new NumberSignal();
+        asyncNumberSignal = new SharedNumberSignal();
         Signal<String> asyncComputedSignal = asyncNumberSignal
                 .mapIntValue(counter -> "Counter: " + counter);
         asyncCounter = new Span("Counter: -");
         ComponentEffect.bind(asyncCounter, asyncComputedSignal, Span::setText);
 
-        asyncWithDelayNumberSignal = new NumberSignal();
+        asyncWithDelayNumberSignal = new SharedNumberSignal();
         asyncWithDelayCounter = new Span("Counter: -");
 
         quickBackgroundTaskButton = new NativeButton("Quick background task",

--- a/vaadin-testbench-unit-junit6/pom.xml
+++ b/vaadin-testbench-unit-junit6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-unit-junit6</artifactId>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-quarkus</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-shared</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit/pom.xml
+++ b/vaadin-testbench-unit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>10.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
Bumps the project to 10.1 for better handling breaking changes introduced by signals in Vaadin 25.1
