### PR TITLE
test: fix record-run-testbench assert

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -249,4 +249,3 @@ IntegrationTestHelper.assertFileContains(summaryJson, "http_reqs");
 IntegrationTestHelper.assertFileContains(summaryJson, "\"checks\"");
 IntegrationTestHelper.assertFileContains(summaryJson, "iterations");
 IntegrationTestHelper.assertFileContains(summaryHtml, "k6 Load Test Report");
-IntegrationTestHelper.assertLogContains(basePath, "k6 test completed successfully");


### PR DESCRIPTION
record-run-testbench load test can also fail. Removed assert for successful load test message in the log.
