### PR TITLE
feat: Enable giving checks allowed failure rate

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
@@ -74,12 +74,20 @@ public abstract class AbstractK6Mojo extends AbstractMojo {
     protected int httpReqDurationP99;
 
     /**
-     * Whether to abort the k6 test immediately when a check fails. When true, a
-     * single failed check causes the test to stop. When false, failures are
-     * still recorded but the test continues.
+     * Whether to abort the k6 test immediately when the checks threshold is
+     * breached. When true, exceeding the allowed failure rate causes the test
+     * to stop. When false, failures are still recorded but the test continues.
      */
     @Parameter(property = "k6.threshold.checksAbortOnFail", defaultValue = "true")
     protected boolean checksAbortOnFail;
+
+    /**
+     * Fraction of check failures tolerated before the test is considered failed
+     * (e.g. {@code 0.01} = up to 1% of checks may fail). Must be in
+     * {@code [0, 1)}. Set to {@code 0} to require all checks to pass.
+     */
+    @Parameter(property = "k6.threshold.checksAllowedFailureRate", defaultValue = "0.01")
+    protected double checksAllowedFailureRate;
 
     /**
      * Custom thresholds for any k6 metric, in addition to the default
@@ -229,8 +237,11 @@ public abstract class AbstractK6Mojo extends AbstractMojo {
      * @return the threshold configuration
      */
     protected ThresholdConfig buildThresholdConfig() {
-        ThresholdConfig config = new ThresholdConfig(httpReqDurationP95,
-                httpReqDurationP99, checksAbortOnFail);
+        ThresholdConfig config = new ThresholdConfig()
+                .withHttpReqDurationP95(httpReqDurationP95)
+                .withHttpReqDurationP99(httpReqDurationP99)
+                .withChecksAbortOnFail(checksAbortOnFail)
+                .withChecksAllowedFailureRate(checksAllowedFailureRate);
         if (customThresholds != null && !customThresholds.isBlank()) {
             config = config.withCustomThresholds(customThresholds);
         }

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombiner.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombiner.java
@@ -56,7 +56,7 @@ public class K6ScenarioCombiner {
     public void combine(List<ScenarioConfig> scenarios, Path outputFile,
             int totalVus, String duration) throws IOException {
         combine(scenarios, outputFile, totalVus, duration,
-                ThresholdConfig.DEFAULT, LoadProfile.ramp("10s", "10s"));
+                new ThresholdConfig(), LoadProfile.ramp("10s", "10s"));
     }
 
     /**

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/RecorderOptions.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/RecorderOptions.java
@@ -22,11 +22,11 @@ public record RecorderOptions(ThresholdConfig thresholdConfig,
         ResponseCheckConfig responseCheckConfig) {
 
     public static final RecorderOptions DEFAULT = new RecorderOptions(
-            ThresholdConfig.DEFAULT, ResponseCheckConfig.EMPTY);
+            new ThresholdConfig(), ResponseCheckConfig.EMPTY);
 
     public RecorderOptions {
         if (thresholdConfig == null) {
-            thresholdConfig = ThresholdConfig.DEFAULT;
+            thresholdConfig = new ThresholdConfig();
         }
         if (responseCheckConfig == null) {
             responseCheckConfig = ResponseCheckConfig.EMPTY;

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/ResourceExtractor.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/ResourceExtractor.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * Extracts bundled JavaScript utilities from plugin resources to a temporary
  * directory. Bundles vaadin-k6-helpers.js plus k6-summary.js (a local copy of
- * https://jslib.k6.io/k6-summary/0.0.1/index.js) so generated tests run without
+ * https://jslib.k6.io/k6-summary/0.0.4/index.js) so generated tests run without
  * external downloads.
  */
 public class ResourceExtractor {

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/ThresholdConfig.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/ThresholdConfig.java
@@ -8,6 +8,8 @@
  */
 package com.vaadin.testbench.loadtest.util;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -18,69 +20,98 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Configuration for k6 test thresholds. Controls when the load test is
+ * Fluent configuration for k6 test thresholds. Controls when the load test is
  * considered failed based on response times and check pass rates.
  * <p>
- * Default thresholds include {@code http_req_duration} p95/p99 and
- * {@code checks rate==1}. Additional thresholds for any k6 metric can be added
- * via {@link #withCustomThreshold(String, String)}, and the defaults can be
- * edited via the constructor parameters or disabled by passing 0.
+ * Construct with {@code new ThresholdConfig()} and chain {@code withXyz(...)}
+ * calls; each mutates this instance and returns it for chaining. Default
+ * thresholds include {@code http_req_duration} p95/p99 and a
+ * {@code checks rate>=0.99} threshold (allowing up to 1% failed checks).
+ * Defaults can be overridden via the wither methods or disabled by passing 0.
  *
- * @param httpReqDurationP95
- *            95th percentile response time threshold in ms (0 to disable)
- * @param httpReqDurationP99
- *            99th percentile response time threshold in ms (0 to disable)
- * @param checksAbortOnFail
- *            if true, abort the test immediately when a check fails
- * @param customThresholds
- *            additional thresholds keyed by k6 metric name, each with a list of
- *            threshold expressions (e.g. {@code "p(95)<500"} or
- *            {@code "rate<0.01"})
+ * <pre>
+ * ThresholdConfig config = new ThresholdConfig().withHttpReqDurationP95(1500)
+ *         .withHttpReqDurationP99(4000).withChecksAllowedFailureRate(0.02);
+ * </pre>
  */
-public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
-        boolean checksAbortOnFail, Map<String, List<String>> customThresholds) {
+public final class ThresholdConfig {
 
     /**
-     * Canonical constructor that makes a defensive copy of custom thresholds.
+     * Default tolerated rate of failed checks before the test fails.
      */
-    public ThresholdConfig {
-        customThresholds = customThresholds != null
-                ? new LinkedHashMap<>(customThresholds)
-                : new LinkedHashMap<>();
+    public static final double DEFAULT_CHECKS_ALLOWED_FAILURE_RATE = 0.01;
+
+    private int httpReqDurationP95 = 2000;
+    private int httpReqDurationP99 = 5000;
+    private boolean checksAbortOnFail = true;
+    private double checksAllowedFailureRate = DEFAULT_CHECKS_ALLOWED_FAILURE_RATE;
+    private Map<String, List<String>> customThresholds = new LinkedHashMap<>();
+
+    /**
+     * Creates a new {@link ThresholdConfig} populated with the default values.
+     * Use the {@code withXyz} methods to derive customised configurations.
+     */
+    public ThresholdConfig() {
     }
 
     /**
-     * Backwards-compatible constructor without custom thresholds.
+     * Sets the 95th percentile {@code http_req_duration} threshold (in ms) and
+     * returns this instance for chaining. Set to {@code 0} to disable the
+     * default p95 threshold.
+     */
+    public ThresholdConfig withHttpReqDurationP95(int httpReqDurationP95) {
+        this.httpReqDurationP95 = httpReqDurationP95;
+        return this;
+    }
+
+    /**
+     * Sets the 99th percentile {@code http_req_duration} threshold (in ms) and
+     * returns this instance for chaining. Set to {@code 0} to disable the
+     * default p99 threshold.
+     */
+    public ThresholdConfig withHttpReqDurationP99(int httpReqDurationP99) {
+        this.httpReqDurationP99 = httpReqDurationP99;
+        return this;
+    }
+
+    /**
+     * Sets the abort-on-fail flag and returns this instance for chaining. When
+     * {@code true} (default), the test aborts immediately when the checks
+     * threshold is breached.
+     */
+    public ThresholdConfig withChecksAbortOnFail(boolean checksAbortOnFail) {
+        this.checksAbortOnFail = checksAbortOnFail;
+        return this;
+    }
+
+    /**
+     * Sets the allowed check-failure rate and returns this instance for
+     * chaining. The value is the fraction of check failures tolerated before
+     * the test is considered failed (e.g. {@code 0.01} = up to 1% of checks may
+     * fail). Must be in {@code [0, 1)}; {@code 0} requires all checks to pass.
      *
-     * @param httpReqDurationP95
-     *            95th percentile response time threshold in ms (0 to disable)
-     * @param httpReqDurationP99
-     *            99th percentile response time threshold in ms (0 to disable)
-     * @param checksAbortOnFail
-     *            if true, abort the test immediately when a check fails
+     * @throws IllegalArgumentException
+     *             if the rate is outside {@code [0, 1)}
      */
-    public ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
-            boolean checksAbortOnFail) {
-        this(httpReqDurationP95, httpReqDurationP99, checksAbortOnFail,
-                new LinkedHashMap<>());
+    public ThresholdConfig withChecksAllowedFailureRate(
+            double checksAllowedFailureRate) {
+        if (checksAllowedFailureRate >= 1 || checksAllowedFailureRate < 0) {
+            throw new IllegalArgumentException(
+                    "Given failure rate ouside accepted range [0, 1)");
+        }
+        this.checksAllowedFailureRate = checksAllowedFailureRate;
+        return this;
     }
 
     /**
-     * Default thresholds: p95 &lt; 2000ms, p99 &lt; 5000ms, abort on check
-     * failure.
-     */
-    public static final ThresholdConfig DEFAULT = new ThresholdConfig(2000,
-            5000, true);
-
-    /**
-     * Returns a new {@link ThresholdConfig} with an additional custom threshold
-     * expression for the given k6 metric. Multiple expressions can be added for
-     * the same metric by calling this method repeatedly.
+     * Adds a custom threshold expression for the given k6 metric and returns
+     * this instance for chaining. Multiple expressions can be added for the
+     * same metric by calling this method repeatedly.
      * <p>
      * Example usage:
-     * 
+     *
      * <pre>
-     * ThresholdConfig config = ThresholdConfig.DEFAULT
+     * ThresholdConfig config = new ThresholdConfig()
      *         .withCustomThreshold("http_req_waiting", "p(95)&lt;500")
      *         .withCustomThreshold("http_req_failed", "rate&lt;0.01")
      *         .withCustomThreshold("http_req_duration", "p(50)&lt;1000");
@@ -96,15 +127,13 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
      * @param expression
      *            the threshold expression (e.g. {@code "p(95)<500"},
      *            {@code "rate<0.01"}, {@code "count>100"})
-     * @return a new ThresholdConfig with the additional threshold
+     * @return this instance for chaining
      */
     public ThresholdConfig withCustomThreshold(String metric,
             String expression) {
-        Map<String, List<String>> merged = new LinkedHashMap<>(
-                customThresholds);
-        merged.computeIfAbsent(metric, k -> new ArrayList<>()).add(expression);
-        return new ThresholdConfig(httpReqDurationP95, httpReqDurationP99,
-                checksAbortOnFail, merged);
+        this.customThresholds.computeIfAbsent(metric, k -> new ArrayList<>())
+                .add(expression);
+        return this;
     }
 
     /**
@@ -113,12 +142,11 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
      *
      * @param thresholds
      *            the custom thresholds string to parse
-     * @return a new ThresholdConfig with the custom thresholds applied
+     * @return this instance for chaining
      * @throws IllegalArgumentException
      *             if the format is invalid
      */
     public ThresholdConfig withCustomThresholds(String thresholds) {
-        ThresholdConfig result = this;
         for (String entry : thresholds.split(",")) {
             entry = entry.trim();
             if (entry.isEmpty()) {
@@ -132,9 +160,9 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
             }
             String metric = entry.substring(0, colonIndex).trim();
             String expression = entry.substring(colonIndex + 1).trim();
-            result = result.withCustomThreshold(metric, expression);
+            withCustomThreshold(metric, expression);
         }
-        return result;
+        return this;
     }
 
     /**
@@ -143,7 +171,7 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
      *
      * <pre>
      *   thresholds: {
-     *     checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }],
+     *     checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }],
      *     http_req_duration: ['p(95)&lt;2000', 'p(99)&lt;5000'],
      *     http_req_failed: ['rate&lt;0.01'],
      *   },
@@ -171,11 +199,13 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
         sb.append("  thresholds: {\n");
 
         // checks threshold
+        String checksExpression = buildChecksThresholdExpression();
         if (checksAbortOnFail) {
-            sb.append(
-                    "    checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }],\n");
+            sb.append("    checks: [{ threshold: '").append(checksExpression)
+                    .append("', abortOnFail: true, delayAbortEval: '5s' }],\n");
         } else {
-            sb.append("    checks: ['rate==1'],\n");
+            sb.append("    checks: ['").append(checksExpression)
+                    .append("'],\n");
         }
 
         // http_req_duration: custom expressions override matching defaults
@@ -265,5 +295,21 @@ public record ThresholdConfig(int httpReqDurationP95, int httpReqDurationP99,
             sb.append(",").append(p);
         }
         return sb.toString();
+    }
+
+    /**
+     * Builds the k6 threshold expression for the {@code checks} metric based on
+     * the configured allowed failure rate. Returns {@code rate==1} when zero
+     * failures are tolerated, otherwise {@code rate>=X} where X is the minimum
+     * required pass rate.
+     */
+    private String buildChecksThresholdExpression() {
+        if (checksAllowedFailureRate <= 0) {
+            return "rate==1";
+        }
+        String passRate = BigDecimal.valueOf(1.0 - checksAllowedFailureRate)
+                .setScale(4, RoundingMode.HALF_UP).stripTrailingZeros()
+                .toPlainString();
+        return "rate>=" + passRate;
     }
 }

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
@@ -241,7 +241,7 @@ class HarToK6ConverterTest {
                 "(r) => r.body.includes('<title>')");
 
         new HarToK6Converter().convert(harFile, outputFile,
-                new RecorderOptions(ThresholdConfig.DEFAULT, checks));
+                new RecorderOptions(new ThresholdConfig(), checks));
 
         String script = Files.readString(outputFile);
         assertTrue(
@@ -269,7 +269,7 @@ class HarToK6ConverterTest {
                 "(r) => !r.body.includes('timeout')");
 
         new HarToK6Converter().convert(harFile, outputFile,
-                new RecorderOptions(ThresholdConfig.DEFAULT, checks));
+                new RecorderOptions(new ThresholdConfig(), checks));
 
         String script = Files.readString(outputFile);
         assertTrue(
@@ -296,7 +296,7 @@ class HarToK6ConverterTest {
                 "(r) => r.timings.duration < 3000");
 
         new HarToK6Converter().convert(harFile, outputFile,
-                new RecorderOptions(ThresholdConfig.DEFAULT, checks));
+                new RecorderOptions(new ThresholdConfig(), checks));
 
         String script = Files.readString(outputFile);
         // Count occurrences — should appear in both init and UIDL blocks

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
@@ -167,7 +167,7 @@ class K6ScenarioCombinerTest {
         combiner.combine(
                 List.of(new ScenarioConfig("alpha", a, 50),
                         new ScenarioConfig("beta", b, 50)),
-                output, 10, "30s", ThresholdConfig.DEFAULT,
+                output, 10, "30s", new ThresholdConfig(),
                 LoadProfile.ramp("5s", "5s"));
 
         String content = Files.readString(output);

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/ThresholdConfigTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/ThresholdConfigTest.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.testbench.loadtest.util;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,15 +19,18 @@ class ThresholdConfigTest {
 
     @Test
     void defaultThresholds() {
-        String block = ThresholdConfig.DEFAULT.toK6ThresholdsBlock();
+        String block = new ThresholdConfig().toK6ThresholdsBlock();
         assertTrue(block.contains("'p(95)<2000'"));
         assertTrue(block.contains("'p(99)<5000'"));
         assertTrue(block.contains("abortOnFail: true"));
+        // Default tolerates 1% failed checks
+        assertTrue(block.contains("threshold: 'rate>=0.99'"));
     }
 
     @Test
     void disabledP95() {
-        ThresholdConfig config = new ThresholdConfig(0, 5000, true);
+        ThresholdConfig config = new ThresholdConfig()
+                .withHttpReqDurationP95(0);
         String block = config.toK6ThresholdsBlock();
         assertFalse(block.contains("p(95)"));
         assertTrue(block.contains("'p(99)<5000'"));
@@ -34,7 +38,8 @@ class ThresholdConfigTest {
 
     @Test
     void disabledP99() {
-        ThresholdConfig config = new ThresholdConfig(2000, 0, true);
+        ThresholdConfig config = new ThresholdConfig()
+                .withHttpReqDurationP99(0);
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("'p(95)<2000'"));
         assertFalse(block.contains("p(99)"));
@@ -42,15 +47,16 @@ class ThresholdConfigTest {
 
     @Test
     void checksWithoutAbort() {
-        ThresholdConfig config = new ThresholdConfig(2000, 5000, false);
+        ThresholdConfig config = new ThresholdConfig()
+                .withChecksAbortOnFail(false);
         String block = config.toK6ThresholdsBlock();
-        assertTrue(block.contains("checks: ['rate==1']"));
+        assertTrue(block.contains("checks: ['rate>=0.99']"));
         assertFalse(block.contains("abortOnFail"));
     }
 
     @Test
     void customThresholdAdded() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_failed", "rate<0.01");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("http_req_failed: ['rate<0.01']"));
@@ -58,7 +64,7 @@ class ThresholdConfigTest {
 
     @Test
     void multipleCustomThresholdsForSameMetric() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_waiting", "p(95)<500")
                 .withCustomThreshold("http_req_waiting", "p(99)<1000");
         String block = config.toK6ThresholdsBlock();
@@ -68,7 +74,7 @@ class ThresholdConfigTest {
 
     @Test
     void customDurationOverridesMatchingDefaults() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_duration", "p(95)<500");
         String block = config.toK6ThresholdsBlock();
         // Custom p(95) overrides default p(95)
@@ -80,7 +86,7 @@ class ThresholdConfigTest {
 
     @Test
     void customDurationKeepsDefaultsWhenNoOverlap() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_duration", "p(50)<1000");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("'p(95)<2000'"));
@@ -93,7 +99,8 @@ class ThresholdConfigTest {
 
     @Test
     void customDurationWithDefaultsDisabled() {
-        ThresholdConfig config = new ThresholdConfig(0, 0, true)
+        ThresholdConfig config = new ThresholdConfig().withHttpReqDurationP95(0)
+                .withHttpReqDurationP99(0)
                 .withCustomThreshold("http_req_duration", "p(90)<3000");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("http_req_duration: ['p(90)<3000']"));
@@ -103,7 +110,7 @@ class ThresholdConfigTest {
 
     @Test
     void customDurationOverridingDefaultsNoDuplicates() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_duration", "p(95)<500")
                 .withCustomThreshold("http_req_duration", "p(99)<1500");
         String block = config.toK6ThresholdsBlock();
@@ -129,26 +136,57 @@ class ThresholdConfigTest {
 
     @Test
     void editedDefaultThresholds() {
-        ThresholdConfig config = new ThresholdConfig(1000, 3000, false);
+        ThresholdConfig config = new ThresholdConfig()
+                .withHttpReqDurationP95(1000).withHttpReqDurationP99(3000)
+                .withChecksAbortOnFail(false);
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("'p(95)<1000'"));
         assertTrue(block.contains("'p(99)<3000'"));
-        assertTrue(block.contains("checks: ['rate==1']"));
+        assertTrue(block.contains("checks: ['rate>=0.99']"));
     }
 
     @Test
-    void withCustomThresholdIsImmutable() {
-        ThresholdConfig original = ThresholdConfig.DEFAULT;
-        ThresholdConfig modified = original
+    void zeroAllowedFailureRateRequiresAllChecksToPass() {
+        ThresholdConfig config = new ThresholdConfig()
+                .withChecksAllowedFailureRate(0.0);
+        String block = config.toK6ThresholdsBlock();
+        assertTrue(block.contains("threshold: 'rate==1'"));
+    }
+
+    @Test
+    void customAllowedFailureRate() {
+        ThresholdConfig config = new ThresholdConfig()
+                .withChecksAbortOnFail(false)
+                .withChecksAllowedFailureRate(0.10);
+        String block = config.toK6ThresholdsBlock();
+        assertTrue(block.contains("checks: ['rate>=0.9']"));
+    }
+
+    @Test
+    void invalidAllowedFailureRateThrows() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new ThresholdConfig().withChecksAllowedFailureRate(1.0),
+                "Should have thrown for invalid failure rate");
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new ThresholdConfig().withChecksAllowedFailureRate(-0.01),
+                "Should have thrown for negative failure rate");
+
+    }
+
+    @Test
+    void allowedFailureRatePreservedThroughCustomThresholds() {
+        ThresholdConfig config = new ThresholdConfig()
+                .withChecksAllowedFailureRate(0.02)
                 .withCustomThreshold("http_req_failed", "rate<0.01");
-        // Original should not be affected
-        assertFalse(original.toK6ThresholdsBlock().contains("http_req_failed"));
-        assertTrue(modified.toK6ThresholdsBlock().contains("http_req_failed"));
+        String block = config.toK6ThresholdsBlock();
+        assertTrue(block.contains("threshold: 'rate>=0.98'"));
+        assertTrue(block.contains("http_req_failed: ['rate<0.01']"));
     }
 
     @Test
     void parseCustomThresholdsFromString() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT.withCustomThresholds(
+        ThresholdConfig config = new ThresholdConfig().withCustomThresholds(
                 "http_req_failed:rate<0.01,http_req_waiting:p(95)<500");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("http_req_failed: ['rate<0.01']"));
@@ -160,7 +198,7 @@ class ThresholdConfigTest {
 
     @Test
     void parseCustomThresholdsIgnoresEmptyEntries() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT.withCustomThresholds(
+        ThresholdConfig config = new ThresholdConfig().withCustomThresholds(
                 "http_req_failed:rate<0.01,,  ,http_reqs:count>100");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block.contains("http_req_failed: ['rate<0.01']"));
@@ -170,7 +208,7 @@ class ThresholdConfigTest {
     @Test
     void parseCustomThresholdsInvalidFormatThrows() {
         try {
-            ThresholdConfig.DEFAULT.withCustomThresholds("invalid-no-colon");
+            new ThresholdConfig().withCustomThresholds("invalid-no-colon");
             throw new AssertionError("Should have thrown");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Invalid custom threshold"));
@@ -179,7 +217,7 @@ class ThresholdConfigTest {
 
     @Test
     void multipleCustomMetrics() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT
+        ThresholdConfig config = new ThresholdConfig()
                 .withCustomThreshold("http_req_failed", "rate<0.01")
                 .withCustomThreshold("http_req_waiting", "p(95)<500")
                 .withCustomThreshold("http_reqs", "count>100");
@@ -198,7 +236,7 @@ class ThresholdConfigTest {
 
     @Test
     void defaultWithCustomWaitingThresholds() {
-        ThresholdConfig config = ThresholdConfig.DEFAULT.withCustomThresholds(
+        ThresholdConfig config = new ThresholdConfig().withCustomThresholds(
                 "http_req_waiting:p(95)<1000,http_req_waiting:p(99)<2000");
         String block = config.toK6ThresholdsBlock();
         assertTrue(block
@@ -209,10 +247,4 @@ class ThresholdConfigTest {
         assertTrue(block.contains("abortOnFail: true"));
     }
 
-    @Test
-    void backwardsCompatibleConstructor() {
-        ThresholdConfig config = new ThresholdConfig(2000, 5000, true);
-        assertEquals(ThresholdConfig.DEFAULT.toK6ThresholdsBlock(),
-                config.toK6ThresholdsBlock());
-    }
 }


### PR DESCRIPTION
Add checksAllowerFailureRate configuration.

Default accepts 1% failure rate.

Change ThresholdConfig to fluid instead of
a record. Drop DEFAULT as new will always
generate with default values.
