### PR TITLE
fix: Failing test should fail recording

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RecordMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RecordMojo.java
@@ -336,8 +336,9 @@ public class K6RecordMojo extends AbstractK6Mojo {
                     + Files.size(harPath) + " bytes)");
 
             if (!testSuccess) {
-                getLog().warn(
-                        "TestBench test may have failed, but HAR was recorded. Continuing with conversion...");
+                throw new MojoExecutionException(
+                        "TestBench test '" + currentTestClass
+                                + "' failed. Fix the test before recording.");
             }
 
             // Step 4: Filter external domains
@@ -413,12 +414,17 @@ public class K6RecordMojo extends AbstractK6Mojo {
 
             Process process = pb.start();
 
-            // Stream output
+            // Stream output and detect test failures/errors
+            boolean hasTestFailures = false;
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(process.getInputStream()))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     getLog().info("[test] " + line);
+                    if (line.contains("[ERROR] Failures:")
+                            || line.contains("[ERROR] Errors:")) {
+                        hasTestFailures = true;
+                    }
                 }
             }
 
@@ -433,6 +439,10 @@ public class K6RecordMojo extends AbstractK6Mojo {
             int exitCode = process.exitValue();
             if (exitCode != 0) {
                 getLog().warn("TestBench test exited with code: " + exitCode);
+                return false;
+            }
+
+            if (hasTestFailures) {
                 return false;
             }
 


### PR DESCRIPTION
If a recording test fails on
Failure or Error the recording
should stop on an exception.
