### PR TITLE
feat: add ITs for load testing with k6

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -309,11 +309,12 @@ jobs:
         run: |
           mvn verify \
             -pl vaadin-testbench-loadtest/testbench-converter-plugin -am \
+            -P maven-invoker-it \
             -DskipUnitTests \
             -B
 
       - name: Upload invoker logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: loadtest-converter-invoker-logs

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -270,6 +270,58 @@ jobs:
             **/target/failsafe-reports/TEST-*.xml
           retention-days: 7
 
+  loadtest-converter-tests:
+    name: Load Test Converter Plugin ITs
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.HEAD_SHA }}
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: "temurin"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+
+      - name: Set TB License
+        run: |
+          TB_LICENSE=${{secrets.TB_LICENSE}}
+          mkdir -p ~/.vaadin/
+          echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
+
+      - name: Run Maven Invoker Tests
+        run: |
+          mvn verify \
+            -pl vaadin-testbench-loadtest/testbench-converter-plugin -am \
+            -DskipUnitTests \
+            -B
+
+      - name: Upload invoker logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: loadtest-converter-invoker-logs
+          path: |
+            vaadin-testbench-loadtest/testbench-converter-plugin/target/its/**/build.log
+            vaadin-testbench-loadtest/testbench-converter-plugin/target/invoker-reports/**
+          retention-days: 7
+
   validation-status:
     name: Validation Status
     permissions:
@@ -278,7 +330,7 @@ jobs:
       checks: write
       pull-requests: write
     if: always()
-    needs: [format-check, build, unit-tests, integration-tests]
+    needs: [format-check, build, unit-tests, integration-tests, loadtest-converter-tests]
     runs-on: ubuntu-latest
 
     steps:
@@ -307,11 +359,13 @@ jobs:
           echo "build: ${{ needs.build.result }}"
           echo "unit-tests: ${{ needs.unit-tests.result }}"
           echo "integration-tests: ${{ needs.integration-tests.result }}"
+          echo "loadtest-converter-tests: ${{ needs.loadtest-converter-tests.result }}"
 
           if [ "${{ needs.format-check.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \
              [ "${{ needs.unit-tests.result }}" != "success" ] || \
-             [ "${{ needs.integration-tests.result }}" != "success" ]; then
+             [ "${{ needs.integration-tests.result }}" != "success" ] || \
+             [ "${{ needs.loadtest-converter-tests.result }}" != "success" ]; then
             echo "One or more validation jobs failed"
             exit 1
           fi

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
@@ -145,9 +145,9 @@ The refactored k6 tests include:
 
 ## Integration Tests
 
-Self-contained Maven Invoker projects under `src/it/` exercise each Mojo end-to-end against a real Vaadin Flow fixture. They are gated behind the `maven-invoker-it` profile so a default `mvn verify` only runs unit tests.
+Self-contained Maven Invoker projects under `src/it/` exercise each Mojo end-to-end against a real Vaadin Flow fixture. `mvn verify` runs them. Skip with `-DskipTests`.
 
-**Prerequisites:** Java 21+, Maven, [k6](https://grafana.com/docs/k6/latest/get-started/installation/) on `PATH`, and Chrome installed (used by the recording ITs).
+**Prerequisites:** Java 21+, Maven, and Chrome installed (used by the recording ITs).
 
 Run the full suite:
 

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
@@ -145,21 +145,21 @@ The refactored k6 tests include:
 
 ## Integration Tests
 
-Self-contained Maven Invoker projects under `src/it/` exercise each Mojo end-to-end against a real Vaadin Flow fixture. `mvn verify` runs them. Skip with `-DskipTests`.
+Self-contained Maven Invoker projects under `src/it/` exercise each Mojo end-to-end against a real Vaadin Flow fixture. They are gated behind the `maven-invoker-it` profile so a default `mvn verify` only runs unit tests.
 
 **Prerequisites:** Java 21+, Maven, and Chrome installed (used by the recording ITs).
 
 Run the full suite:
 
 ```bash
-mvn verify
+mvn verify -Pmaven-invoker-it
 ```
 
 Run a single IT (or a comma-separated list):
 
 ```bash
-mvn invoker:run -Dinvoker.test=convert-har
-mvn invoker:run -Dinvoker.test=demo-server,record-testbench
+mvn invoker:run -Pmaven-invoker-it -Dinvoker.test=convert-har
+mvn invoker:run -Pmaven-invoker-it -Dinvoker.test=demo-server,record-testbench
 ```
 
 The ITs install the plugin to `target/local-repo` and clone each project under `target/its/`. Build logs are at `target/its/<name>/build.log`.

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/README.md
@@ -142,3 +142,24 @@ The refactored k6 tests include:
 - **Dynamic session handling** - Extracts session IDs from responses
 - **Configurable target** - Use `-e APP_IP=host -e APP_PORT=port` to test different servers
 - **Vaadin helper imports** - Uses shared utility functions for Vaadin protocol handling (`vaadin-k6-helpers.js`)
+
+## Integration Tests
+
+Self-contained Maven Invoker projects under `src/it/` exercise each Mojo end-to-end against a real Vaadin Flow fixture. They are gated behind the `maven-invoker-it` profile so a default `mvn verify` only runs unit tests.
+
+**Prerequisites:** Java 21+, Maven, [k6](https://grafana.com/docs/k6/latest/get-started/installation/) on `PATH`, and Chrome installed (used by the recording ITs).
+
+Run the full suite:
+
+```bash
+mvn verify
+```
+
+Run a single IT (or a comma-separated list):
+
+```bash
+mvn invoker:run -Dinvoker.test=convert-har
+mvn invoker:run -Dinvoker.test=demo-server,record-testbench
+```
+
+The ITs install the plugin to `target/local-repo` and clone each project under `target/its/`. Build logs are at `target/its/<name>/build.log`.

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -21,6 +21,17 @@
         <maven.version>3.9.6</maven.version>
         <maven-plugin-api.version>3.9.6</maven-plugin-api.version>
         <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
+        <!-- Pinned k6 version for the auto-install integration test (000-install-k6).
+             Bumping this updates every IT that consumes the downloaded binary. -->
+        <k6.version>0.54.0</k6.version>
+        <!--
+            OS-agnostic install location for the k6 binary. The 000-install-k6
+            IT does the actual download and writes the resolved absolute path
+            to ${k6.install.dir}/k6.properties; properties-maven-plugin loads
+            that file in the maven-invoker-it profile, and the second invoker
+            execution broadcasts the value as -Dk6.binary to every other IT.
+        -->
+        <k6.install.dir>${project.build.directory}/k6-bin</k6.install.dir>
     </properties>
 
     <dependencies>
@@ -151,6 +162,108 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <!--
+                 IT pipeline:
+
+                 1) install-k6 (pre-integration-test): installs the
+                    plugin under test into target/local-repo and runs
+                    the 000-install-k6 IT, which downloads the k6
+                    binary for the host OS/arch and writes
+                    target/k6-bin/k6.properties with the resolved
+                    absolute path.
+
+                 2) load-k6-binary (pre-integration-test, declared
+                    after the invoker plugin so it runs second):
+                    reads k6.properties into the parent project's
+                    properties so ${k6.binary} resolves to the path
+                    the bootstrap IT just produced.
+
+                 3) run-tests (integration-test): runs every other
+                    IT, broadcasting -Dk6.binary=${k6.binary} so each
+                    spawned Maven sees the resolved path. The plugin
+                    under test reads it via
+                    AbstractK6Mojo.@Parameter(property="k6.binary").
+             -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.9.1</version>
+                <configuration>
+                    <skipInstallation>${skipTests}</skipInstallation>
+                    <skipInvocation>${skipTests}</skipInvocation>
+                    <localRepositoryPath>target/local-repo</localRepositoryPath>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                    <streamLogsOnFailures>true</streamLogsOnFailures>
+                    <addTestClassPath>true</addTestClassPath>
+                    <extraArtifacts>
+                        <artifact>com.vaadin:testbench-loadtest-support:${project.version}</artifact>
+                    </extraArtifacts>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-k6</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <pomIncludes>
+                                <pomInclude>000-install-k6/pom.xml</pomInclude>
+                            </pomIncludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <pomExcludes>
+                                <pomExclude>000-install-k6/pom.xml</pomExclude>
+                            </pomExcludes>
+                            <!--
+                                Broadcast as -Dk6.binary=... to every
+                                spawned IT. ${k6.binary} resolves at
+                                execution time, after
+                                properties-maven-plugin loaded the
+                                value written by 000-install-k6.
+                            -->
+                            <properties>
+                                <k6.binary>${k6.binary}</k6.binary>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>load-k6-binary</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${k6.install.dir}/k6.properties</file>
+                            </files>
+                            <!-- Allow downstream ITs to run in
+                                 isolation when 000-install-k6 has
+                                 not been executed yet; k6.binary
+                                 stays empty and NodeRunner falls
+                                 back to "k6" on PATH. -->
+                            <quiet>true</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -163,110 +163,127 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <!--
-                 IT pipeline:
-
-                 1) install-k6 (pre-integration-test): installs the
-                    plugin under test into target/local-repo and runs
-                    the 000-install-k6 IT, which downloads the k6
-                    binary for the host OS/arch and writes
-                    target/k6-bin/k6.properties with the resolved
-                    absolute path.
-
-                 2) load-k6-binary (pre-integration-test, declared
-                    after the invoker plugin so it runs second):
-                    reads k6.properties into the parent project's
-                    properties so ${k6.binary} resolves to the path
-                    the bootstrap IT just produced.
-
-                 3) run-tests (integration-test): runs every other
-                    IT, broadcasting -Dk6.binary=${k6.binary} so each
-                    spawned Maven sees the resolved path. The plugin
-                    under test reads it via
-                    AbstractK6Mojo.@Parameter(property="k6.binary").
-             -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.9.1</version>
-                <configuration>
-                    <skipInstallation>${skipTests}</skipInstallation>
-                    <skipInvocation>${skipTests}</skipInvocation>
-                    <localRepositoryPath>target/local-repo</localRepositoryPath>
-                    <settingsFile>src/it/settings.xml</settingsFile>
-                    <postBuildHookScript>verify</postBuildHookScript>
-                    <streamLogsOnFailures>true</streamLogsOnFailures>
-                    <addTestClassPath>true</addTestClassPath>
-                    <extraArtifacts>
-                        <artifact>com.vaadin:testbench-loadtest-support:${project.version}</artifact>
-                        <artifact>com.vaadin:flow-html-components-testbench:${flow.version}</artifact>
-                    </extraArtifacts>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>install-k6</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>install</goal>
-                            <goal>integration-test</goal>
-                        </goals>
-                        <configuration>
-                            <pomIncludes>
-                                <pomInclude>000-install-k6/pom.xml</pomInclude>
-                            </pomIncludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>run-tests</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <pomExcludes>
-                                <pomExclude>000-install-k6/pom.xml</pomExclude>
-                            </pomExcludes>
-                            <!--
-                                Broadcast as -Dk6.binary=... to every
-                                spawned IT. ${k6.binary} resolves at
-                                execution time, after
-                                properties-maven-plugin loaded the
-                                value written by 000-install-k6.
-                            -->
-                            <properties>
-                                <k6.binary>${k6.binary}</k6.binary>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <executions>
-                    <execution>
-                        <id>load-k6-binary</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>read-project-properties</goal>
-                        </goals>
-                        <configuration>
-                            <files>
-                                <file>${k6.install.dir}/k6.properties</file>
-                            </files>
-                            <!-- Allow downstream ITs to run in
-                                 isolation when 000-install-k6 has
-                                 not been executed yet; k6.binary
-                                 stays empty and NodeRunner falls
-                                 back to "k6" on PATH. -->
-                            <quiet>true</quiet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+             Opt-in profile that wires up the maven-invoker IT pipeline.
+             Activate with `-Pmaven-invoker-it`.
+         -->
+        <profile>
+            <id>maven-invoker-it</id>
+            <build>
+                <plugins>
+                    <!--
+                         IT pipeline:
+
+                         1) install-k6 (pre-integration-test): installs
+                            the plugin under test into target/local-repo
+                            and runs the 000-install-k6 IT, which
+                            downloads the k6 binary for the host OS/arch
+                            and writes target/k6-bin/k6.properties with
+                            the resolved absolute path.
+
+                         2) load-k6-binary (pre-integration-test,
+                            declared after the invoker plugin so it
+                            runs second): reads k6.properties into the
+                            parent project's properties so ${k6.binary}
+                            resolves to the path the bootstrap IT just
+                            produced.
+
+                         3) run-tests (integration-test): runs every
+                            other IT, broadcasting -Dk6.binary=${k6.binary}
+                            so each spawned Maven sees the resolved
+                            path. The plugin under test reads it via
+                            AbstractK6Mojo.@Parameter(property="k6.binary").
+                     -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>3.9.1</version>
+                        <configuration>
+                            <skipInstallation>${skipTests}</skipInstallation>
+                            <skipInvocation>${skipTests}</skipInvocation>
+                            <localRepositoryPath>target/local-repo</localRepositoryPath>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <streamLogsOnFailures>true</streamLogsOnFailures>
+                            <addTestClassPath>true</addTestClassPath>
+                            <extraArtifacts>
+                                <artifact>com.vaadin:testbench-loadtest-support:${project.version}</artifact>
+                                <artifact>com.vaadin:flow-html-components-testbench:${flow.version}</artifact>
+                            </extraArtifacts>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>install-k6</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <pomIncludes>
+                                        <pomInclude>000-install-k6/pom.xml</pomInclude>
+                                    </pomIncludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>run-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <pomExcludes>
+                                        <pomExclude>000-install-k6/pom.xml</pomExclude>
+                                    </pomExcludes>
+                                    <!--
+                                        Broadcast as -Dk6.binary=... to
+                                        every spawned IT. ${k6.binary}
+                                        resolves at execution time,
+                                        after properties-maven-plugin
+                                        loaded the value written by
+                                        000-install-k6.
+                                    -->
+                                    <properties>
+                                        <k6.binary>${k6.binary}</k6.binary>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>load-k6-binary</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <files>
+                                        <file>${k6.install.dir}/k6.properties</file>
+                                    </files>
+                                    <!-- Allow downstream ITs to run in
+                                         isolation when 000-install-k6
+                                         has not been executed yet;
+                                         k6.binary stays empty and
+                                         NodeRunner falls back to "k6"
+                                         on PATH. -->
+                                    <quiet>true</quiet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -199,6 +199,7 @@
                     <addTestClassPath>true</addTestClassPath>
                     <extraArtifacts>
                         <artifact>com.vaadin:testbench-loadtest-support:${project.version}</artifact>
+                        <artifact>com.vaadin:flow-html-components-testbench:${flow.version}</artifact>
                     </extraArtifacts>
                 </configuration>
                 <executions>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/invoker.properties
@@ -1,0 +1,9 @@
+# Highest ordinal so this IT runs before every other IT (including
+# demo-server which is ordinal=100). The downloaded binary is reused across
+# all subsequent ITs that exercise loadtest:run / record / record-playwright.
+invoker.ordinal=200
+# process-resources is the earliest phase that runs both the download (bound
+# to generate-resources) and the chmod (bound to process-resources). validate
+# alone is too early.
+invoker.goals=process-resources
+invoker.buildResult=success

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/pom.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>install-k6</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <name>install-k6</name>
+    <description>
+        Bootstrap IT that downloads and unpacks the k6 binary for the host
+        OS/arch into the converter plugin's target/k6-bin directory, then
+        writes the resolved absolute binary path to
+        target/k6-bin/k6.properties.
+
+        The parent pom's properties-maven-plugin reads that file in the
+        pre-integration-test phase, and the second maven-invoker-plugin
+        execution broadcasts -Dk6.binary=&lt;path&gt; to every other IT.
+
+        All OS detection lives in this pom; the parent only knows the
+        OS-agnostic install directory and the pinned k6 version.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Filtered from parent at maven-invoker-plugin install time. -->
+        <k6.version>@k6.version@</k6.version>
+        <k6.install.dir>@k6.install.dir@</k6.install.dir>
+        <!-- Populated by the OS profiles below. -->
+        <k6.os>UNDEFINED</k6.os>
+        <k6.arch>UNDEFINED</k6.arch>
+        <k6.archive.extension>UNDEFINED</k6.archive.extension>
+        <k6.binary.name>UNDEFINED</k6.binary.name>
+        <is.windows>false</is.windows>
+        <!-- Derived. -->
+        <k6.archive.url>https://github.com/grafana/k6/releases/download/v${k6.version}/k6-v${k6.version}-${k6.os}-${k6.arch}.${k6.archive.extension}</k6.archive.url>
+        <k6.binary>${k6.install.dir}/k6-v${k6.version}-${k6.os}-${k6.arch}/${k6.binary.name}</k6.binary>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.13.0</version>
+                <executions>
+                    <execution>
+                        <id>install-k6</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${k6.archive.url}</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${k6.install.dir}</outputDirectory>
+                            <skipCache>false</skipCache>
+                            <checkSignature>false</checkSignature>
+                            <retries>3</retries>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Zip archives drop the executable bit on macOS; tar.gz
+                 preserves it on Linux. chmod is a no-op on Windows. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>chmod-k6</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>chmod</executable>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>${k6.binary}</argument>
+                            </arguments>
+                            <skip>${is.windows}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Bridge file: parent's properties-maven-plugin reads this in
+                 pre-integration-test to resolve ${k6.binary} for the second
+                 invoker execution's broadcast. Ant's <propertyfile> uses
+                 java.util.Properties#store(), so backslashes in Windows
+                 paths get escaped correctly. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>write-k6-properties</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <propertyfile file="${k6.install.dir}/k6.properties">
+                                    <entry key="k6.binary" value="${k6.binary}"/>
+                                </propertyfile>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <!--
+        Maven's <os> matcher reads os.name /
+        os.arch directly from the JVM and works pre-extensions.
+    -->
+    <profiles>
+        <profile>
+            <id>k6-linux-amd64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <name>linux</name>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>linux</k6.os>
+                <k6.arch>amd64</k6.arch>
+                <k6.archive.extension>tar.gz</k6.archive.extension>
+                <k6.binary.name>k6</k6.binary.name>
+            </properties>
+        </profile>
+        <profile>
+            <id>k6-linux-x86_64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <name>linux</name>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>linux</k6.os>
+                <k6.arch>amd64</k6.arch>
+                <k6.archive.extension>tar.gz</k6.archive.extension>
+                <k6.binary.name>k6</k6.binary.name>
+            </properties>
+        </profile>
+        <profile>
+            <id>k6-linux-arm64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <name>linux</name>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>linux</k6.os>
+                <k6.arch>arm64</k6.arch>
+                <k6.archive.extension>tar.gz</k6.archive.extension>
+                <k6.binary.name>k6</k6.binary.name>
+            </properties>
+        </profile>
+        <profile>
+            <id>k6-mac-amd64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>macos</k6.os>
+                <k6.arch>amd64</k6.arch>
+                <k6.archive.extension>zip</k6.archive.extension>
+                <k6.binary.name>k6</k6.binary.name>
+            </properties>
+        </profile>
+        <profile>
+            <id>k6-mac-arm64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>macos</k6.os>
+                <k6.arch>arm64</k6.arch>
+                <k6.archive.extension>zip</k6.archive.extension>
+                <k6.binary.name>k6</k6.binary.name>
+            </properties>
+        </profile>
+        <profile>
+            <id>k6-windows-amd64</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <k6.os>windows</k6.os>
+                <k6.arch>amd64</k6.arch>
+                <k6.archive.extension>zip</k6.archive.extension>
+                <k6.binary.name>k6.exe</k6.binary.name>
+                <is.windows>true</is.windows>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/000-install-k6/verify.bsh
@@ -1,0 +1,39 @@
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+// IT basedir is <plugin>/target/its/000-install-k6/ when maven-invoker-plugin
+// clones the project. Two levels up reaches <plugin>/target/, where the
+// install-k6 step wrote k6-bin/ alongside local-repo/.
+File k6Dir = new File(basedir, "../../k6-bin");
+if (!k6Dir.isDirectory()) {
+    throw new RuntimeException(
+            "k6 install dir not created: " + k6Dir.getAbsolutePath());
+}
+
+// Walk the directory iteratively (Files.walk + Path.normalize trip BeanShell
+// reflection on Java 21+).
+List queue = new ArrayList();
+queue.add(k6Dir);
+boolean found = false;
+while (!queue.isEmpty()) {
+    File f = (File) queue.remove(0);
+    if (f.isDirectory()) {
+        File[] children = f.listFiles();
+        if (children != null) {
+            for (int i = 0; i < children.length; i++) {
+                queue.add(children[i]);
+            }
+        }
+    } else {
+        String name = f.getName();
+        if (name.equals("k6") || name.equals("k6.exe")) {
+            found = true;
+            break;
+        }
+    }
+}
+if (!found) {
+    throw new RuntimeException(
+            "k6 binary not found under " + k6Dir.getAbsolutePath());
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=generate-test-resources

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>convert-har-skip-filter</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies skipFilter and skipRefactor flags on loadtest:convert. With both
+        flags set, external requests are kept and the Vaadin helper import is
+        not injected.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>convert-no-filter</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>convert</goal>
+                        </goals>
+                        <configuration>
+                            <harFile>${project.basedir}/src/test/resources/recorded.har</harFile>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <outputName>recorded</outputName>
+                            <skipFilter>true</skipFilter>
+                            <skipRefactor>true</skipRefactor>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/src/test/resources/recorded.har
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/src/test/resources/recorded.har
@@ -1,0 +1,63 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "testbench-it", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2026-01-01T00:00:00.000Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8080/",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {"size": 0, "mimeType": "text/html"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {"blocked": 0, "dns": 0, "connect": 0, "send": 0, "wait": 0, "receive": 0}
+      },
+      {
+        "startedDateTime": "2026-01-01T00:00:00.200Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/collect?v=1",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {"size": 0, "mimeType": "image/gif"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {"blocked": 0, "dns": 0, "connect": 0, "send": 0, "wait": 0, "receive": 0}
+      }
+    ],
+    "pages": []
+  }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har-skip-filter/verify.bsh
@@ -1,0 +1,17 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+// With skipRefactor=true the only output is the unrefactored *-generated.js
+Path generated = basePath.resolve("target/k6/tests/recorded-generated.js");
+Path refactored = basePath.resolve("target/k6/tests/recorded.js");
+
+IntegrationTestHelper.assertFileExists(generated);
+IntegrationTestHelper.assertFileDoesNotExist(refactored);
+
+// Filter step skipped → external domain is preserved in the generated script
+IntegrationTestHelper.assertFileContains(generated, "google-analytics.com");
+
+// Refactor step skipped → the BASE_URL config block injected by the
+// refactorer is absent
+IntegrationTestHelper.assertFileDoesNotContain(generated, "const BASE_URL");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=generate-test-resources

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>convert-har</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies that loadtest:convert turns a small fixture HAR into a Vaadin-aware
+        k6 script. External domains are filtered and the Vaadin helper import is
+        injected by the refactoring step.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>convert</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>convert</goal>
+                        </goals>
+                        <configuration>
+                            <harFile>${project.basedir}/src/test/resources/recorded.har</harFile>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <outputName>recorded</outputName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/src/test/resources/recorded.har
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/src/test/resources/recorded.har
@@ -1,0 +1,90 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "testbench-it", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2026-01-01T00:00:00.000Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8080/",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {"size": 0, "mimeType": "text/html"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {"blocked": 0, "dns": 0, "connect": 0, "send": 0, "wait": 0, "receive": 0}
+      },
+      {
+        "startedDateTime": "2026-01-01T00:00:00.100Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8080/?v-r=init&location=",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {"size": 0, "mimeType": "application/json"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {"blocked": 0, "dns": 0, "connect": 0, "send": 0, "wait": 0, "receive": 0}
+      },
+      {
+        "startedDateTime": "2026-01-01T00:00:00.200Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/collect?v=1",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [],
+          "cookies": [],
+          "content": {"size": 0, "mimeType": "image/gif"},
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {"blocked": 0, "dns": 0, "connect": 0, "send": 0, "wait": 0, "receive": 0}
+      }
+    ],
+    "pages": []
+  }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/convert-har/verify.bsh
@@ -1,0 +1,18 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+Path k6Script = basePath.resolve("target/k6/tests/recorded.js");
+Path k6Helpers = basePath.resolve("target/k6/utils/vaadin-k6-helpers.js");
+
+IntegrationTestHelper.assertFileExists(k6Script);
+IntegrationTestHelper.assertFileExists(k6Helpers);
+
+// Refactor step injects the Vaadin helper import
+IntegrationTestHelper.assertFileContains(k6Script, "vaadin-k6-helpers.js");
+
+// Default filtering removes external (google-analytics) requests
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "google-analytics.com");
+
+// k6 entry function is generated
+IntegrationTestHelper.assertFileContains(k6Script, "export default function");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/invoker.properties
@@ -1,0 +1,4 @@
+# High ordinal makes this IT execute first so other ITs can reference the
+# packaged JAR by relative path.
+invoker.ordinal=100
+invoker.goals=clean package

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/pom.xml
@@ -12,15 +12,16 @@
     <name>demo-server</name>
     <description>
         Minimal Vaadin Flow + Spring Boot application used as a fixture by the
-        testbench-converter-plugin integration tests.
-        Built first via invoker.ordinal so other ITs can reference the
-        repackaged JAR by relative path.
+        testbench-converter-plugin integration tests. Built first via
+        invoker.ordinal so other ITs can reference the repackaged JAR by
+        relative path. Depends only on Flow (open source) and TestBench — no
+        Vaadin platform / flow-components artifacts — so the IT can resolve
+        every dependency from the Flow snapshot repository alone.
     </description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
-        <vaadin.version>@vaadin.version@</vaadin.version>
         <flow.version>@flow.version@</flow.version>
         <spring.boot.version>@spring.boot.version@</spring.boot.version>
         <testbench.version>@project.version@</testbench.version>
@@ -37,8 +38,8 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${vaadin.version}</version>
+                <artifactId>flow-bom</artifactId>
+                <version>${flow.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -46,9 +47,20 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Vaadin Flow Spring integration: pulls in flow-server +
+             SpringServlet auto-configuration. Avoids vaadin-spring-boot-starter
+             which would drag in the full platform / flow-components stack. -->
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <artifactId>vaadin-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -65,17 +77,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-button-testbench</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-text-field-testbench</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-notification-testbench</artifactId>
+            <artifactId>flow-html-components-testbench</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>demo-server</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <name>demo-server</name>
+    <description>
+        Minimal Vaadin Flow + Spring Boot application used as a fixture by the
+        testbench-converter-plugin integration tests.
+        Built first via invoker.ordinal so other ITs can reference the
+        repackaged JAR by relative path.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <vaadin.version>@vaadin.version@</vaadin.version>
+        <flow.version>@flow.version@</flow.version>
+        <spring.boot.version>@spring.boot.version@</spring.boot.version>
+        <testbench.version>@project.version@</testbench.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-bom</artifactId>
+                <version>${vaadin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- TestBench scenario for record-testbench IT -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-core-junit6</artifactId>
+            <version>${testbench.version}</version>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-button-testbench</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-text-field-testbench</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-notification-testbench</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>testbench-loadtest-support</artifactId>
+            <version>${testbench.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Playwright for record-playwright IT -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.58.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>demo-server</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Failsafe is invoked directly (failsafe:integration-test) by the
+                 record goal, which forks a new Maven against this project. The
+                 plugin must be on the build classpath; phase binding is not
+                 needed here because the converter plugin orchestrates the
+                 lifecycle. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/Application.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/Application.java
@@ -11,12 +11,9 @@ package com.vaadin.test.loadtest;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.theme.lumo.Lumo;
 
 @SpringBootApplication
-@StyleSheet(Lumo.STYLESHEET)
 public class Application implements AppShellConfigurator {
 
     public static void main(String[] args) {

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/Application.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/Application.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.test.loadtest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@SpringBootApplication
+@StyleSheet(Lumo.STYLESHEET)
+public class Application implements AppShellConfigurator {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/HelloWorldView.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/HelloWorldView.java
@@ -8,22 +8,32 @@
  */
 package com.vaadin.test.loadtest;
 
-import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.notification.Notification;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 @PageTitle("Hello World")
 @Route("")
-public class HelloWorldView extends HorizontalLayout {
+public class HelloWorldView extends Div {
 
     public HelloWorldView() {
-        TextField name = new TextField("Your name");
-        Button sayHello = new Button("Say hello");
-        sayHello.addClickListener(e -> Notification.show("Hello " + name.getValue()));
-        setMargin(true);
-        add(name, sayHello);
+        Input name = new Input();
+        name.setId("name");
+        NativeLabel nameLabel = new NativeLabel("Your name");
+        nameLabel.setFor(name);
+
+        Span greeting = new Span();
+        greeting.setId("greeting");
+
+        NativeButton sayHello = new NativeButton("Say hello",
+                e -> greeting.setText("Hello " + name.getValue()));
+        sayHello.setId("say-hello");
+
+        getStyle().set("padding", "1em");
+        add(nameLabel, name, sayHello, greeting);
     }
 }

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/HelloWorldView.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/java/com/vaadin/test/loadtest/HelloWorldView.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.test.loadtest;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@PageTitle("Hello World")
+@Route("")
+public class HelloWorldView extends HorizontalLayout {
+
+    public HelloWorldView() {
+        TextField name = new TextField("Your name");
+        Button sayHello = new Button("Say hello");
+        sayHello.addClickListener(e -> Notification.show("Hello " + name.getValue()));
+        setMargin(true);
+        add(name, sayHello);
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/resources/application.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+vaadin.allowed-packages=com.vaadin,com.vaadin.test.loadtest
+vaadin.launch-browser=false
+
+# Actuator: only health/metrics, on a separate port matching what
+# StartServerMojo polls when managementPort is configured.
+management.endpoints.web.exposure.include=health,metrics
+management.endpoint.health.show-details=always

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/AbstractIT.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/AbstractIT.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.test.loadtest;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import com.vaadin.testbench.BrowserTestBase;
+import com.vaadin.testbench.loadtest.LoadTestItHelper;
+
+/**
+ * Base for IT scenarios. When the system property {@code k6.proxy.host} is
+ * set (e.g., {@code k6.proxy.host=localhost:6000}), {@link LoadTestItHelper}
+ * routes the browser through the recording proxy started by
+ * {@code TestbenchRecordMojo}.
+ */
+public abstract class AbstractIT extends BrowserTestBase {
+
+    @BeforeEach
+    public void open() {
+        setDriver(LoadTestItHelper.openWithProxy(getDriver(), getViewUrl()));
+    }
+
+    private String getViewUrl() {
+        return LoadTestItHelper.getRootURL() + "/" + getViewName();
+    }
+
+    public abstract String getViewName();
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldIT.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldIT.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.test.loadtest;
+
+import org.junit.jupiter.api.Assertions;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.testbench.BrowserTest;
+
+/**
+ * User scenario for the HelloWorldView. Drives the browser through the
+ * recording proxy so that {@code TestbenchRecordMojo} captures a HAR.
+ */
+public class HelloWorldIT extends AbstractIT {
+
+    private static final String TEST_NAME = "Vaadin User";
+
+    @BrowserTest
+    public void helloWorldWorkflow() {
+        TextFieldElement nameField = $(TextFieldElement.class)
+                .withCaption("Your name").waitForFirst();
+        nameField.setValue(TEST_NAME);
+
+        ButtonElement sayHelloButton = $(ButtonElement.class)
+                .withCaption("Say hello").waitForFirst();
+        sayHelloButton.click();
+
+        NotificationElement notification = $(NotificationElement.class)
+                .waitForFirst();
+        Assertions.assertTrue(
+                notification.getText().contains("Hello " + TEST_NAME),
+                "Notification should greet the entered name, got: "
+                        + notification.getText());
+    }
+
+    @Override
+    public String getViewName() {
+        return "";
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldIT.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldIT.java
@@ -10,9 +10,9 @@ package com.vaadin.test.loadtest;
 
 import org.junit.jupiter.api.Assertions;
 
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.notification.testbench.NotificationElement;
-import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.testbench.BrowserTest;
 
 /**
@@ -25,20 +25,18 @@ public class HelloWorldIT extends AbstractIT {
 
     @BrowserTest
     public void helloWorldWorkflow() {
-        TextFieldElement nameField = $(TextFieldElement.class)
-                .withCaption("Your name").waitForFirst();
+        InputTextElement nameField = $(InputTextElement.class).id("name");
         nameField.setValue(TEST_NAME);
 
-        ButtonElement sayHelloButton = $(ButtonElement.class)
-                .withCaption("Say hello").waitForFirst();
+        NativeButtonElement sayHelloButton = $(NativeButtonElement.class)
+                .id("say-hello");
         sayHelloButton.click();
 
-        NotificationElement notification = $(NotificationElement.class)
-                .waitForFirst();
+        SpanElement greeting = $(SpanElement.class).id("greeting");
         Assertions.assertTrue(
-                notification.getText().contains("Hello " + TEST_NAME),
-                "Notification should greet the entered name, got: "
-                        + notification.getText());
+                greeting.getText().contains("Hello " + TEST_NAME),
+                "Greeting should mention the entered name, got: "
+                        + greeting.getText());
     }
 
     @Override

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldPlaywrightIT.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldPlaywrightIT.java
@@ -69,7 +69,7 @@ public class HelloWorldPlaywrightIT {
         page.getByLabel("Your name").fill(TEST_NAME);
         page.getByRole(AriaRole.BUTTON,
                 new Page.GetByRoleOptions().setName("Say hello")).click();
-        assertThat(page.locator("vaadin-notification-card"))
+        assertThat(page.locator("#greeting"))
                 .containsText("Hello " + TEST_NAME);
     }
 }

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldPlaywrightIT.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/demo-server/src/test/java/com/vaadin/test/loadtest/HelloWorldPlaywrightIT.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.test.loadtest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
+import com.vaadin.testbench.loadtest.PlaywrightHelper;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Playwright user scenario for the HelloWorldView. When the
+ * {@code k6.harOutputPath} system property is set, {@link PlaywrightHelper}
+ * configures the BrowserContext with native HAR recording and
+ * {@code TestbenchRecordMojo} converts the resulting HAR into a k6 script.
+ * <p>
+ * Uses the system-installed Chrome via {@code setChannel("chrome")} to avoid
+ * requiring a separate Playwright Chromium download.
+ */
+public class HelloWorldPlaywrightIT {
+
+    private static final String TEST_NAME = "Vaadin User";
+
+    private Playwright playwright;
+    private Browser browser;
+    private BrowserContext context;
+    private Page page;
+
+    @BeforeEach
+    public void setUp() {
+        playwright = Playwright.create();
+        browser = playwright.chromium()
+                .launch(new BrowserType.LaunchOptions().setChannel("chrome")
+                        .setHeadless(true));
+        context = PlaywrightHelper.createBrowserContext(browser);
+        page = context.newPage();
+        page.navigate(PlaywrightHelper.getBaseUrl() + "/");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @Test
+    public void helloWorldWorkflow() {
+        page.getByLabel("Your name").fill(TEST_NAME);
+        page.getByRole(AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Say hello")).click();
+        assertThat(page.locator("vaadin-notification-card"))
+                .containsText("Hello " + TEST_NAME);
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/pom.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>load-profiles</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies that every load profile configurable on the
+        testbench-converter-plugin run goal is honoured against the existing
+        demo-server fixture. Six independent run executions cover all four
+        built-in patterns (constant, ramp, stress, soak), the custom-stages
+        pattern driven by the stages parameter, and one explicit k6
+        executor (shared-iterations) — exercising both the CLI-flag path
+        used by constant/ramping-vus and the embedded-config wrapper path
+        used by every other executor. Each execution targets its own k6
+        test file so the summaries land in distinct paths and verify.bsh
+        can inspect per-profile evidence.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.jar>${project.basedir}/../demo-server/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18480</loadtest.serverPort>
+        <loadtest.managementPort>18482</loadtest.managementPort>
+        <k6.dir>${project.basedir}/src/test/k6</k6.dir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Built-in profile #1 — constant. All VUs start
+                        immediately, no ramp phases. Maps to k6's
+                        constant-vus executor; configured via CLI flags
+                        (no embedded wrapper).
+                    -->
+                    <execution>
+                        <id>run-constant</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/constant.js</testFile>
+                            <virtualUsers>2</virtualUsers>
+                            <duration>3s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Built-in profile #2 — ramp. Ramp up → sustain →
+                        ramp down using k6's ramping-vus executor with
+                        custom rampUp / rampDown durations.
+                    -->
+                    <execution>
+                        <id>run-ramp</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/ramp.js</testFile>
+                            <virtualUsers>2</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>ramp</loadPattern>
+                            <rampUp>1s</rampUp>
+                            <rampDown>1s</rampDown>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Built-in profile #3 — stress. Five-stage pattern
+                        with a 150 % spike phase. The 10s duration is the
+                        smallest that keeps every stage > 0s after the
+                        ms→s rounding inside LoadProfile.formatDuration
+                        (the spike target rounds vus*1.5 up, so vus=2
+                        produces a 3-VU spike).
+                    -->
+                    <execution>
+                        <id>run-stress</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/stress.js</testFile>
+                            <virtualUsers>2</virtualUsers>
+                            <duration>10s</duration>
+                            <loadPattern>stress</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Built-in profile #4 — soak. Quick ramp-up, long
+                        sustain, quick ramp-down. The 10s duration leaves
+                        room for the 5 % ramp phases to round to ≥ 1s.
+                    -->
+                    <execution>
+                        <id>run-soak</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/soak.js</testFile>
+                            <virtualUsers>2</virtualUsers>
+                            <duration>10s</duration>
+                            <loadPattern>soak</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Custom-stages profile. Setting the stages
+                        parameter switches the profile to CUSTOM and
+                        ignores virtualUsers / duration / rampUp /
+                        rampDown. Three stages: ramp 0→2 in 1s, hold at
+                        2 for 2s, ramp down to 0 in 1s.
+                    -->
+                    <execution>
+                        <id>run-custom</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/custom.js</testFile>
+                            <stages>1s:2,2s:2,1s:0</stages>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Explicit executor: shared-iterations. This
+                        executor cannot be configured via CLI flags so
+                        K6RunMojo writes a wrapper script with embedded
+                        scenario options, runs it, then deletes the
+                        wrapper. The summary still records the resulting
+                        iteration count, which verify.bsh asserts.
+                    -->
+                    <execution>
+                        <id>run-executor</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/executor.js</testFile>
+                            <executor>shared-iterations</executor>
+                            <virtualUsers>2</virtualUsers>
+                            <iterations>10</iterations>
+                            <duration>10s</duration>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <!--
+                        Fully custom scenario: customScenario takes
+                        precedence over loadPattern, executor and stages
+                        and is inserted verbatim into the wrapper
+                        script's scenario block. Picks per-vu-iterations
+                        with a distinct iteration count (4 VUs * 5
+                        iters = 20 total) so verify.bsh can confirm the
+                        raw content shaped the run, not a fallback
+                        profile.
+                    -->
+                    <execution>
+                        <id>run-custom-scenario</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <testFile>${k6.dir}/custom-scenario.js</testFile>
+                            <virtualUsers>4</virtualUsers>
+                            <duration>10s</duration>
+                            <customScenario>executor: 'per-vu-iterations', vus: 4, iterations: 5, maxDuration: '10s',</customScenario>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>-1</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/constant.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/constant.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/custom-scenario.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/custom-scenario.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/custom.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/custom.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/executor.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/executor.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/ramp.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/ramp.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/soak.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/soak.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/stress.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/src/test/k6/stress.js
@@ -1,0 +1,22 @@
+// Trivial scenario shared by every load-profiles run execution. Seven
+// copies exist (constant/ramp/stress/soak/custom/executor/custom-scenario)
+// so each pom execution writes its summary to a distinct file and the
+// verify script can inspect per-profile output. Content is intentionally
+// identical across files; the load profile is supplied entirely by the
+// plugin configuration.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  check(http.get(`http://${host}:${port}/`),
+      { 'status 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  return __ENV.SUMMARY_FILE
+      ? { [__ENV.SUMMARY_FILE]: JSON.stringify(data, null, 2) }
+      : {}
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/load-profiles/verify.bsh
@@ -1,0 +1,113 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath  = basedir.toPath();
+Path reportDir = basePath.resolve("src/test/k6/report");
+
+// 1. Each run wrote its summary to a per-profile filename. Existence
+// proves k6 reached the end of the run for that profile. The
+// shared-iterations executor goes through K6RunMojo.runWithEmbedded
+// Config, which runs a generated "wrapper-<test>.js" instead of the
+// original — the summary follows the wrapper's basename.
+String[] summaryFiles = new String[] {
+    "constant-summary.json",
+    "ramp-summary.json",
+    "stress-summary.json",
+    "soak-summary.json",
+    "custom-summary.json",
+    "wrapper-executor-summary.json",
+    "wrapper-custom-scenario-summary.json",
+};
+for (int i = 0; i < summaryFiles.length; i++) {
+    IntegrationTestHelper.assertFileExists(
+        reportDir.resolve(summaryFiles[i]));
+}
+
+// 2. K6RunMojo logs the resolved load profile per execution; check the
+// build.log for each profile's signature so the configuration can be
+// shown to have flowed through. Strings come from LoadProfile.toString.
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: constant (no ramping)");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: ramp (up: 1s, down: 1s)");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: stress (gradual increase with spike)");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: soak (quick ramp, long sustain)");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: custom (3 stages)");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: shared-iterations executor");
+IntegrationTestHelper.assertLogContains(basePath,
+    "Load pattern: custom scenario (raw k6 definition)");
+
+// 3. Every ramping pattern triggers NodeRunner to log the resolved
+// stages. The stage line is "    <duration> → <target> VUs" but the
+// arrow is non-ASCII and may be re-encoded in the captured build.log,
+// so the assertion matches by duration + target only.
+Path log = basePath.resolve("build.log");
+// Ramp: 1s → 2 VUs / 3s → 2 VUs / 1s → 0 VUs.
+IntegrationTestHelper.assertFileMatches(log, "1s.*2 VUs");
+IntegrationTestHelper.assertFileMatches(log, "3s.*2 VUs");
+IntegrationTestHelper.assertFileMatches(log, "1s.*0 VUs");
+// Stress includes a spike phase to ceil(vus * 1.5) = 3 VUs that no
+// other profile produces; matching it confirms the stress stages were
+// generated.
+IntegrationTestHelper.assertFileMatches(log, "2s.*3 VUs");
+// Soak's long sustain stage is 8s at the target VU count — unique to
+// soak with this configuration.
+IntegrationTestHelper.assertFileMatches(log, "8s.*2 VUs");
+
+// 4. Explicit executors take the embedded-config wrapper path. The log
+// entry from NodeRunner.runK6Test confirms the wrapper was used.
+IntegrationTestHelper.assertLogContains(basePath,
+    "Using embedded scenario configuration");
+IntegrationTestHelper.assertLogContains(basePath, "Generated wrapper:");
+
+// 5. Per-profile sanity checks against the summary JSON: confirms the
+// profile actually shaped the run, not just the log line.
+//
+// constant: vus_max equals the configured 2.
+String constantSummary = IntegrationTestHelper.readFile(
+    reportDir.resolve("constant-summary.json"));
+if (!java.util.regex.Pattern
+        .compile("\"vus_max\"[^\\}]*?\"max\"\\s*:\\s*2\\b",
+            java.util.regex.Pattern.DOTALL)
+        .matcher(constantSummary).find()) {
+    throw new RuntimeException(
+        "constant profile: expected vus_max.max == 2 in summary");
+}
+// stress: spike phase pushed VUs to 3, so vus_max must reflect that.
+String stressSummary = IntegrationTestHelper.readFile(
+    reportDir.resolve("stress-summary.json"));
+if (!java.util.regex.Pattern
+        .compile("\"vus_max\"[^\\}]*?\"max\"\\s*:\\s*3\\b",
+            java.util.regex.Pattern.DOTALL)
+        .matcher(stressSummary).find()) {
+    throw new RuntimeException(
+        "stress profile: expected vus_max.max == 3 (spike phase) in summary");
+}
+// shared-iterations executor: the configured iteration count must be
+// honoured exactly.
+String executorSummary = IntegrationTestHelper.readFile(
+    reportDir.resolve("wrapper-executor-summary.json"));
+if (!java.util.regex.Pattern
+        .compile("\"iterations\"\\s*:\\s*\\{[^\\}]*?\"count\"\\s*:\\s*10\\b",
+            java.util.regex.Pattern.DOTALL)
+        .matcher(executorSummary).find()) {
+    throw new RuntimeException(
+        "shared-iterations executor: expected iterations.count == 10 in summary");
+}
+// customScenario: the raw block selects per-vu-iterations with vus=4
+// and iterations=5 (per VU), so 20 total iterations must be reported.
+// Distinct from the shared-iterations executor's 10, so any fallback
+// to a built-in profile would be caught.
+String customScenarioSummary = IntegrationTestHelper.readFile(
+    reportDir.resolve("wrapper-custom-scenario-summary.json"));
+if (!java.util.regex.Pattern
+        .compile("\"iterations\"\\s*:\\s*\\{[^\\}]*?\"count\"\\s*:\\s*20\\b",
+            java.util.regex.Pattern.DOTALL)
+        .matcher(customScenarioSummary).find()) {
+    throw new RuntimeException(
+        "customScenario: expected iterations.count == 20 (vus=4 * iterations=5) in summary");
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>record-playwright</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        End-to-end run of the loadtest:record-playwright goal. Starts demo-server,
+        runs HelloWorldPlaywrightIT (which captures a HAR via Playwright's native
+        recording), stops the server. Verifies the HAR, generated k6 script,
+        and source-hash cache file. Requires Chrome on PATH (Playwright is
+        configured with channel=chrome). The k6 binary is supplied via
+        -Dk6.binary from the parent pom's invoker config (downloaded by the
+        000-install-k6 bootstrap IT).
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.dir>${project.basedir}/../demo-server</demo.server.dir>
+        <demo.server.jar>${demo.server.dir}/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18380</loadtest.serverPort>
+        <loadtest.managementPort>18382</loadtest.managementPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>record-playwright</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>record-playwright</goal>
+                        </goals>
+                        <configuration>
+                            <testClasses>
+                                <testClass>HelloWorldPlaywrightIT</testClass>
+                            </testClasses>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <!-- Run failsafe in the demo-server clone where the
+                                 IT class was compiled in test-compile phase. -->
+                            <testWorkDir>${demo.server.dir}</testWorkDir>
+                            <harDir>${project.build.directory}</harDir>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <forceRecord>true</forceRecord>
+                            <!-- Skip think-time so a single iteration completes
+                                 quickly enough for the IT's short duration. -->
+                            <thinkTimeEnabled>false</thinkTimeEnabled>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-recorded-scenario</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testDir>${project.build.directory}/k6/tests</testDir>
+                            <virtualUsers>1</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
@@ -58,7 +58,7 @@ IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:1838
 IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
 // Global checks threshold with abortOnFail
 IntegrationTestHelper.assertFileContains(k6Script,
-    "checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }]");
+    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]");
 // Global request-duration thresholds
 IntegrationTestHelper.assertFileContains(k6Script,
     "http_req_duration: ['p(95)<2000', 'p(99)<5000']");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
@@ -1,0 +1,189 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+Path k6Tests = basePath.resolve("target/k6/tests");
+Path k6Utils = basePath.resolve("target/k6/utils");
+
+// HAR captured by Playwright's native recording
+Path har = basePath.resolve("target/hello-world-playwright-recording.har");
+IntegrationTestHelper.assertFileExists(har);
+if (Files.size(har) < 100) {
+    throw new RuntimeException("HAR file unexpectedly small: " + Files.size(har));
+}
+// HAR must contain the recorded HelloWorld interaction
+IntegrationTestHelper.assertFileContains(har, "v-r=init");
+IntegrationTestHelper.assertFileContains(har, "v-r=uidl");
+IntegrationTestHelper.assertFileContains(har, "Vaadin User");
+
+// Raw har-to-k6 output (pre-refactor)
+Path rawScript = k6Tests.resolve("hello-world-playwright-generated.js");
+IntegrationTestHelper.assertFileExists(rawScript);
+
+// Refactored k6 script (Vaadin-aware final output)
+Path k6Script = k6Tests.resolve("hello-world-playwright.js");
+IntegrationTestHelper.assertFileExists(k6Script);
+
+// --- Imports / structure ------------------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import http from 'k6/http'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { check, fail } from 'k6'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { SharedArray } from 'k6/data'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "../utils/vaadin-k6-helpers.js");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { textSummary } from '../utils/k6-summary.js'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "updateNodeMap, resolveNode");
+IntegrationTestHelper.assertFileContains(k6Script, "export default function");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "export function handleSummary");
+
+// --- Server config injected by refactor --------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const APP_IP = __ENV.APP_IP || 'localhost'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const APP_PORT = __ENV.APP_PORT || '8080'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`");
+
+// Recorded port (18380) must have been replaced by ${BASE_URL} in all
+// quoted URLs (the literal still appears in `// Request N:` comments).
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "'http://localhost:18380");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:18380");
+
+// --- Thresholds ---------------------------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
+// Global checks threshold with abortOnFail
+IntegrationTestHelper.assertFileContains(k6Script,
+    "checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }]");
+// Global request-duration thresholds
+IntegrationTestHelper.assertFileContains(k6Script,
+    "http_req_duration: ['p(95)<2000', 'p(99)<5000']");
+// Per-request tagged thresholds for each captured step
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world-playwright: 1 GET /}': ['max>=0']");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world-playwright: 5 GET init}': ['max>=0']");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world-playwright: 9 POST uidl}': ['max>=0']");
+
+// --- Input data CSV -----------------------------------------------------
+Path csv = k6Tests.resolve("hello-world-playwright-data.csv");
+IntegrationTestHelper.assertFileExists(csv);
+String csvContent = IntegrationTestHelper.readFile(csv);
+String csvNormalized = csvContent.replace("\r\n", "\n").trim();
+// Header (input_1 — derived from the single text-field on HelloWorldView)
+// followed by the recorded value (TEST_NAME from HelloWorldPlaywrightIT)
+if (!csvNormalized.startsWith("input_1\n")) {
+    throw new RuntimeException(
+        "hello-world-playwright-data.csv should start with header 'input_1', got: " + csvContent);
+}
+if (!csvNormalized.contains("\nVaadin User")) {
+    throw new RuntimeException(
+        "hello-world-playwright-data.csv should contain row 'Vaadin User', got: " + csvContent);
+}
+// Script must consume the CSV
+IntegrationTestHelper.assertFileContains(k6Script,
+    "open('./hello-world-playwright-data.csv')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "new SharedArray('input data'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "inputData[Math.floor(Math.random() * inputData.length)]");
+// The text-field value substitutes the CSV column rather than the literal
+IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
+
+// --- Recorded request flow ---------------------------------------------
+// Playwright captures the workflow as 11 requests (text-field mSync + button
+// click are batched into a single UIDL POST).
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 11: POST");
+IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
+IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "tags: { name: 'hello-world-playwright: 5 GET init' }");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "tags: { name: 'hello-world-playwright: 9 POST uidl' }");
+
+// Recorded user actions: text-field mSync + change, button click, notification close
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-text-field#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-button#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-notification#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
+IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
+IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"opened-changed\"");
+
+// --- Vaadin session bootstrapping --------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "let uiId = response.body.match(/\"v-uiId\"");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "nodeMap = updateNodeMap(nodeMap, response.body)");
+// Init / UIDL response validation checks
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'init request succeeded': (r) => r.status === 200");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'valid init response':");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'UIDL request succeeded': (r) => r.status === 200");
+IntegrationTestHelper.assertFileContains(k6Script, "'no server error':");
+IntegrationTestHelper.assertFileContains(k6Script, "'security key valid':");
+// Sync counters tracked from UIDL responses
+IntegrationTestHelper.assertFileContains(k6Script,
+    "syncId = Math.max(0, parseInt(syncIdMatch[1]))");
+IntegrationTestHelper.assertFileContains(k6Script, "clientId++");
+
+// --- Think times: pom sets thinkTimeEnabled=false ----------------------
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "// Think time:");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "sleep(");
+IntegrationTestHelper.assertLogContains(basePath, "Think times: disabled");
+
+// --- handleSummary configures stdout + optional JSON file --------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "textSummary(consoleData, { indent: ' ', enableColors: true })");
+IntegrationTestHelper.assertFileContains(k6Script, "__ENV.SUMMARY_FILE");
+
+// --- Vaadin helpers + summary lib copied next to the tests -------------
+IntegrationTestHelper.assertFileExists(k6Utils.resolve("vaadin-k6-helpers.js"));
+IntegrationTestHelper.assertFileExists(k6Utils.resolve("k6-summary.js"));
+
+// --- Source-hash cache so subsequent runs short-circuit ----------------
+Path hashFile = k6Tests.resolve("hello-world-playwright.hash");
+IntegrationTestHelper.assertFileExists(hashFile);
+String hash = IntegrationTestHelper.readFile(hashFile).trim();
+if (!hash.matches("[a-f0-9]{64}")) {
+    throw new RuntimeException(
+        "hello-world-playwright.hash should contain a 64-char SHA-256 hex digest, got: " + hash);
+}
+
+// --- Build log proves Playwright + refactor pipeline ran ---------------
+IntegrationTestHelper.assertLogContains(basePath,
+    "Using Playwright native HAR recording");
+IntegrationTestHelper.assertLogContains(basePath, "HAR converted to k6 test");
+IntegrationTestHelper.assertLogContains(basePath, "Refactored k6 test written to");
+IntegrationTestHelper.assertLogContains(basePath, "Detected Vaadin session");
+
+// --- k6 run produced JSON + HTML reports -------------------------------
+Path reportDir = k6Tests.resolve("report");
+Path summaryJson = reportDir.resolve("hello-world-playwright-summary.json");
+Path summaryHtml = reportDir.resolve("hello-world-playwright-summary.html");
+IntegrationTestHelper.assertDirectoryExists(reportDir);
+IntegrationTestHelper.assertFileExists(summaryJson);
+IntegrationTestHelper.assertFileExists(summaryHtml);
+IntegrationTestHelper.assertFileContains(summaryJson, "http_req_duration");
+IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
+IntegrationTestHelper.assertFileContains(summaryJson, "\"checks\"");
+IntegrationTestHelper.assertFileContains(summaryJson, "iterations");
+// HTML report renders the k6 result template
+IntegrationTestHelper.assertFileContains(summaryHtml, "k6 Load Test Report");
+
+// Build log proves k6 actually executed the recorded script
+IntegrationTestHelper.assertLogContains(basePath, "k6 test completed successfully");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
@@ -1,162 +1,165 @@
 import java.nio.file.*;
 import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
 
-Path basePath = basedir.toPath();
-Path k6Tests = basePath.resolve("target/k6/tests");
-Path k6Utils = basePath.resolve("target/k6/utils");
+// Recorded flow: page GET, 2 static GETs, init, 3 more static GETs, then
+// 2 UIDL POSTs:
+//   8 = ui-navigate (initial page-load sync)
+//   9 = batched input mSync+change AND button click (last request — uses
+//       handleSummary as the section end marker since there is no
+//       "// Request 10:"). Playwright batches both user actions into a
+//       single POST, so input sync and click share request 9.
 
-// HAR captured by Playwright's native recording
-Path har = basePath.resolve("target/hello-world-playwright-recording.har");
+// ----- Paths -------------------------------------------------------------
+Path basePath    = basedir.toPath();
+Path k6Tests     = basePath.resolve("target/k6/tests");
+Path k6Utils     = basePath.resolve("target/k6/utils");
+Path har         = basePath.resolve("target/hello-world-playwright-recording.har");
+Path rawScript   = k6Tests.resolve("hello-world-playwright-generated.js");
+Path k6Script    = k6Tests.resolve("hello-world-playwright.js");
+Path csv         = k6Tests.resolve("hello-world-playwright-data.csv");
+Path hashFile    = k6Tests.resolve("hello-world-playwright.hash");
+Path reportDir   = k6Tests.resolve("report");
+Path summaryJson = reportDir.resolve("hello-world-playwright-summary.json");
+Path summaryHtml = reportDir.resolve("hello-world-playwright-summary.html");
+
+// ----- HAR captured by Playwright's native recording ---------------------
 IntegrationTestHelper.assertFileExists(har);
 if (Files.size(har) < 100) {
     throw new RuntimeException("HAR file unexpectedly small: " + Files.size(har));
 }
-// HAR must contain the recorded HelloWorld interaction
 IntegrationTestHelper.assertFileContains(har, "v-r=init");
 IntegrationTestHelper.assertFileContains(har, "v-r=uidl");
 IntegrationTestHelper.assertFileContains(har, "Vaadin User");
 
-// Raw har-to-k6 output (pre-refactor)
-Path rawScript = k6Tests.resolve("hello-world-playwright-generated.js");
+// ----- Both raw and refactored k6 outputs exist --------------------------
 IntegrationTestHelper.assertFileExists(rawScript);
-
-// Refactored k6 script (Vaadin-aware final output)
-Path k6Script = k6Tests.resolve("hello-world-playwright.js");
 IntegrationTestHelper.assertFileExists(k6Script);
 
-// --- Imports / structure ------------------------------------------------
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import http from 'k6/http'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { check, fail } from 'k6'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { SharedArray } from 'k6/data'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "../utils/vaadin-k6-helpers.js");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { textSummary } from '../utils/k6-summary.js'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "updateNodeMap, resolveNode");
-IntegrationTestHelper.assertFileContains(k6Script, "export default function");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "export function handleSummary");
+// ----- Script structure: imports + helpers come before the entry function
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "import http from 'k6/http'",
+    "import { check, fail } from 'k6'",
+    "import { SharedArray } from 'k6/data'",
+    "updateNodeMap, resolveNode",
+    "../utils/vaadin-k6-helpers.js",
+    "import { textSummary } from '../utils/k6-summary.js'",
+    "export default function",
+    "export function handleSummary"
+});
 
-// --- Server config injected by refactor --------------------------------
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const APP_IP = __ENV.APP_IP || 'localhost'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const APP_PORT = __ENV.APP_PORT || '8080'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`");
-
-// Recorded port (18380) must have been replaced by ${BASE_URL} in all
-// quoted URLs (the literal still appears in `// Request N:` comments).
+// ----- Server config block: APP_IP, APP_PORT, BASE_URL declared in order -
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "const APP_IP = __ENV.APP_IP || 'localhost'",
+    "const APP_PORT = __ENV.APP_PORT || '8080'",
+    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`"
+});
+// The recorded port (18380) must have been replaced inside every quoted URL.
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "'http://localhost:18380");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:18380");
 
-// --- Thresholds ---------------------------------------------------------
-IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
-// Global checks threshold with abortOnFail
-IntegrationTestHelper.assertFileContains(k6Script,
-    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]");
-// Global request-duration thresholds
-IntegrationTestHelper.assertFileContains(k6Script,
-    "http_req_duration: ['p(95)<2000', 'p(99)<5000']");
-// Per-request tagged thresholds for each captured step
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world-playwright: 1 GET /}': ['max>=0']");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world-playwright: 4 GET init}': ['max>=0']");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world-playwright: 8 POST uidl}': ['max>=0']");
+// ----- Threshold rules live inside the thresholds block, not somewhere else
+IntegrationTestHelper.assertSectionContains(k6Script, "thresholds: {", "},", new String[] {
+    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]",
+    "http_req_duration: ['p(95)<2000', 'p(99)<5000']",
+    "'http_req_duration{name:hello-world-playwright: 1 GET /}': ['max>=0']",
+    "'http_req_duration{name:hello-world-playwright: 4 GET init}': ['max>=0']",
+    "'http_req_duration{name:hello-world-playwright: 9 POST uidl}': ['max>=0']"
+});
 
-// --- Input data CSV -----------------------------------------------------
-Path csv = k6Tests.resolve("hello-world-playwright-data.csv");
+// ----- Input data CSV ---------------------------------------------------
+// Header (input_1, derived from the single text-field on HelloWorldView)
+// followed by the recorded value (TEST_NAME from HelloWorldPlaywrightIT).
 IntegrationTestHelper.assertFileExists(csv);
-String csvContent = IntegrationTestHelper.readFile(csv);
-String csvNormalized = csvContent.replace("\r\n", "\n").trim();
-// Header (input_1 — derived from the single text-field on HelloWorldView)
-// followed by the recorded value (TEST_NAME from HelloWorldPlaywrightIT)
+String csvNormalized = IntegrationTestHelper.readFile(csv).replace("\r\n", "\n").trim();
 if (!csvNormalized.startsWith("input_1\n")) {
     throw new RuntimeException(
-        "hello-world-playwright-data.csv should start with header 'input_1', got: " + csvContent);
+        "hello-world-playwright-data.csv should start with header 'input_1', got: " + csvNormalized);
 }
 if (!csvNormalized.contains("\nVaadin User")) {
     throw new RuntimeException(
-        "hello-world-playwright-data.csv should contain row 'Vaadin User', got: " + csvContent);
+        "hello-world-playwright-data.csv should contain row 'Vaadin User', got: " + csvNormalized);
 }
-// Script must consume the CSV
+// Script must consume the CSV instead of inlining the recorded value.
 IntegrationTestHelper.assertFileContains(k6Script,
     "open('./hello-world-playwright-data.csv')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "new SharedArray('input data'");
+IntegrationTestHelper.assertFileContains(k6Script, "new SharedArray('input data'");
 IntegrationTestHelper.assertFileContains(k6Script,
     "inputData[Math.floor(Math.random() * inputData.length)]");
-// The text-field value substitutes the CSV column rather than the literal
 IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
 
-// --- Recorded request flow ---------------------------------------------
-// Playwright captures the workflow as 9 requests: page GET, 2 static GETs,
-// init, 3 more static GETs, then 2 UIDLs — the input mSync+change and the
-// button click are batched into a single POST.
-IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
+// ----- Recorded request flow --------------------------------------------
+// The ordered check enforces that the key requests appear in temporal order
+// in the script (page → init → batched input/click).
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "// Request 1: GET",
+    "// Request 4:",
+    "// Request 9:"
+});
 IntegrationTestHelper.assertFileContains(k6Script, "// Request 9: POST");
-IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
-IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world-playwright: 4 GET init' }");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world-playwright: 8 POST uidl' }");
 
-// Recorded user actions: input value sync, button click. The view uses
-// Flow's native HTML components (Input, NativeButton, Span) with explicit
-// element IDs, so resolveNode() looks them up by id rather than tag#index.
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'name')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'say-hello')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
-IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
+// ----- Recorded request bodies live in the right request block ----------
+// HelloWorldView uses Flow's native HTML components (Input, NativeButton,
+// Span) with explicit element IDs, so resolveNode() looks them up by id.
 
-// --- Vaadin session bootstrapping --------------------------------------
+// Request 4 (GET init): URL and tag.
+IntegrationTestHelper.assertSectionContains(k6Script,
+    "// Request 4:", "// Request 5:", new String[] {
+        "?v-r=init",
+        "tags: { name: 'hello-world-playwright: 4 GET init' }"
+    });
+// Request 9 (batched input mSync+change AND button click): URL, tag,
+// resolveNode by id for both elements, the input value substituted from
+// the CSV row, and the click event payload. Playwright batches both user
+// actions into this single POST.
+IntegrationTestHelper.assertSectionContains(k6Script,
+    "// Request 9:", "export function handleSummary", new String[] {
+        "?v-r=uidl&v-uiId=${uiId}",
+        "tags: { name: 'hello-world-playwright: 9 POST uidl' }",
+        "resolveNode(nodeMap, 'name')",
+        "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"",
+        "resolveNode(nodeMap, 'say-hello')",
+        "\"event\":\"click\""
+    });
+
+// ----- Vaadin session bootstrapping + response checks --------------------
 IntegrationTestHelper.assertFileContains(k6Script,
     "let uiId = response.body.match(/\"v-uiId\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "nodeMap = updateNodeMap(nodeMap, response.body)");
-// Init / UIDL response validation checks
 IntegrationTestHelper.assertFileContains(k6Script,
     "'init request succeeded': (r) => r.status === 200");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'valid init response':");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'UIDL request succeeded': (r) => r.status === 200");
-IntegrationTestHelper.assertFileContains(k6Script, "'no server error':");
-IntegrationTestHelper.assertFileContains(k6Script, "'security key valid':");
-// Sync counters tracked from UIDL responses
+IntegrationTestHelper.assertFileContains(k6Script, "'valid init response':");
+IntegrationTestHelper.assertSectionContains(k6Script,
+        "// Abort iteration and trigger test abort if UIDL response is invalid", "}))", new String[] {
+    "'UIDL request succeeded': (r) => r.status === 200",
+    "'no server error': (r) => !r.body.includes('\"appError\"')",
+    "'no exception': (r) => !r.body.includes('Exception')",
+    "'session is valid': (r) => !r.body.includes('Your session needs to be refreshed')",
+    "'security key valid': (r) => !r.body.includes('Invalid security key')",
+    "'valid UIDL response': () => syncIdMatch !== null"
+});
 IntegrationTestHelper.assertFileContains(k6Script,
     "syncId = Math.max(0, parseInt(syncIdMatch[1]))");
 IntegrationTestHelper.assertFileContains(k6Script, "clientId++");
 
-// --- Think times: pom sets thinkTimeEnabled=false ----------------------
+// ----- Think times disabled (pom sets thinkTimeEnabled=false) -----------
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "// Think time:");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "sleep(");
 IntegrationTestHelper.assertLogContains(basePath, "Think times: disabled");
 
-// --- handleSummary configures stdout + optional JSON file --------------
+// ----- handleSummary: stdout + optional JSON file -----------------------
 IntegrationTestHelper.assertFileContains(k6Script,
     "textSummary(consoleData, { indent: ' ', enableColors: true })");
 IntegrationTestHelper.assertFileContains(k6Script, "__ENV.SUMMARY_FILE");
 
-// --- Vaadin helpers + summary lib copied next to the tests -------------
+// ----- Vaadin helpers + summary lib copied next to the tests -----------
 IntegrationTestHelper.assertFileExists(k6Utils.resolve("vaadin-k6-helpers.js"));
 IntegrationTestHelper.assertFileExists(k6Utils.resolve("k6-summary.js"));
 
-// --- Source-hash cache so subsequent runs short-circuit ----------------
-Path hashFile = k6Tests.resolve("hello-world-playwright.hash");
+// ----- Source-hash cache so subsequent runs short-circuit ---------------
 IntegrationTestHelper.assertFileExists(hashFile);
 String hash = IntegrationTestHelper.readFile(hashFile).trim();
 if (!hash.matches("[a-f0-9]{64}")) {
@@ -164,17 +167,13 @@ if (!hash.matches("[a-f0-9]{64}")) {
         "hello-world-playwright.hash should contain a 64-char SHA-256 hex digest, got: " + hash);
 }
 
-// --- Build log proves Playwright + refactor pipeline ran ---------------
-IntegrationTestHelper.assertLogContains(basePath,
-    "Using Playwright native HAR recording");
+// ----- Build log proves the recording + refactor pipeline ran -----------
+IntegrationTestHelper.assertLogContains(basePath, "Using Playwright native HAR recording");
 IntegrationTestHelper.assertLogContains(basePath, "HAR converted to k6 test");
 IntegrationTestHelper.assertLogContains(basePath, "Refactored k6 test written to");
 IntegrationTestHelper.assertLogContains(basePath, "Detected Vaadin session");
 
-// --- k6 run produced JSON + HTML reports -------------------------------
-Path reportDir = k6Tests.resolve("report");
-Path summaryJson = reportDir.resolve("hello-world-playwright-summary.json");
-Path summaryHtml = reportDir.resolve("hello-world-playwright-summary.html");
+// ----- k6 run produced JSON + HTML reports ------------------------------
 IntegrationTestHelper.assertDirectoryExists(reportDir);
 IntegrationTestHelper.assertFileExists(summaryJson);
 IntegrationTestHelper.assertFileExists(summaryHtml);
@@ -182,8 +181,5 @@ IntegrationTestHelper.assertFileContains(summaryJson, "http_req_duration");
 IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
 IntegrationTestHelper.assertFileContains(summaryJson, "\"checks\"");
 IntegrationTestHelper.assertFileContains(summaryJson, "iterations");
-// HTML report renders the k6 result template
 IntegrationTestHelper.assertFileContains(summaryHtml, "k6 Load Test Report");
-
-// Build log proves k6 actually executed the recorded script
 IntegrationTestHelper.assertLogContains(basePath, "k6 test completed successfully");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
@@ -66,9 +66,9 @@ IntegrationTestHelper.assertFileContains(k6Script,
 IntegrationTestHelper.assertFileContains(k6Script,
     "'http_req_duration{name:hello-world-playwright: 1 GET /}': ['max>=0']");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world-playwright: 5 GET init}': ['max>=0']");
+    "'http_req_duration{name:hello-world-playwright: 4 GET init}': ['max>=0']");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world-playwright: 9 POST uidl}': ['max>=0']");
+    "'http_req_duration{name:hello-world-playwright: 8 POST uidl}': ['max>=0']");
 
 // --- Input data CSV -----------------------------------------------------
 Path csv = k6Tests.resolve("hello-world-playwright-data.csv");
@@ -97,28 +97,28 @@ IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
 
 // --- Recorded request flow ---------------------------------------------
-// Playwright captures the workflow as 11 requests (text-field mSync + button
-// click are batched into a single UIDL POST).
+// Playwright captures the workflow as 9 requests: page GET, 2 static GETs,
+// init, 3 more static GETs, then 2 UIDLs — the input mSync+change and the
+// button click are batched into a single POST.
 IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
-IntegrationTestHelper.assertFileContains(k6Script, "// Request 11: POST");
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 9: POST");
 IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
 IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world-playwright: 5 GET init' }");
+    "tags: { name: 'hello-world-playwright: 4 GET init' }");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world-playwright: 9 POST uidl' }");
+    "tags: { name: 'hello-world-playwright: 8 POST uidl' }");
 
-// Recorded user actions: text-field mSync + change, button click, notification close
+// Recorded user actions: input value sync, button click. The view uses
+// Flow's native HTML components (Input, NativeButton, Span) with explicit
+// element IDs, so resolveNode() looks them up by id rather than tag#index.
 IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-text-field#1')");
+    "resolveNode(nodeMap, 'name')");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-button#1')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-notification#1')");
+    "resolveNode(nodeMap, 'say-hello')");
 IntegrationTestHelper.assertFileContains(k6Script,
     "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
 IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
-IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"opened-changed\"");
 
 // --- Vaadin session bootstrapping --------------------------------------
 IntegrationTestHelper.assertFileContains(k6Script,

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/pom.xml
@@ -70,6 +70,16 @@
                             <!-- Skip think-time so a single iteration completes
                                  quickly enough for the IT's short duration. -->
                             <thinkTimeEnabled>false</thinkTimeEnabled>
+                            <!-- Force headless Chrome for the spawned failsafe
+                                 run. no-sandbox and disable-dev-shm-usage
+                                 are required on CI runners where Chrome cannot
+                                 use the kernel sandbox or /dev/shm. Override
+                                 locally with -Dk6.mavenArgs="..." (see
+                                 AbstractRecordMojo#mavenArgs). -->
+                            <mavenArgs>
+                                -Dcom.vaadin.testbench.Parameters.headless=true
+                                -Dcom.vaadin.testbench.Parameters.chromeOptions=--no-sandbox,--disable-dev-shm-usage
+                            </mavenArgs>
                         </configuration>
                     </execution>
                     <execution>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>record-testbench</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        End-to-end run of the loadtest:record goal driving a real Chrome browser
+        through the recording proxy: starts demo-server, runs HelloWorldIT
+        against the proxy, stops the server. Verifies the recorded HAR, the
+        generated k6 script, and the source-hash cache file. Requires Chrome on
+        PATH. The k6 binary is supplied via -Dk6.binary from the parent pom's
+        invoker config (downloaded by the 000-install-k6 bootstrap IT).
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.dir>${project.basedir}/../demo-server</demo.server.dir>
+        <demo.server.jar>${demo.server.dir}/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18280</loadtest.serverPort>
+        <loadtest.managementPort>18282</loadtest.managementPort>
+        <loadtest.proxyPort>16000</loadtest.proxyPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>record</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>record</goal>
+                        </goals>
+                        <configuration>
+                            <testClasses>
+                                <testClass>HelloWorldIT</testClass>
+                            </testClasses>
+                            <proxyPort>${loadtest.proxyPort}</proxyPort>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <!-- Run failsafe in the demo-server clone where the
+                                 IT class was compiled in test-compile phase. -->
+                            <testWorkDir>${demo.server.dir}</testWorkDir>
+                            <harDir>${project.build.directory}</harDir>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <forceRecord>true</forceRecord>
+                            <!-- Skip think-time so a single iteration completes
+                                 quickly enough for the IT's short duration. -->
+                            <thinkTimeEnabled>false</thinkTimeEnabled>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-recorded-scenario</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testDir>${project.build.directory}/k6/tests</testDir>
+                            <virtualUsers>1</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -58,7 +58,7 @@ IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:1828
 IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
 // Global checks threshold with abortOnFail
 IntegrationTestHelper.assertFileContains(k6Script,
-    "checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }]");
+    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]");
 // Global request-duration thresholds
 IntegrationTestHelper.assertFileContains(k6Script,
     "http_req_duration: ['p(95)<2000', 'p(99)<5000']");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -1,0 +1,187 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+Path k6Tests = basePath.resolve("target/k6/tests");
+Path k6Utils = basePath.resolve("target/k6/utils");
+
+// HAR captured by the recording proxy
+Path har = basePath.resolve("target/hello-world-recording.har");
+IntegrationTestHelper.assertFileExists(har);
+if (Files.size(har) < 100) {
+    throw new RuntimeException("HAR file unexpectedly small: " + Files.size(har));
+}
+// HAR must contain the recorded HelloWorld interaction
+IntegrationTestHelper.assertFileContains(har, "v-r=init");
+IntegrationTestHelper.assertFileContains(har, "v-r=uidl");
+IntegrationTestHelper.assertFileContains(har, "Vaadin User");
+
+// Raw har-to-k6 output (pre-refactor)
+Path rawScript = k6Tests.resolve("hello-world-generated.js");
+IntegrationTestHelper.assertFileExists(rawScript);
+
+// Refactored k6 script (Vaadin-aware final output)
+Path k6Script = k6Tests.resolve("hello-world.js");
+IntegrationTestHelper.assertFileExists(k6Script);
+
+// --- Imports / structure ------------------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import http from 'k6/http'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { check, fail } from 'k6'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { SharedArray } from 'k6/data'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "../utils/vaadin-k6-helpers.js");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "import { textSummary } from '../utils/k6-summary.js'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "updateNodeMap, resolveNode");
+IntegrationTestHelper.assertFileContains(k6Script, "export default function");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "export function handleSummary");
+
+// --- Server config injected by refactor --------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const APP_IP = __ENV.APP_IP || 'localhost'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const APP_PORT = __ENV.APP_PORT || '8080'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`");
+
+// Recorded port (18280) must have been replaced by ${BASE_URL} in all
+// quoted URLs (the literal still appears in `// Request N:` comments).
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "'http://localhost:18280");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:18280");
+
+// --- Thresholds ---------------------------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
+// Global checks threshold with abortOnFail
+IntegrationTestHelper.assertFileContains(k6Script,
+    "checks: [{ threshold: 'rate==1', abortOnFail: true, delayAbortEval: '5s' }]");
+// Global request-duration thresholds
+IntegrationTestHelper.assertFileContains(k6Script,
+    "http_req_duration: ['p(95)<2000', 'p(99)<5000']");
+// Per-request tagged thresholds for each captured step
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world: 1 GET /}': ['max>=0']");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world: 5 GET init}': ['max>=0']");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'http_req_duration{name:hello-world: 9 POST uidl}': ['max>=0']");
+
+// --- Input data CSV -----------------------------------------------------
+Path csv = k6Tests.resolve("hello-world-data.csv");
+IntegrationTestHelper.assertFileExists(csv);
+String csvContent = IntegrationTestHelper.readFile(csv);
+String csvNormalized = csvContent.replace("\r\n", "\n").trim();
+// Header (input_1 — derived from the single text-field on HelloWorldView)
+// followed by the recorded value (TEST_NAME from HelloWorldIT)
+if (!csvNormalized.startsWith("input_1\n")) {
+    throw new RuntimeException(
+        "hello-world-data.csv should start with header 'input_1', got: " + csvContent);
+}
+if (!csvNormalized.contains("\nVaadin User")) {
+    throw new RuntimeException(
+        "hello-world-data.csv should contain row 'Vaadin User', got: " + csvContent);
+}
+// Script must consume the CSV
+IntegrationTestHelper.assertFileContains(k6Script,
+    "open('./hello-world-data.csv')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "new SharedArray('input data'");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "inputData[Math.floor(Math.random() * inputData.length)]");
+// The text-field value substitutes the CSV column rather than the literal
+IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
+
+// --- Recorded request flow ---------------------------------------------
+// 12 requests captured: 4 static GETs, init, 3 more static GETs, 4 UIDLs
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 12: POST");
+IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
+IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "tags: { name: 'hello-world: 5 GET init' }");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "tags: { name: 'hello-world: 9 POST uidl' }");
+
+// Recorded user actions: text-field mSync + change, button click, notification close
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-text-field#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-button#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "resolveNode(nodeMap, 'vaadin-notification#1')");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
+IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
+IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"opened-changed\"");
+
+// --- Vaadin session bootstrapping --------------------------------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "let uiId = response.body.match(/\"v-uiId\"");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "nodeMap = updateNodeMap(nodeMap, response.body)");
+// Init / UIDL response validation checks
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'init request succeeded': (r) => r.status === 200");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'valid init response':");
+IntegrationTestHelper.assertFileContains(k6Script,
+    "'UIDL request succeeded': (r) => r.status === 200");
+IntegrationTestHelper.assertFileContains(k6Script, "'no server error':");
+IntegrationTestHelper.assertFileContains(k6Script, "'security key valid':");
+// Sync counters tracked from UIDL responses
+IntegrationTestHelper.assertFileContains(k6Script,
+    "syncId = Math.max(0, parseInt(syncIdMatch[1]))");
+IntegrationTestHelper.assertFileContains(k6Script, "clientId++");
+
+// --- Think times: pom sets thinkTimeEnabled=false ----------------------
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "// Think time:");
+IntegrationTestHelper.assertFileDoesNotContain(k6Script, "sleep(");
+IntegrationTestHelper.assertLogContains(basePath, "Think times: disabled");
+
+// --- handleSummary configures stdout + optional JSON file --------------
+IntegrationTestHelper.assertFileContains(k6Script,
+    "textSummary(consoleData, { indent: ' ', enableColors: true })");
+IntegrationTestHelper.assertFileContains(k6Script, "__ENV.SUMMARY_FILE");
+
+// --- Vaadin helpers + summary lib copied next to the tests -------------
+IntegrationTestHelper.assertFileExists(k6Utils.resolve("vaadin-k6-helpers.js"));
+IntegrationTestHelper.assertFileExists(k6Utils.resolve("k6-summary.js"));
+
+// --- Source-hash cache so subsequent runs short-circuit ----------------
+Path hashFile = k6Tests.resolve("hello-world.hash");
+IntegrationTestHelper.assertFileExists(hashFile);
+String hash = IntegrationTestHelper.readFile(hashFile).trim();
+if (!hash.matches("[a-f0-9]{64}")) {
+    throw new RuntimeException(
+        "hello-world.hash should contain a 64-char SHA-256 hex digest, got: " + hash);
+}
+
+// --- Build log proves the proxy + refactor pipeline ran ----------------
+IntegrationTestHelper.assertLogContains(basePath, "Proxy captured");
+IntegrationTestHelper.assertLogContains(basePath, "HAR converted to k6 test");
+IntegrationTestHelper.assertLogContains(basePath, "Refactored k6 test written to");
+IntegrationTestHelper.assertLogContains(basePath, "Detected Vaadin session");
+
+// --- k6 run produced JSON + HTML reports -------------------------------
+Path reportDir = k6Tests.resolve("report");
+Path summaryJson = reportDir.resolve("hello-world-summary.json");
+Path summaryHtml = reportDir.resolve("hello-world-summary.html");
+IntegrationTestHelper.assertDirectoryExists(reportDir);
+IntegrationTestHelper.assertFileExists(summaryJson);
+IntegrationTestHelper.assertFileExists(summaryHtml);
+IntegrationTestHelper.assertFileContains(summaryJson, "http_req_duration");
+IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
+IntegrationTestHelper.assertFileContains(summaryJson, "\"checks\"");
+IntegrationTestHelper.assertFileContains(summaryJson, "iterations");
+// HTML report renders the k6 result template
+IntegrationTestHelper.assertFileContains(summaryHtml, "k6 Load Test Report");
+
+// Build log proves k6 actually executed the recorded script
+IntegrationTestHelper.assertLogContains(basePath, "k6 test completed successfully");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -1,161 +1,166 @@
 import java.nio.file.*;
 import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
 
-Path basePath = basedir.toPath();
-Path k6Tests = basePath.resolve("target/k6/tests");
-Path k6Utils = basePath.resolve("target/k6/utils");
+// Recorded flow: page GET, 2 static GETs, init, 3 more static GETs, then
+// 3 UIDL POSTs:
+//   8  = ui-navigate (initial page-load sync)
+//   9  = input value mSync+change
+//   10 = button click (last request — uses handleSummary as the section
+//        end marker since there is no "// Request 11:")
 
-// HAR captured by the recording proxy
-Path har = basePath.resolve("target/hello-world-recording.har");
+// ----- Paths -------------------------------------------------------------
+Path basePath    = basedir.toPath();
+Path k6Tests     = basePath.resolve("target/k6/tests");
+Path k6Utils     = basePath.resolve("target/k6/utils");
+Path har         = basePath.resolve("target/hello-world-recording.har");
+Path rawScript   = k6Tests.resolve("hello-world-generated.js");
+Path k6Script    = k6Tests.resolve("hello-world.js");
+Path csv         = k6Tests.resolve("hello-world-data.csv");
+Path hashFile    = k6Tests.resolve("hello-world.hash");
+Path reportDir   = k6Tests.resolve("report");
+Path summaryJson = reportDir.resolve("hello-world-summary.json");
+Path summaryHtml = reportDir.resolve("hello-world-summary.html");
+
+// ----- HAR captured by the recording proxy -------------------------------
 IntegrationTestHelper.assertFileExists(har);
 if (Files.size(har) < 100) {
     throw new RuntimeException("HAR file unexpectedly small: " + Files.size(har));
 }
-// HAR must contain the recorded HelloWorld interaction
 IntegrationTestHelper.assertFileContains(har, "v-r=init");
 IntegrationTestHelper.assertFileContains(har, "v-r=uidl");
 IntegrationTestHelper.assertFileContains(har, "Vaadin User");
 
-// Raw har-to-k6 output (pre-refactor)
-Path rawScript = k6Tests.resolve("hello-world-generated.js");
+// ----- Both raw and refactored k6 outputs exist --------------------------
 IntegrationTestHelper.assertFileExists(rawScript);
-
-// Refactored k6 script (Vaadin-aware final output)
-Path k6Script = k6Tests.resolve("hello-world.js");
 IntegrationTestHelper.assertFileExists(k6Script);
 
-// --- Imports / structure ------------------------------------------------
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import http from 'k6/http'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { check, fail } from 'k6'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { SharedArray } from 'k6/data'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "../utils/vaadin-k6-helpers.js");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "import { textSummary } from '../utils/k6-summary.js'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "updateNodeMap, resolveNode");
-IntegrationTestHelper.assertFileContains(k6Script, "export default function");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "export function handleSummary");
+// ----- Script structure: imports + helpers come before the entry function
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "import http from 'k6/http'",
+    "import { check, fail } from 'k6'",
+    "import { SharedArray } from 'k6/data'",
+    "updateNodeMap, resolveNode",
+    "../utils/vaadin-k6-helpers.js",
+    "import { textSummary } from '../utils/k6-summary.js'",
+    "export default function",
+    "export function handleSummary"
+});
 
-// --- Server config injected by refactor --------------------------------
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const APP_IP = __ENV.APP_IP || 'localhost'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const APP_PORT = __ENV.APP_PORT || '8080'");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`");
-
-// Recorded port (18280) must have been replaced by ${BASE_URL} in all
-// quoted URLs (the literal still appears in `// Request N:` comments).
+// ----- Server config block: APP_IP, APP_PORT, BASE_URL declared in order -
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "const APP_IP = __ENV.APP_IP || 'localhost'",
+    "const APP_PORT = __ENV.APP_PORT || '8080'",
+    "const BASE_URL = `http://${APP_IP}:${APP_PORT}`"
+});
+// The recorded port (18280) must have been replaced inside every quoted URL.
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "'http://localhost:18280");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "`http://localhost:18280");
 
-// --- Thresholds ---------------------------------------------------------
-IntegrationTestHelper.assertFileContains(k6Script, "thresholds: {");
-// Global checks threshold with abortOnFail
-IntegrationTestHelper.assertFileContains(k6Script,
-    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]");
-// Global request-duration thresholds
-IntegrationTestHelper.assertFileContains(k6Script,
-    "http_req_duration: ['p(95)<2000', 'p(99)<5000']");
-// Per-request tagged thresholds for each captured step
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world: 1 GET /}': ['max>=0']");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world: 4 GET init}': ['max>=0']");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world: 8 POST uidl}': ['max>=0']");
+// ----- Threshold rules live inside the thresholds block, not somewhere else
+IntegrationTestHelper.assertSectionContains(k6Script, "thresholds: {", "},", new String[] {
+    "checks: [{ threshold: 'rate>=0.99', abortOnFail: true, delayAbortEval: '5s' }]",
+    "http_req_duration: ['p(95)<2000', 'p(99)<5000']",
+    "'http_req_duration{name:hello-world: 1 GET /}': ['max>=0']",
+    "'http_req_duration{name:hello-world: 4 GET init}': ['max>=0']",
+    "'http_req_duration{name:hello-world: 9 POST uidl}': ['max>=0']"
+});
 
-// --- Input data CSV -----------------------------------------------------
-Path csv = k6Tests.resolve("hello-world-data.csv");
+// ----- Input data CSV ---------------------------------------------------
+// Header (input_1, derived from the single text-field on HelloWorldView)
+// followed by the recorded value (TEST_NAME from HelloWorldIT).
 IntegrationTestHelper.assertFileExists(csv);
-String csvContent = IntegrationTestHelper.readFile(csv);
-String csvNormalized = csvContent.replace("\r\n", "\n").trim();
-// Header (input_1 — derived from the single text-field on HelloWorldView)
-// followed by the recorded value (TEST_NAME from HelloWorldIT)
+String csvNormalized = IntegrationTestHelper.readFile(csv).replace("\r\n", "\n").trim();
 if (!csvNormalized.startsWith("input_1\n")) {
     throw new RuntimeException(
-        "hello-world-data.csv should start with header 'input_1', got: " + csvContent);
+        "hello-world-data.csv should start with header 'input_1', got: " + csvNormalized);
 }
 if (!csvNormalized.contains("\nVaadin User")) {
     throw new RuntimeException(
-        "hello-world-data.csv should contain row 'Vaadin User', got: " + csvContent);
+        "hello-world-data.csv should contain row 'Vaadin User', got: " + csvNormalized);
 }
-// Script must consume the CSV
-IntegrationTestHelper.assertFileContains(k6Script,
-    "open('./hello-world-data.csv')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "new SharedArray('input data'");
+// Script must consume the CSV instead of inlining the recorded value.
+IntegrationTestHelper.assertFileContains(k6Script, "open('./hello-world-data.csv')");
+IntegrationTestHelper.assertFileContains(k6Script, "new SharedArray('input data'");
 IntegrationTestHelper.assertFileContains(k6Script,
     "inputData[Math.floor(Math.random() * inputData.length)]");
-// The text-field value substitutes the CSV column rather than the literal
 IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
 
-// --- Recorded request flow ---------------------------------------------
-// 10 requests captured: page GET, 2 static GETs, init, 3 more static GETs,
-// 3 UIDLs (input mSync+change, button click, post-click follow-up).
-IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
+// ----- Recorded request flow --------------------------------------------
+// The ordered check enforces that the key requests appear in temporal order
+// in the script (page → init → input sync → button click).
+IntegrationTestHelper.assertFileContainsInOrder(k6Script, new String[] {
+    "// Request 1: GET",
+    "// Request 4:",
+    "// Request 9:",
+    "// Request 10:"
+});
 IntegrationTestHelper.assertFileContains(k6Script, "// Request 10: POST");
-IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
-IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world: 4 GET init' }");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world: 8 POST uidl' }");
 
-// Recorded user actions: input value sync, button click. The view uses
-// Flow's native HTML components (Input, NativeButton, Span) with explicit
-// element IDs, so resolveNode() looks them up by id rather than tag#index.
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'name')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'say-hello')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
-IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
+// ----- Recorded request bodies live in the right request block ----------
+// HelloWorldView uses Flow's native HTML components (Input, NativeButton,
+// Span) with explicit element IDs, so resolveNode() looks them up by id.
 
-// --- Vaadin session bootstrapping --------------------------------------
+// Request 4 (GET init): URL and tag.
+IntegrationTestHelper.assertSectionContains(k6Script,
+    "// Request 4:", "// Request 5:", new String[] {
+        "?v-r=init",
+        "tags: { name: 'hello-world: 4 GET init' }"
+    });
+// Request 9 (input mSync+change): URL, tag, resolveNode by id, and the
+// templated input value substituted from the CSV row.
+IntegrationTestHelper.assertSectionContains(k6Script,
+    "// Request 9:", "// Request 10:", new String[] {
+        "?v-r=uidl&v-uiId=${uiId}",
+        "tags: { name: 'hello-world: 9 POST uidl' }",
+        "resolveNode(nodeMap, 'name')",
+        "\"property\":\"value\",\"value\":\"${inputRow.input_1}\""
+    });
+// Request 10 (button click): resolveNode by id and the click event payload.
+IntegrationTestHelper.assertSectionContains(k6Script,
+    "// Request 10:", "export function handleSummary", new String[] {
+        "resolveNode(nodeMap, 'say-hello')",
+        "\"event\":\"click\""
+    });
+
+// ----- Vaadin session bootstrapping + response checks --------------------
 IntegrationTestHelper.assertFileContains(k6Script,
     "let uiId = response.body.match(/\"v-uiId\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "nodeMap = updateNodeMap(nodeMap, response.body)");
-// Init / UIDL response validation checks
 IntegrationTestHelper.assertFileContains(k6Script,
     "'init request succeeded': (r) => r.status === 200");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'valid init response':");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "'UIDL request succeeded': (r) => r.status === 200");
-IntegrationTestHelper.assertFileContains(k6Script, "'no server error':");
-IntegrationTestHelper.assertFileContains(k6Script, "'security key valid':");
-// Sync counters tracked from UIDL responses
+IntegrationTestHelper.assertFileContains(k6Script, "'valid init response':");
+IntegrationTestHelper.assertSectionContains(k6Script,
+        "// Abort iteration and trigger test abort if UIDL response is invalid", "}))", new String[] {
+    "'UIDL request succeeded': (r) => r.status === 200",
+    "'no server error': (r) => !r.body.includes('\"appError\"')",
+    "'no exception': (r) => !r.body.includes('Exception')",
+    "'session is valid': (r) => !r.body.includes('Your session needs to be refreshed')",
+    "'security key valid': (r) => !r.body.includes('Invalid security key')",
+    "'valid UIDL response': () => syncIdMatch !== null"
+});
 IntegrationTestHelper.assertFileContains(k6Script,
     "syncId = Math.max(0, parseInt(syncIdMatch[1]))");
 IntegrationTestHelper.assertFileContains(k6Script, "clientId++");
 
-// --- Think times: pom sets thinkTimeEnabled=false ----------------------
+// ----- Think times disabled (pom sets thinkTimeEnabled=false) -----------
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "// Think time:");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "sleep(");
 IntegrationTestHelper.assertLogContains(basePath, "Think times: disabled");
 
-// --- handleSummary configures stdout + optional JSON file --------------
+// ----- handleSummary: stdout + optional JSON file -----------------------
 IntegrationTestHelper.assertFileContains(k6Script,
     "textSummary(consoleData, { indent: ' ', enableColors: true })");
 IntegrationTestHelper.assertFileContains(k6Script, "__ENV.SUMMARY_FILE");
 
-// --- Vaadin helpers + summary lib copied next to the tests -------------
+// ----- Vaadin helpers + summary lib copied next to the tests -----------
 IntegrationTestHelper.assertFileExists(k6Utils.resolve("vaadin-k6-helpers.js"));
 IntegrationTestHelper.assertFileExists(k6Utils.resolve("k6-summary.js"));
 
-// --- Source-hash cache so subsequent runs short-circuit ----------------
-Path hashFile = k6Tests.resolve("hello-world.hash");
+// ----- Source-hash cache so subsequent runs short-circuit ---------------
 IntegrationTestHelper.assertFileExists(hashFile);
 String hash = IntegrationTestHelper.readFile(hashFile).trim();
 if (!hash.matches("[a-f0-9]{64}")) {
@@ -163,16 +168,13 @@ if (!hash.matches("[a-f0-9]{64}")) {
         "hello-world.hash should contain a 64-char SHA-256 hex digest, got: " + hash);
 }
 
-// --- Build log proves the proxy + refactor pipeline ran ----------------
+// ----- Build log proves the recording + refactor pipeline ran -----------
 IntegrationTestHelper.assertLogContains(basePath, "Proxy captured");
 IntegrationTestHelper.assertLogContains(basePath, "HAR converted to k6 test");
 IntegrationTestHelper.assertLogContains(basePath, "Refactored k6 test written to");
 IntegrationTestHelper.assertLogContains(basePath, "Detected Vaadin session");
 
-// --- k6 run produced JSON + HTML reports -------------------------------
-Path reportDir = k6Tests.resolve("report");
-Path summaryJson = reportDir.resolve("hello-world-summary.json");
-Path summaryHtml = reportDir.resolve("hello-world-summary.html");
+// ----- k6 run produced JSON + HTML reports ------------------------------
 IntegrationTestHelper.assertDirectoryExists(reportDir);
 IntegrationTestHelper.assertFileExists(summaryJson);
 IntegrationTestHelper.assertFileExists(summaryHtml);
@@ -180,8 +182,5 @@ IntegrationTestHelper.assertFileContains(summaryJson, "http_req_duration");
 IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
 IntegrationTestHelper.assertFileContains(summaryJson, "\"checks\"");
 IntegrationTestHelper.assertFileContains(summaryJson, "iterations");
-// HTML report renders the k6 result template
 IntegrationTestHelper.assertFileContains(summaryHtml, "k6 Load Test Report");
-
-// Build log proves k6 actually executed the recorded script
 IntegrationTestHelper.assertLogContains(basePath, "k6 test completed successfully");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -66,9 +66,9 @@ IntegrationTestHelper.assertFileContains(k6Script,
 IntegrationTestHelper.assertFileContains(k6Script,
     "'http_req_duration{name:hello-world: 1 GET /}': ['max>=0']");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world: 5 GET init}': ['max>=0']");
+    "'http_req_duration{name:hello-world: 4 GET init}': ['max>=0']");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "'http_req_duration{name:hello-world: 9 POST uidl}': ['max>=0']");
+    "'http_req_duration{name:hello-world: 8 POST uidl}': ['max>=0']");
 
 // --- Input data CSV -----------------------------------------------------
 Path csv = k6Tests.resolve("hello-world-data.csv");
@@ -97,27 +97,27 @@ IntegrationTestHelper.assertFileContains(k6Script, "${inputRow.input_1}");
 IntegrationTestHelper.assertFileDoesNotContain(k6Script, "\"value\":\"Vaadin User\"");
 
 // --- Recorded request flow ---------------------------------------------
-// 12 requests captured: 4 static GETs, init, 3 more static GETs, 4 UIDLs
+// 10 requests captured: page GET, 2 static GETs, init, 3 more static GETs,
+// 3 UIDLs (input mSync+change, button click, post-click follow-up).
 IntegrationTestHelper.assertFileContains(k6Script, "// Request 1: GET");
-IntegrationTestHelper.assertFileContains(k6Script, "// Request 12: POST");
+IntegrationTestHelper.assertFileContains(k6Script, "// Request 10: POST");
 IntegrationTestHelper.assertFileContains(k6Script, "?v-r=init");
 IntegrationTestHelper.assertFileContains(k6Script, "?v-r=uidl&v-uiId=${uiId}");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world: 5 GET init' }");
+    "tags: { name: 'hello-world: 4 GET init' }");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "tags: { name: 'hello-world: 9 POST uidl' }");
+    "tags: { name: 'hello-world: 8 POST uidl' }");
 
-// Recorded user actions: text-field mSync + change, button click, notification close
+// Recorded user actions: input value sync, button click. The view uses
+// Flow's native HTML components (Input, NativeButton, Span) with explicit
+// element IDs, so resolveNode() looks them up by id rather than tag#index.
 IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-text-field#1')");
+    "resolveNode(nodeMap, 'name')");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-button#1')");
-IntegrationTestHelper.assertFileContains(k6Script,
-    "resolveNode(nodeMap, 'vaadin-notification#1')");
+    "resolveNode(nodeMap, 'say-hello')");
 IntegrationTestHelper.assertFileContains(k6Script,
     "\"property\":\"value\",\"value\":\"${inputRow.input_1}\"");
 IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"click\"");
-IntegrationTestHelper.assertFileContains(k6Script, "\"event\":\"opened-changed\"");
 
 // --- Vaadin session bootstrapping --------------------------------------
 IntegrationTestHelper.assertFileContains(k6Script,

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>response-checks-fails</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Negative-path counterpart to response-checks: verifies that a custom
+        check whose expression evaluates to false is reported as a failure
+        in the k6 summary for every scope (INIT, UIDL, ALL).
+
+        Records HelloWorldIT against the demo-server fixture so the captured
+        HAR contains both init and UIDL requests. customChecks below
+        configures one always-false check per scope. checksAbortOnFail=false
+        and checksAllowedFailureRate=0.99 keep k6 from cutting the test
+        short, and failOnThreshold=false on the run lets the build complete
+        even though the checks-rate threshold is breached — without those,
+        k6 would exit non-zero and verify.bsh would never run.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.dir>${project.basedir}/../demo-server</demo.server.dir>
+        <demo.server.jar>${demo.server.dir}/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18385</loadtest.serverPort>
+        <loadtest.managementPort>18387</loadtest.managementPort>
+        <loadtest.proxyPort>16105</loadtest.proxyPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>record</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>record</goal>
+                        </goals>
+                        <configuration>
+                            <testClasses>
+                                <testClass>HelloWorldIT</testClass>
+                            </testClasses>
+                            <proxyPort>${loadtest.proxyPort}</proxyPort>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <testWorkDir>${demo.server.dir}</testWorkDir>
+                            <harDir>${project.build.directory}</harDir>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <forceRecord>true</forceRecord>
+                            <thinkTimeEnabled>false</thinkTimeEnabled>
+                            <mavenArgs>
+                                -Dcom.vaadin.testbench.Parameters.headless=true
+                                -Dcom.vaadin.testbench.Parameters.chromeOptions=--no-sandbox,--disable-dev-shm-usage
+                            </mavenArgs>
+                            <!--
+                                One always-false check per documented scope.
+                                Names are kept distinct so verify.bsh can
+                                grep them out of the summary entries
+                                without ambiguity.
+                            -->
+                            <customChecks>INIT|init never passes|(r) =&gt; false;UIDL|uidl never passes|(r) =&gt; false;ALL|never passes|(r) =&gt; false</customChecks>
+                            <!--
+                                Disable abort-on-fail and raise the allowed
+                                failure rate so k6 keeps running even when
+                                the always-false checks blow past the
+                                checks-rate threshold. Without this k6
+                                would stop after the 5s delayAbortEval
+                                window and many failure samples would be
+                                lost.
+                            -->
+                            <checksAbortOnFail>false</checksAbortOnFail>
+                            <checksAllowedFailureRate>0.99</checksAllowedFailureRate>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-recorded-scenario</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testDir>${project.build.directory}/k6/tests</testDir>
+                            <virtualUsers>1</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <!--
+                                Always-false checks make the checks-rate
+                                threshold breach; without this the build
+                                would fail before verify.bsh has a chance
+                                to inspect the summary.
+                            -->
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks-fails/verify.bsh
@@ -1,0 +1,127 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath    = basedir.toPath();
+Path k6Tests     = basePath.resolve("target/k6/tests");
+Path k6Script    = k6Tests.resolve("hello-world.js");
+Path summaryJson = k6Tests.resolve("report/hello-world-summary.json");
+
+// 1. Generated script must exist before any assertions can run.
+IntegrationTestHelper.assertFileExists(k6Script);
+
+// 2. Each always-false custom check made it into the script. Same
+// per-scope placement assertions as the happy-path response-checks IT,
+// but with the failing-check names. The point is to confirm that the
+// checks are wired in (so they will execute) before inspecting the
+// summary for the failure outcomes.
+String[] customCheckNames = new String[] {
+    "init never passes",
+    "uidl never passes",
+    "never passes",
+};
+for (int i = 0; i < customCheckNames.length; i++) {
+    IntegrationTestHelper.assertFileContains(k6Script,
+        "'" + customCheckNames[i] + "':");
+}
+
+String initSectionStart =
+    "// Abort iteration and trigger test abort if init response is invalid";
+String initSectionEnd =
+    "// Extract Vaadin session values from init response";
+IntegrationTestHelper.assertSectionContains(k6Script,
+    initSectionStart, initSectionEnd, new String[] {
+        "'init never passes':",
+        "'never passes':",
+    });
+IntegrationTestHelper.assertSectionDoesNotContain(k6Script,
+    initSectionStart, initSectionEnd, "'uidl never passes':");
+
+String uidlSectionStart =
+    "// Abort iteration and trigger test abort if UIDL response is invalid";
+String uidlSectionEnd =
+    "// Update Vaadin sync counters from response";
+String script = IntegrationTestHelper.readFile(k6Script);
+int cursor = 0;
+int uidlBlockCount = 0;
+while (true) {
+    int start = script.indexOf(uidlSectionStart, cursor);
+    if (start < 0) {
+        break;
+    }
+    int end = script.indexOf(uidlSectionEnd, start);
+    if (end < 0) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " is missing its end marker");
+    }
+    String block = script.substring(start, end);
+    if (!block.contains("'uidl never passes':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " missing UIDL custom check");
+    }
+    if (!block.contains("'never passes':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " missing ALL custom check");
+    }
+    if (block.contains("'init never passes':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start
+                + " unexpectedly contains INIT custom check");
+    }
+    uidlBlockCount++;
+    cursor = end;
+}
+if (uidlBlockCount == 0) {
+    throw new RuntimeException(
+        "Generated script has no UIDL response handling block — recording "
+            + "did not capture a UIDL request");
+}
+
+// 3. The k6 run produced a summary that records the failures for the
+// custom checks that actually executed. Field order inside an entry is
+// not stable, so the assertion locates the entry via its unique
+// "path": "::<name>" anchor and inspects the enclosing object braces.
+//
+// Note on UIDL: HarToK6Converter wraps each response-handling block in
+//   if (!check(response, {...})) { fail(...) }
+// so an always-false INIT or ALL check aborts the iteration before any
+// UIDL request runs. The UIDL custom check is correctly wired into
+// every UIDL block (verified above) but never gets exercised here, so
+// k6 omits it from the summary entirely. Only the init-block failures
+// are summary-asserted.
+String[] executedFailingChecks = new String[] {
+    "init never passes",
+    "never passes",
+};
+IntegrationTestHelper.assertFileExists(summaryJson);
+String summary = IntegrationTestHelper.readFile(summaryJson);
+for (int i = 0; i < executedFailingChecks.length; i++) {
+    String name = executedFailingChecks[i];
+    String anchor = "\"path\": \"::" + name + "\"";
+    int anchorIdx = summary.indexOf(anchor);
+    if (anchorIdx < 0) {
+        throw new RuntimeException(
+            "Summary missing custom check entry for: " + name);
+    }
+    int objectStart = summary.lastIndexOf('{', anchorIdx);
+    int objectEnd = summary.indexOf('}', anchorIdx);
+    if (objectStart < 0 || objectEnd < 0) {
+        throw new RuntimeException(
+            "Summary check entry for '" + name + "' is malformed");
+    }
+    String entry = summary.substring(objectStart, objectEnd + 1);
+    // Always-false expression: every invocation must be a fail; passes
+    // must stay at 0 since k6 records each check call as either pass or
+    // fail, never both.
+    if (!entry.matches("(?s).*\"fails\":\\s*[1-9][0-9]*.*")) {
+        throw new RuntimeException(
+            "Custom check '" + name + "' never failed (fails == 0): "
+                + entry);
+    }
+    if (!entry.matches("(?s).*\"passes\":\\s*0[^0-9].*")
+            && !entry.matches("(?s).*\"passes\":\\s*0\\s*[},].*")) {
+        throw new RuntimeException(
+            "Custom check '" + name
+                + "' unexpectedly passed at least once: " + entry);
+    }
+}
+

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>response-checks</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies that custom response check configuration is wired through
+        the testbench-converter-plugin POM into the generated k6 script and
+        produces matching results in the k6 summary.
+
+        Records HelloWorldIT against the demo-server fixture (mirroring
+        record-run-testbench) so the captured HAR contains both an init and
+        UIDL request — the two contexts where AbstractRecordMojo asks
+        HarToK6Converter to inject custom response checks. customChecks below
+        configures every documented scope (INIT, UIDL, ALL) so the verify
+        script can assert per-scope placement in the generated test and the
+        k6 summary.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.dir>${project.basedir}/../demo-server</demo.server.dir>
+        <demo.server.jar>${demo.server.dir}/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18380</loadtest.serverPort>
+        <loadtest.managementPort>18382</loadtest.managementPort>
+        <loadtest.proxyPort>16100</loadtest.proxyPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>record</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>record</goal>
+                        </goals>
+                        <configuration>
+                            <testClasses>
+                                <testClass>HelloWorldIT</testClass>
+                            </testClasses>
+                            <proxyPort>${loadtest.proxyPort}</proxyPort>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <testWorkDir>${demo.server.dir}</testWorkDir>
+                            <harDir>${project.build.directory}</harDir>
+                            <outputDir>${project.build.directory}/k6/tests</outputDir>
+                            <forceRecord>true</forceRecord>
+                            <thinkTimeEnabled>false</thinkTimeEnabled>
+                            <mavenArgs>
+                                -Dcom.vaadin.testbench.Parameters.headless=true
+                                -Dcom.vaadin.testbench.Parameters.chromeOptions=--no-sandbox,--disable-dev-shm-usage
+                            </mavenArgs>
+                            <!--
+                                customChecks below covers every documented
+                                scope. INIT-scoped checks must only land in
+                                the init response handling block, UIDL-scoped
+                                checks only in the UIDL block, and the ALL
+                                scope must appear in both. Names are kept
+                                distinct so verify.bsh can grep for them
+                                without ambiguity. Expressions are
+                                deliberately permissive so they pass against
+                                the demo-server fixture; the test asserts
+                                wiring, not check semantics.
+                            -->
+                            <customChecks>INIT|init has uiid|(r) =&gt; r.body.includes('v-uiId');UIDL|uidl status ok|(r) =&gt; r.status === 200;ALL|response under 30s|(r) =&gt; r.timings.duration &lt; 30000</customChecks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-recorded-scenario</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testDir>${project.build.directory}/k6/tests</testDir>
+                            <virtualUsers>1</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/response-checks/verify.bsh
@@ -1,0 +1,117 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath    = basedir.toPath();
+Path k6Tests     = basePath.resolve("target/k6/tests");
+Path k6Script    = k6Tests.resolve("hello-world.js");
+Path summaryJson = k6Tests.resolve("report/hello-world-summary.json");
+
+// 1. Generated script must exist before any check assertions can run.
+IntegrationTestHelper.assertFileExists(k6Script);
+
+// 2. Each configured custom check name shows up somewhere in the script.
+// Confirms the customChecks string was parsed and emitted by
+// ResponseCheckConfig.toK6CheckLines.
+String[] customCheckNames = new String[] {
+    "init has uiid",
+    "uidl status ok",
+    "response under 30s",
+};
+for (int i = 0; i < customCheckNames.length; i++) {
+    IntegrationTestHelper.assertFileContains(k6Script,
+        "'" + customCheckNames[i] + "':");
+}
+
+// 3. INIT-scoped check and the ALL-scoped check land inside the init
+// response handling block (and only that block); the UIDL-scoped check
+// does not.
+String initSectionStart =
+    "// Abort iteration and trigger test abort if init response is invalid";
+String initSectionEnd =
+    "// Extract Vaadin session values from init response";
+IntegrationTestHelper.assertSectionContains(k6Script,
+    initSectionStart, initSectionEnd, new String[] {
+        "'init has uiid':",
+        "'response under 30s':",
+    });
+IntegrationTestHelper.assertSectionDoesNotContain(k6Script,
+    initSectionStart, initSectionEnd, "'uidl status ok':");
+
+// 4. UIDL-scoped check and the ALL-scoped check land inside every UIDL
+// response handling block; the INIT-scoped check does not. The recorded
+// flow has multiple UIDL responses, so every block (between the start
+// marker and the next sync-counter update) must include both names.
+String uidlSectionStart =
+    "// Abort iteration and trigger test abort if UIDL response is invalid";
+String uidlSectionEnd =
+    "// Update Vaadin sync counters from response";
+String script = IntegrationTestHelper.readFile(k6Script);
+int cursor = 0;
+int uidlBlockCount = 0;
+while (true) {
+    int start = script.indexOf(uidlSectionStart, cursor);
+    if (start < 0) {
+        break;
+    }
+    int end = script.indexOf(uidlSectionEnd, start);
+    if (end < 0) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " is missing its end marker");
+    }
+    String block = script.substring(start, end);
+    if (!block.contains("'uidl status ok':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " missing UIDL custom check");
+    }
+    if (!block.contains("'response under 30s':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start + " missing ALL custom check");
+    }
+    if (block.contains("'init has uiid':")) {
+        throw new RuntimeException(
+            "UIDL block at offset " + start
+                + " unexpectedly contains INIT custom check");
+    }
+    uidlBlockCount++;
+    cursor = end;
+}
+if (uidlBlockCount == 0) {
+    throw new RuntimeException(
+        "Generated script has no UIDL response handling block — recording "
+            + "did not capture a UIDL request");
+}
+
+// 5. The k6 run produced a summary that lists every custom check, each
+// passing at least once and never failing. root_group.checks is the
+// authoritative list of named checks executed during the run; field
+// order inside an entry is not stable, so the assertion locates the
+// entry via its unique "path": "::<name>" anchor and inspects the
+// enclosing object braces.
+IntegrationTestHelper.assertFileExists(summaryJson);
+String summary = IntegrationTestHelper.readFile(summaryJson);
+for (int i = 0; i < customCheckNames.length; i++) {
+    String name = customCheckNames[i];
+    String anchor = "\"path\": \"::" + name + "\"";
+    int anchorIdx = summary.indexOf(anchor);
+    if (anchorIdx < 0) {
+        throw new RuntimeException(
+            "Summary missing custom check entry for: " + name);
+    }
+    int objectStart = summary.lastIndexOf('{', anchorIdx);
+    int objectEnd = summary.indexOf('}', anchorIdx);
+    if (objectStart < 0 || objectEnd < 0) {
+        throw new RuntimeException(
+            "Summary check entry for '" + name + "' is malformed");
+    }
+    String entry = summary.substring(objectStart, objectEnd + 1);
+    if (!entry.matches("(?s).*\"passes\":\\s*[1-9][0-9]*.*")) {
+        throw new RuntimeException(
+            "Custom check '" + name + "' never executed (passes == 0): "
+                + entry);
+    }
+    if (!entry.matches("(?s).*\"fails\":\\s*0[^0-9].*")
+            && !entry.matches("(?s).*\"fails\":\\s*0\\s*[},].*")) {
+        throw new RuntimeException(
+            "Custom check '" + name + "' reported a failure: " + entry);
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>run-constant-load</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        End-to-end run of the loadtest:run goal: starts the demo-server fixture,
+        executes a tiny k6 script for 5s with vus=1, and verifies that the
+        JSON/HTML reports were produced. The k6 binary is supplied via
+        -Dk6.binary from the parent pom's invoker config (downloaded by the
+        000-install-k6 bootstrap IT), so PATH need not contain k6 and this pom
+        carries no platform-specific configuration.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.jar>${project.basedir}/../demo-server/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18180</loadtest.serverPort>
+        <loadtest.managementPort>18182</loadtest.managementPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testFile>${project.basedir}/src/test/k6/test.js</testFile>
+                            <virtualUsers>1</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <failOnThreshold>false</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/src/test/k6/test.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/src/test/k6/test.js
@@ -1,0 +1,23 @@
+// Minimal k6 script used by the run-constant-load integration test.
+// Hits the demo-server's root endpoint at the host/port supplied by
+// K6RunMojo via the APP_IP / APP_PORT environment variables. Implements
+// handleSummary so K6RunMojo's SUMMARY_FILE env var produces a JSON file
+// that the plugin then renders into an HTML report.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  const res = http.get(`http://${host}:${port}/`)
+  check(res, { 'status is 200': (r) => r.status === 200 })
+  sleep(0.1)
+}
+
+export function handleSummary(data) {
+  const result = {}
+  if (__ENV.SUMMARY_FILE) {
+    result[__ENV.SUMMARY_FILE] = JSON.stringify(data, null, 2)
+  }
+  return result
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/run-constant-load/verify.bsh
@@ -1,0 +1,19 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+// K6RunMojo writes reports next to the test file under <testDir>/report
+Path reportDir = basePath.resolve("src/test/k6/report");
+Path summaryJson = reportDir.resolve("test-summary.json");
+Path summaryHtml = reportDir.resolve("test-summary.html");
+
+IntegrationTestHelper.assertDirectoryExists(reportDir);
+IntegrationTestHelper.assertFileExists(summaryJson);
+IntegrationTestHelper.assertFileExists(summaryHtml);
+
+// Sanity-check the JSON summary contains the headline metrics
+IntegrationTestHelper.assertFileContains(summaryJson, "http_req_duration");
+IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
+
+// k6 actually ran (build log lists the script under "Tests:")
+IntegrationTestHelper.assertLogContains(basePath, "test.js");

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/settings.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/settings.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2000-2026 Vaadin Ltd
+  ~
+  ~ This program is available under Vaadin Commercial License and Service Terms.
+  ~
+  ~ See <https://vaadin.com/commercial-license-and-service-terms> for the full
+  ~ license.
+  -->
+
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>vaadin-prereleases</id>
+                    <url>https://maven.vaadin.com/vaadin-prereleases</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>vaadin-addons</id>
+                    <url>https://maven.vaadin.com/vaadin-addons</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>vaadin-prereleases</id>
+                    <url>https://maven.vaadin.com/vaadin-prereleases</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
+</settings>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>start-stop-server</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies start-server / stop-server lifecycle goals. The bootstrap
+        demo-server IT (ordinal=100) builds the JAR fixture; this IT starts it
+        on a free port, polls /actuator/health, then stops it after the
+        integration-test phase.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.jar>${project.basedir}/../demo-server/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18080</loadtest.serverPort>
+        <loadtest.managementPort>18082</loadtest.managementPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/start-stop-server/verify.bsh
@@ -1,0 +1,28 @@
+import java.net.*;
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+
+// start-server logs this on success — confirms the JAR launched and the
+// health endpoint was reached
+IntegrationTestHelper.assertLogContains(basePath, "Server started on port 18080");
+
+// After post-integration-test the server process should be gone — the
+// loadtest port must accept no further connections
+int port = 18080;
+boolean stillListening = false;
+Socket socket = new Socket();
+try {
+    socket.connect(new InetSocketAddress("localhost", port), 500);
+    stillListening = true;
+} catch (Exception expected) {
+    // Connection refused = server stopped — desired outcome
+} finally {
+    try { socket.close(); } catch (Exception ignored) {}
+}
+if (stillListening) {
+    throw new RuntimeException(
+        "Server process is still listening on port " + port
+        + " after stop-server ran");
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/invoker.properties
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.loadtest</groupId>
+    <artifactId>thresholds</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <description>
+        Verifies that the threshold configuration is
+        wired through the testbench-converter-plugin POM into the generated k6
+        script and produces matching results in the k6 summary.
+
+        Uses combineScenarios=true with two trivial scenarios so K6RunMojo
+        invokes K6ScenarioCombiner, which embeds ThresholdConfig.toK6Thresholds
+        Block in the generated combined-scenarios.js. Default
+        http_req_duration p95/p99 are overridden,
+        the checks abort-on-fail flag is flipped, and customThresholds covers
+        several supported metric category (trend / rate / counter):
+        http_req_waiting, http_req_connecting, http_req_sending,
+        http_req_receiving (trend); http_req_failed (rate); http_reqs
+        (counter). Threshold values are deliberately permissive so all
+        thresholds pass against the demo-server fixture.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <testbench.loadtest.version>@project.version@</testbench.loadtest.version>
+        <demo.server.jar>${project.basedir}/../demo-server/target/demo-server.jar</demo.server.jar>
+        <loadtest.serverPort>18185</loadtest.serverPort>
+        <loadtest.managementPort>18187</loadtest.managementPort>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>testbench-converter-plugin</artifactId>
+                <version>${testbench.loadtest.version}</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <serverJar>${demo.server.jar}</serverJar>
+                            <serverPort>${loadtest.serverPort}</serverPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <startupTimeout>120</startupTimeout>
+                            <healthPollInterval>2</healthPollInterval>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <testDir>${project.basedir}/src/test/k6</testDir>
+                            <virtualUsers>2</virtualUsers>
+                            <duration>5s</duration>
+                            <loadPattern>constant</loadPattern>
+                            <appIp>localhost</appIp>
+                            <appPort>${loadtest.serverPort}</appPort>
+                            <managementPort>${loadtest.managementPort}</managementPort>
+                            <metricsInterval>0</metricsInterval>
+                            <!--
+                                combineScenarios=true is required for the
+                                threshold block to be embedded in the generated
+                                k6 script. K6RunMojo only forwards
+                                ThresholdConfig to K6ScenarioCombiner when
+                                combining; sequential runs leave the script's
+                                thresholds untouched.
+                            -->
+                            <combineScenarios>true</combineScenarios>
+                            <!--
+                                Permissive override of the documented default
+                                http_req_duration thresholds (p95<2000,
+                                p99<5000). Wide enough to pass on the
+                                demo-server fixture; the assertions only verify
+                                that the values flow through to the script.
+                            -->
+                            <httpReqDurationP95>10000</httpReqDurationP95>
+                            <httpReqDurationP99>20000</httpReqDurationP99>
+                            <!--
+                                Flip the abort-on-fail default so
+                                the generated script omits the abortOnFail
+                                wrapper around the checks threshold.
+                            -->
+                            <checksAbortOnFail>false</checksAbortOnFail>
+                            <!--
+                                Custom thresholds covering several supported
+                                metric category:
+                                trend (http_req_waiting / http_req_connecting /
+                                http_req_sending / http_req_receiving),
+                                rate (http_req_failed) and
+                                counter (http_reqs). All values are slack
+                                enough to pass against the demo-server.
+                            -->
+                            <customThresholds>http_req_waiting:p(95)&lt;10000,http_req_connecting:p(95)&lt;5000,http_req_sending:p(95)&lt;5000,http_req_receiving:p(95)&lt;5000,http_req_failed:rate&lt;0.5,http_reqs:count&gt;0</customThresholds>
+                            <!--
+                                Fail the build if any of the configured
+                                thresholds breach. The IT relies on this so a
+                                misconfigured threshold (e.g. units swap) is
+                                caught instead of silently passing.
+                            -->
+                            <failOnThreshold>true</failOnThreshold>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/src/test/k6/health.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/src/test/k6/health.js
@@ -1,0 +1,15 @@
+// Scenario 2 for the thresholds IT. Hits the demo-server root with a query
+// string so the request is distinguishable in the summary. Two scenarios are
+// required because K6RunMojo only invokes K6ScenarioCombiner (which embeds
+// the configured threshold block) when more than one test file participates
+// in combineScenarios mode.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  const res = http.get(`http://${host}:${port}/?ping=1`)
+  check(res, { 'health status is 200': (r) => r.status === 200 })
+  sleep(0.1)
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/src/test/k6/root.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/src/test/k6/root.js
@@ -1,0 +1,14 @@
+// Scenario 1 for the thresholds IT. Hits the demo-server root endpoint at the
+// host/port supplied by K6RunMojo via the APP_IP / APP_PORT environment
+// variables. Used by combineScenarios mode so the plugin can inject the
+// threshold block configured in the IT pom.
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+export default function () {
+  const host = __ENV.APP_IP || 'localhost'
+  const port = __ENV.APP_PORT || '8080'
+  const res = http.get(`http://${host}:${port}/`)
+  check(res, { 'root status is 200': (r) => r.status === 200 })
+  sleep(0.1)
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/thresholds/verify.bsh
@@ -1,0 +1,85 @@
+import java.nio.file.*;
+import com.vaadin.testbench.loadtest.it.IntegrationTestHelper;
+
+Path basePath = basedir.toPath();
+Path k6Dir = basePath.resolve("src/test/k6");
+Path combined = k6Dir.resolve("combined-scenarios.js");
+// K6RunMojo writes reports under <testDir>/report and names the summary
+// after the script that ran (combined-scenarios-summary.json).
+Path reportDir = k6Dir.resolve("report");
+Path summaryJson = reportDir.resolve("combined-scenarios-summary.json");
+
+// 1. The combined script must exist — proves K6ScenarioCombiner ran and that
+// the threshold block was rendered into the generated test.
+IntegrationTestHelper.assertFileExists(combined);
+
+// 2. Threshold block from ThresholdConfig.toK6ThresholdsBlock is present.
+IntegrationTestHelper.assertFileContains(combined, "thresholds: {");
+
+// 3. Documented httpReqDurationP95 / httpReqDurationP99 overrides flowed
+// through to the generated http_req_duration thresholds.
+IntegrationTestHelper.assertSectionContains(combined,
+    "http_req_duration: [", "],",
+    new String[] { "p(95)<10000", "p(99)<20000" });
+
+// 4. checksAbortOnFail=false collapses the checks threshold to a plain
+// string list (no abortOnFail wrapper).
+IntegrationTestHelper.assertFileMatches(combined,
+    "checks:\\s*\\['rate>=[0-9.]+'\\]");
+IntegrationTestHelper.assertFileDoesNotContain(combined, "abortOnFail");
+
+// 5. Every customThresholds entry from the POM appears verbatim in the
+// generated thresholds block. Covers all documented k6 metric categories:
+// trend (http_req_waiting/connecting/sending/receiving), rate
+// (http_req_failed) and counter (http_reqs).
+String[] customThresholdLines = new String[] {
+    "http_req_waiting: ['p(95)<10000']",
+    "http_req_connecting: ['p(95)<5000']",
+    "http_req_sending: ['p(95)<5000']",
+    "http_req_receiving: ['p(95)<5000']",
+    "http_req_failed: ['rate<0.5']",
+    "http_reqs: ['count>0']",
+};
+for (int i = 0; i < customThresholdLines.length; i++) {
+    IntegrationTestHelper.assertFileContains(combined,
+        customThresholdLines[i]);
+}
+
+// 6. k6 ran the combined script and produced a summary. Each configured
+// threshold expression must appear in the JSON with a passing status.
+IntegrationTestHelper.assertFileExists(summaryJson);
+// JSON.stringify(data, null, 2) emits each threshold as
+//   "<expression>": {
+//     "ok": true,
+//     ...
+//   }
+// Matching "<expression>": { ... "ok": true with a non-greedy gap that
+// disallows another opening brace keeps the assertion scoped to the same
+// threshold object regardless of key ordering.
+String[] thresholdExpressions = new String[] {
+    "p(95)<10000",       // http_req_duration default override
+    "p(99)<20000",       // http_req_duration default override
+    "p(95)<5000",        // http_req_connecting / sending / receiving
+    "rate<0.5",          // http_req_failed (rate metric)
+    "count>0",           // http_reqs (counter metric)
+};
+for (int i = 0; i < thresholdExpressions.length; i++) {
+    String expr = thresholdExpressions[i];
+    String escaped = java.util.regex.Pattern.quote(expr);
+    IntegrationTestHelper.assertFileMatches(summaryJson,
+        "\"" + escaped + "\"\\s*:\\s*\\{[^\\{]*?\"ok\"\\s*:\\s*true");
+}
+// The checks threshold expression depends on checksAllowedFailureRate; just
+// confirm a "rate>=..." threshold is reported as passing.
+IntegrationTestHelper.assertFileMatches(summaryJson,
+    "\"rate>=[0-9.]+\"\\s*:\\s*\\{[^\\{]*?\"ok\"\\s*:\\s*true");
+
+// 7. Sanity check: no configured threshold was reported as breached.
+String summary = IntegrationTestHelper.readFile(summaryJson);
+if (java.util.regex.Pattern
+        .compile("\"ok\"\\s*:\\s*false")
+        .matcher(summary).find()) {
+    throw new RuntimeException(
+        "Summary reports a breached threshold (\"ok\": false) in: "
+            + summaryJson);
+}

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
@@ -58,6 +58,17 @@ public abstract class AbstractK6Mojo extends AbstractMojo {
     protected boolean skip;
 
     /**
+     * Absolute path to the k6 executable. When unset (the default), the plugin
+     * resolves {@code k6} from {@code PATH}. Set this when k6 is installed in a
+     * non-standard location (common on Windows and hardened CI images) or when
+     * an automated installer (such as the {@code 000-install-k6}
+     * integration-test fixture) downloads a version-pinned binary outside
+     * {@code PATH}.
+     */
+    @Parameter(property = "k6.binary")
+    protected String k6Binary;
+
+    /**
      * 95th percentile HTTP request duration threshold in milliseconds. The k6
      * test will fail if p(95) response time exceeds this value. Set to 0 to
      * disable this threshold.
@@ -152,7 +163,7 @@ public abstract class AbstractK6Mojo extends AbstractMojo {
         }
 
         // Initialize runner (now uses Java implementations internally)
-        nodeRunner = new NodeRunner(extractionPath);
+        nodeRunner = new NodeRunner(extractionPath, k6Binary);
     }
 
     // Visible for testing

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
@@ -422,6 +422,12 @@ public class K6RunMojo extends AbstractK6Mojo {
                     "Failed to generate combined test file", e);
         }
 
+        // K6ScenarioCombiner unconditionally imports the Vaadin k6 helpers
+        // via a `../utils/...` relative path; copy them next to the
+        // generated script so k6 can resolve the import even when the input
+        // tests do not need them.
+        copyVaadinHelpers(combinedFile.getParent());
+
         // Run the combined test (VUs and duration are embedded in the file,
         // don't override)
         try {

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/NodeRunner.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/NodeRunner.java
@@ -37,16 +37,43 @@ public class NodeRunner {
     private ProxyRecorder proxyRecorder;
     private String summaryTrendStats = "avg,min,med,max,p(95),p(99)";
     private Path reportDir;
+    private String k6Binary;
 
     /**
-     * Creates a new node runner for the given working directory.
+     * Creates a new node runner for the given working directory. The k6 binary
+     * is resolved from {@code PATH}.
      *
      * @param workingDirectory
      *            the directory to run node/k6 commands in
      */
     public NodeRunner(Path workingDirectory) {
+        this(workingDirectory, null);
+    }
+
+    /**
+     * Creates a new node runner for the given working directory using an
+     * explicit k6 binary path.
+     *
+     * @param workingDirectory
+     *            the directory to run node/k6 commands in
+     * @param k6Binary
+     *            absolute path to the k6 executable, or {@code null} / blank to
+     *            resolve {@code k6} from {@code PATH}
+     */
+    public NodeRunner(Path workingDirectory, String k6Binary) {
         ExperimentalWarning.log();
         this.workingDirectory = workingDirectory;
+        this.k6Binary = (k6Binary == null || k6Binary.isBlank()) ? null
+                : k6Binary;
+    }
+
+    /**
+     * Returns the k6 command to invoke. Either the explicit absolute path
+     * configured at construction time, or the literal {@code "k6"} so it is
+     * resolved from {@code PATH}.
+     */
+    private String k6Command() {
+        return k6Binary != null ? k6Binary : "k6";
     }
 
     /**
@@ -78,7 +105,7 @@ public class NodeRunner {
      */
     public boolean isK6Available() {
         try {
-            ProcessBuilder pb = new ProcessBuilder("k6", "version");
+            ProcessBuilder pb = new ProcessBuilder(k6Command(), "version");
             Process process = pb.start();
             boolean finished = process.waitFor(10, TimeUnit.SECONDS);
             if (finished && process.exitValue() == 0) {
@@ -302,7 +329,7 @@ public class NodeRunner {
 
         try {
             List<String> command = new ArrayList<>();
-            command.add("k6");
+            command.add(k6Command());
             command.add("run");
 
             if (loadProfile.isRamping()) {
@@ -482,7 +509,7 @@ public class NodeRunner {
 
         try {
             List<String> command = new ArrayList<>();
-            command.add("k6");
+            command.add(k6Command());
             command.add("run");
 
             // Only add VUs and duration if not using embedded config

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/it/IntegrationTestHelper.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/it/IntegrationTestHelper.java
@@ -11,6 +11,7 @@ package com.vaadin.testbench.loadtest.it;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 /**
  * Shared assertion helpers for {@code verify.bsh} scripts under
@@ -76,5 +77,106 @@ public final class IntegrationTestHelper {
     public static void assertLogDoesNotContain(Path basedir, String needle) {
         Path log = basedir.resolve("build.log");
         assertFileDoesNotContain(log, needle);
+    }
+
+    /**
+     * Asserts that the file content matches the given regex (DOTALL, substring
+     * search via {@link java.util.regex.Matcher#find()}).
+     */
+    public static void assertFileMatches(Path path, String regex) {
+        assertFileExists(path);
+        String content = readFile(path);
+        if (!Pattern.compile(regex, Pattern.DOTALL).matcher(content).find()) {
+            throw new RuntimeException("File '" + path
+                    + "' does not match expected pattern: " + regex);
+        }
+    }
+
+    /**
+     * Asserts that each needle appears in the file and that they appear in the
+     * given order. Useful to enforce "imports come before the entry function"
+     * or "request 4 comes before request 8".
+     */
+    public static void assertFileContainsInOrder(Path path, String... needles) {
+        assertFileExists(path);
+        String content = readFile(path);
+        int cursor = 0;
+        String previous = null;
+        for (String needle : needles) {
+            int found = content.indexOf(needle, cursor);
+            if (found < 0) {
+                throw new RuntimeException("File '" + path
+                        + "' missing expected snippet"
+                        + (previous == null ? "" : " after '" + previous + "'")
+                        + ": '" + needle + "'");
+            }
+            cursor = found + needle.length();
+            previous = needle;
+        }
+    }
+
+    /**
+     * Asserts that {@code needle} appears between {@code sectionStart} and
+     * {@code sectionEnd} in the file. Both markers are matched as literal
+     * substrings; the first {@code sectionEnd} after {@code sectionStart}
+     * closes the section. Throws if either marker is missing.
+     */
+    public static void assertSectionContains(Path path, String sectionStart,
+            String sectionEnd, String needle) {
+        String section = requireSection(path, sectionStart, sectionEnd);
+        if (!section.contains(needle)) {
+            throw new RuntimeException("File '" + path + "' section '"
+                    + sectionStart + "' .. '" + sectionEnd
+                    + "' does not contain expected text: '" + needle + "'");
+        }
+    }
+
+    /**
+     * Asserts that every {@code needle} appears between {@code sectionStart}
+     * and {@code sectionEnd} in the file. The section is sliced once and
+     * checked against each needle independently (no ordering enforced).
+     */
+    public static void assertSectionContains(Path path, String sectionStart,
+            String sectionEnd, String[] needles) {
+        String section = requireSection(path, sectionStart, sectionEnd);
+        for (String needle : needles) {
+            if (!section.contains(needle)) {
+                throw new RuntimeException("File '" + path + "' section '"
+                        + sectionStart + "' .. '" + sectionEnd
+                        + "' does not contain expected text: '" + needle + "'");
+            }
+        }
+    }
+
+    /**
+     * Symmetric counterpart of
+     * {@link #assertSectionContains(Path, String, String, String)}.
+     */
+    public static void assertSectionDoesNotContain(Path path,
+            String sectionStart, String sectionEnd, String needle) {
+        String section = requireSection(path, sectionStart, sectionEnd);
+        if (section.contains(needle)) {
+            throw new RuntimeException("File '" + path + "' section '"
+                    + sectionStart + "' .. '" + sectionEnd
+                    + "' unexpectedly contains text: '" + needle + "'");
+        }
+    }
+
+    private static String requireSection(Path path, String sectionStart,
+            String sectionEnd) {
+        assertFileExists(path);
+        String content = readFile(path);
+        int start = content.indexOf(sectionStart);
+        if (start < 0) {
+            throw new RuntimeException("File '" + path
+                    + "' missing section start marker: '" + sectionStart + "'");
+        }
+        int end = content.indexOf(sectionEnd, start + sectionStart.length());
+        if (end < 0) {
+            throw new RuntimeException(
+                    "File '" + path + "' missing section end marker '"
+                            + sectionEnd + "' after '" + sectionStart + "'");
+        }
+        return content.substring(start, end);
     }
 }

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/it/IntegrationTestHelper.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/it/IntegrationTestHelper.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.testbench.loadtest.it;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Shared assertion helpers for {@code verify.bsh} scripts under
+ * {@code src/it/}. Loaded onto the BeanShell classpath via the
+ * {@code addTestClassPath=true} setting on the maven-invoker-plugin.
+ */
+public final class IntegrationTestHelper {
+
+    private IntegrationTestHelper() {
+    }
+
+    public static void assertFileExists(Path path) {
+        if (!Files.exists(path)) {
+            throw new RuntimeException("Expected file does not exist: " + path);
+        }
+    }
+
+    public static void assertFileDoesNotExist(Path path) {
+        if (Files.exists(path)) {
+            throw new RuntimeException(
+                    "Expected file to be absent but found: " + path);
+        }
+    }
+
+    public static void assertDirectoryExists(Path path) {
+        if (!Files.isDirectory(path)) {
+            throw new RuntimeException(
+                    "Expected directory does not exist: " + path);
+        }
+    }
+
+    public static String readFile(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + path, e);
+        }
+    }
+
+    public static void assertFileContains(Path path, String needle) {
+        assertFileExists(path);
+        String content = readFile(path);
+        if (!content.contains(needle)) {
+            throw new RuntimeException("File '" + path
+                    + "' does not contain expected text: '" + needle + "'");
+        }
+    }
+
+    public static void assertFileDoesNotContain(Path path, String needle) {
+        assertFileExists(path);
+        String content = readFile(path);
+        if (content.contains(needle)) {
+            throw new RuntimeException("File '" + path
+                    + "' unexpectedly contains text: '" + needle + "'");
+        }
+    }
+
+    public static void assertLogContains(Path basedir, String needle) {
+        Path log = basedir.resolve("build.log");
+        assertFileContains(log, needle);
+    }
+
+    public static void assertLogDoesNotContain(Path basedir, String needle) {
+        Path log = basedir.resolve("build.log");
+        assertFileDoesNotContain(log, needle);
+    }
+}

--- a/vaadin-testbench-loadtest/testbench-loadtest-support/src/main/java/com/vaadin/testbench/loadtest/LoadTestItHelper.java
+++ b/vaadin-testbench-loadtest/testbench-loadtest-support/src/main/java/com/vaadin/testbench/loadtest/LoadTestItHelper.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
+import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBench;
 
 /**
@@ -79,6 +80,17 @@ public final class LoadTestItHelper {
         // Force localhost traffic through proxy (don't bypass loopback)
         options.addArguments("--proxy-bypass-list=<-loopback>");
         options.setAcceptInsecureCerts(true);
+
+        // Honor TestBench's local-driver flags so headless / --no-sandbox /
+        // --disable-dev-shm-usage propagate to the proxy driver too. Without
+        // this, CI runners blow up here with "session not created: Chrome
+        // instance exited" because TestBench's BrowserExtension already
+        // started a headless driver, then openWithProxy() quit it and we
+        // build a fresh one with the proxy flags only.
+        if (Parameters.isHeadless()) {
+            options.addArguments("--headless=new");
+        }
+        options.addArguments(Parameters.getChromeOptions());
 
         return TestBench.createDriver(new ChromeDriver(options));
     }


### PR DESCRIPTION
Introduces a comprehensive integration testing pipeline for the `testbench-converter-plugin`, enabling robust, cross-platform end-to-end verification of the plugin using Maven Invoker. The changes add a bootstrap process for downloading and configuring the `k6` binary, as well as new integration tests to verify plugin features and options. The testing infrastructure is now more modular, OS-aware, and ensures reproducible test environments.

The most important changes are:

**Integration Test Infrastructure:**
- Added a new integration test pipeline using Maven Invoker, including a bootstrap project (`000-install-k6`) that downloads the correct `k6` binary for the host OS/arch, sets executable permissions, and publishes the resolved binary path for downstream ITs. This ensures all integration tests use a consistent, pinned version of `k6` across platforms.
- Updated the main plugin `pom.xml` to orchestrate the IT pipeline, including property propagation and cross-IT coordination for the `k6` binary location.

Fixes: #2210