### PR TITLE
chore: update project to 9.6

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,7 +3,7 @@ name: TestBench Validation
 on:
   push:
     branches:
-      - "9.5"
+      - "9.6"
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-testbench-parent</artifactId>
     <packaging>pom</packaging>
-    <version>9.5-SNAPSHOT</version>
+    <version>9.6-SNAPSHOT</version>
     <name>Vaadin TestBench parent</name>
 
     <organization>
@@ -37,8 +37,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <spring.boot.version>3.5.0</spring.boot.version>
-        <vaadin.version>24.9-SNAPSHOT</vaadin.version>
-        <flow.version>24.9-SNAPSHOT</flow.version>
+        <vaadin.version>24.10-SNAPSHOT</vaadin.version>
+        <flow.version>24.10-SNAPSHOT</flow.version>
         <slf4j.version>2.0.7</slf4j.version>
         <failsafe.version>3.5.2</failsafe.version>
         <surefire.version>3.5.2</surefire.version>
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>2.0.0</version>
+                <version>3.0.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-bom</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core-junit5</artifactId>

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
@@ -8,9 +8,9 @@
  */
 package com.vaadin.testbench;
 
-import java.io.IOException;
+import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -20,7 +20,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -528,8 +527,9 @@ public abstract class AbstractBrowserTestBase
         private static String loadDndScript(String scriptLocation) {
             InputStream stream = AbstractBrowserTestBase.class
                     .getResourceAsStream(scriptLocation);
-            return IOUtils.readLines(stream, StandardCharsets.UTF_8).stream()
-                    .collect(Collectors.joining("\n"));
+            return new BufferedReader(
+                    new InputStreamReader(stream, StandardCharsets.UTF_8))
+                            .lines().collect(Collectors.joining("\n"));
         }
     }
 

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core</artifactId>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests-junit5</artifactId>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests</artifactId>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-shared</artifactId>

--- a/vaadin-testbench-unit-junit5/pom.xml
+++ b/vaadin-testbench-unit-junit5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-junit5</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-quarkus</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-shared</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit/pom.xml
+++ b/vaadin-testbench-unit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>9.5-SNAPSHOT</version>
+        <version>9.6-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
Updates TestBench to 9.6 to support Vaadin 24.10 and License Checker 3.0

DO NOT MERGE:
This PR is made only to ensure validation passes.
The changes will be directly pushed to the 9.6 branch