### PR TITLE
fix: ignore browser paths

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarFilter.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarFilter.java
@@ -52,6 +52,16 @@ public class HarFilter {
     static final Set<String> K6_SUPPORTED_METHODS = Set.of("GET", "POST", "PUT",
             "PATCH", "DELETE", "HEAD", "OPTIONS");
 
+    /**
+     * URL paths that browsers request automatically and that are not part of
+     * meaningful application load. Filtered out regardless of response status —
+     * even when the server serves them they are per-page constant traffic that
+     * adds no useful signal, and 404s from them pollute error reports.
+     */
+    private static final Set<String> BROWSER_NOISE_PATHS = Set.of(
+            "/favicon.ico", "/apple-touch-icon.png",
+            "/apple-touch-icon-precomposed.png");
+
     private static final Logger log = Logger
             .getLogger(HarFilter.class.getName());
     private final ObjectMapper objectMapper;
@@ -130,6 +140,11 @@ public class HarFilter {
                     log.fine("  Filtered WebSocket upgrade: " + url);
                     continue;
                 }
+                // Filter browser noise (favicon.ico etc.)
+                if (isBrowserNoise(url)) {
+                    log.fine("  Filtered browser noise: " + url);
+                    continue;
+                }
             }
             filteredEntries.add(entry);
         }
@@ -186,6 +201,22 @@ public class HarFilter {
             }
         }
         return false;
+    }
+
+    /**
+     * Check if a URL path is a known browser noise request.
+     *
+     * @param url
+     *            the URL to check
+     * @return {@code true} if the URL path matches a known noise path
+     */
+    private boolean isBrowserNoise(String url) {
+        try {
+            String path = new URI(url).getPath();
+            return path != null && BROWSER_NOISE_PATHS.contains(path);
+        } catch (URISyntaxException e) {
+            return false;
+        }
     }
 
     /**

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarFilterTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarFilterTest.java
@@ -75,6 +75,28 @@ class HarFilterTest {
     }
 
     @Test
+    void browserNoisePathsAreFiltered() throws IOException {
+        String har = createHarWithEntries(
+                entry("GET", "http://localhost:8080/favicon.ico", null),
+                entry("GET", "http://localhost:8080/apple-touch-icon.png",
+                        null),
+                entry("GET",
+                        "http://localhost:8080/apple-touch-icon-precomposed.png",
+                        null),
+                entry("GET", "http://localhost:8080/", null));
+
+        Path harFile = tempDir.resolve("test.har");
+        Files.writeString(harFile, har);
+
+        HarFilter filter = new HarFilter();
+        HarFilter.FilterResult result = filter.filter(harFile);
+
+        assertEquals(4, result.originalCount());
+        assertEquals(3, result.filteredCount());
+        assertEquals(1, result.remainingCount());
+    }
+
+    @Test
     void supportedMethodsAreKept() throws IOException {
         String har = createHarWithEntries(
                 entry("GET", "http://localhost:8080/", null),


### PR DESCRIPTION
ignore requests like favicon.ico
which often returns a 404.
