### PR TITLE
fix: guard response.body in generated k6

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-playwright/verify.bsh
@@ -124,9 +124,9 @@ IntegrationTestHelper.assertSectionContains(k6Script,
 
 // ----- Vaadin session bootstrapping + response checks --------------------
 IntegrationTestHelper.assertFileContains(k6Script,
-    "let uiId = response.body.match(/\"v-uiId\"");
+    "let uiId = body.match(/\"v-uiId\"");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
+    "let csrfToken = body.match(/\"Vaadin-Security-Key\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "nodeMap = updateNodeMap(nodeMap, response.body)");
 IntegrationTestHelper.assertFileContains(k6Script,
@@ -135,10 +135,10 @@ IntegrationTestHelper.assertFileContains(k6Script, "'valid init response':");
 IntegrationTestHelper.assertSectionContains(k6Script,
         "// Abort iteration and trigger test abort if UIDL response is invalid", "}))", new String[] {
     "'UIDL request succeeded': (r) => r.status === 200",
-    "'no server error': (r) => !r.body.includes('\"appError\"')",
-    "'no exception': (r) => !r.body.includes('Exception')",
-    "'session is valid': (r) => !r.body.includes('Your session needs to be refreshed')",
-    "'security key valid': (r) => !r.body.includes('Invalid security key')",
+    "'no server error': (r) => !(r.body || '').includes('\"appError\"')",
+    "'no exception': (r) => !(r.body || '').includes('Exception')",
+    "'session is valid': (r) => !(r.body || '').includes('Your session needs to be refreshed')",
+    "'security key valid': (r) => !(r.body || '').includes('Invalid security key')",
     "'valid UIDL response': () => syncIdMatch !== null"
 });
 IntegrationTestHelper.assertFileContains(k6Script,

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/it/record-run-testbench/verify.bsh
@@ -191,9 +191,9 @@ IntegrationTestHelper.assertSectionContains(k6Script,
 
 // ----- Vaadin session bootstrapping + response checks --------------------
 IntegrationTestHelper.assertFileContains(k6Script,
-    "let uiId = response.body.match(/\"v-uiId\"");
+    "let uiId = body.match(/\"v-uiId\"");
 IntegrationTestHelper.assertFileContains(k6Script,
-    "let csrfToken = response.body.match(/\"Vaadin-Security-Key\"");
+    "let csrfToken = body.match(/\"Vaadin-Security-Key\"");
 IntegrationTestHelper.assertFileContains(k6Script,
     "nodeMap = updateNodeMap(nodeMap, response.body)");
 IntegrationTestHelper.assertFileContains(k6Script,
@@ -202,10 +202,10 @@ IntegrationTestHelper.assertFileContains(k6Script, "'valid init response':");
 IntegrationTestHelper.assertSectionContains(k6Script,
         "// Abort iteration and trigger test abort if UIDL response is invalid", "}))", new String[] {
     "'UIDL request succeeded': (r) => r.status === 200",
-    "'no server error': (r) => !r.body.includes('\"appError\"')",
-    "'no exception': (r) => !r.body.includes('Exception')",
-    "'session is valid': (r) => !r.body.includes('Your session needs to be refreshed')",
-    "'security key valid': (r) => !r.body.includes('Invalid security key')",
+    "'no server error': (r) => !(r.body || '').includes('\"appError\"')",
+    "'no exception': (r) => !(r.body || '').includes('Exception')",
+    "'session is valid': (r) => !(r.body || '').includes('Your session needs to be refreshed')",
+    "'security key valid': (r) => !(r.body || '').includes('Invalid security key')",
     "'valid UIDL response': () => syncIdMatch !== null"
 });
 IntegrationTestHelper.assertFileContains(k6Script,

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarToK6Converter.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarToK6Converter.java
@@ -707,25 +707,28 @@ public class HarToK6Converter {
     private String generateSessionExtractionCode(String requestLabel,
             ResponseCheckConfig responseCheckConfig) {
         StringBuilder code = new StringBuilder();
+        // Coerce body to '' when the server returned an error response with a
+        // null/undefined body.
+        code.append("  var body = response.body || ''\n");
         code.append(
                 "  // Abort iteration and trigger test abort if init response is invalid\n");
         code.append("  if (!check(response, {\n");
         code.append("    'init request succeeded': (r) => r.status === 200,\n");
         code.append(
-                "    'session is valid': (r) => !r.body.includes('Your session needs to be refreshed'),\n");
+                "    'session is valid': (r) => !(r.body || '').includes('Your session needs to be refreshed'),\n");
         code.append(
-                "    'valid init response': (r) => r.body.includes('\"v-uiId\"') && r.body.includes('\"Vaadin-Security-Key\"'),\n");
+                "    'valid init response': (r) => (r.body || '').includes('\"v-uiId\"') && (r.body || '').includes('\"Vaadin-Security-Key\"'),\n");
         code.append(responseCheckConfig
                 .toK6CheckLines(ResponseCheckConfig.Scope.INIT));
         code.append("  })) {\n");
         code.append("    fail(`").append(escapeJsTemplate(requestLabel)).append(
-                ": init failed (status ${response.status}): ${response.body.substring(0, 200)}`)\n");
+                ": init failed (status ${response.status}): ${body.substring(0, 200)}`)\n");
         code.append("  }\n\n");
         code.append("  // Extract Vaadin session values from init response\n");
         code.append(
-                "  let uiId = response.body.match(/\"v-uiId\"\\s*:\\s*(\\d+)/)[1]\n");
+                "  let uiId = body.match(/\"v-uiId\"\\s*:\\s*(\\d+)/)[1]\n");
         code.append(
-                "  let csrfToken = response.body.match(/\"Vaadin-Security-Key\"\\s*:\\s*\"([^\"]+)\"/)[1]\n");
+                "  let csrfToken = body.match(/\"Vaadin-Security-Key\"\\s*:\\s*\"([^\"]+)\"/)[1]\n");
         code.append("  let syncId = 0\n");
         code.append("  let clientId = 0\n");
         code.append("  let gridKeys = []\n");
@@ -751,8 +754,10 @@ public class HarToK6Converter {
         StringBuilder code = new StringBuilder();
         code.append(
                 "  // Re-extract Vaadin session values after login/navigation\n");
+        // Same body-null guard as elsewhere — a 200 response with no body
+        // shouldn't crash the script with a TypeError.
         code.append(
-                "  if (response.status === 200 && response.body.includes('\"Vaadin-Security-Key\"')) {\n");
+                "  if (response.status === 200 && (response.body || '').includes('\"Vaadin-Security-Key\"')) {\n");
         code.append(
                 "    var newUiId = response.body.match(/\"v-uiId\"\\s*:\\s*(\\d+)/)\n");
         code.append(
@@ -785,24 +790,27 @@ public class HarToK6Converter {
         StringBuilder code = new StringBuilder();
         code.append(
                 "  // Abort iteration and trigger test abort if UIDL response is invalid\n");
+        // Coerce body to '' when the server returned an error response with a
+        // null/undefined body.
+        code.append("  var body = response.body || ''\n");
         code.append(
-                "  var syncIdMatch = response.body.match(/\"syncId\"\\s*:\\s*(-?\\d+)/)\n");
+                "  var syncIdMatch = body.match(/\"syncId\"\\s*:\\s*(-?\\d+)/)\n");
         code.append("  if (!check(response, {\n");
         code.append("    'UIDL request succeeded': (r) => r.status === 200,\n");
         code.append(
-                "    'no server error': (r) => !r.body.includes('\"appError\"'),\n");
+                "    'no server error': (r) => !(r.body || '').includes('\"appError\"'),\n");
         code.append(
-                "    'no exception': (r) => !r.body.includes('Exception'),\n");
+                "    'no exception': (r) => !(r.body || '').includes('Exception'),\n");
         code.append(
-                "    'session is valid': (r) => !r.body.includes('Your session needs to be refreshed'),\n");
+                "    'session is valid': (r) => !(r.body || '').includes('Your session needs to be refreshed'),\n");
         code.append(
-                "    'security key valid': (r) => !r.body.includes('Invalid security key'),\n");
+                "    'security key valid': (r) => !(r.body || '').includes('Invalid security key'),\n");
         code.append("    'valid UIDL response': () => syncIdMatch !== null,\n");
         code.append(responseCheckConfig
                 .toK6CheckLines(ResponseCheckConfig.Scope.UIDL));
         code.append("  })) {\n");
         code.append("    fail(`").append(escapeJsTemplate(requestLabel)).append(
-                ": UIDL failed (status ${response.status}): ${response.body.substring(0, 200)}`)\n");
+                ": UIDL failed (status ${response.status}): ${body.substring(0, 200)}`)\n");
         code.append("  }\n\n");
         code.append(
                 "  // Update Vaadin sync counters from response (-1 means UNDEFINED_SYNC_ID, treat as 0)\n");
@@ -810,8 +818,7 @@ public class HarToK6Converter {
         code.append("  clientId++\n");
         code.append(
                 "  // Extract grid item keys from response (used for select/edit operations)\n");
-        code.append(
-                "  var found = response.body.match(/\"key\":\"[^\"]+\"/g)\n");
+        code.append("  var found = body.match(/\"key\":\"[^\"]+\"/g)\n");
         code.append(
                 "  if (found) gridKeys = found.map(s => s.split('\"')[3])\n");
         // Refresh stable-key → node-ID bindings from the response's changes

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/resources/k6-utils/vaadin-k6-helpers.js
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/resources/k6-utils/vaadin-k6-helpers.js
@@ -181,14 +181,18 @@ export function vaadinRequest(baseUrl, vaadinInfo, rpcPayload, idCounter, route)
         createBaseParams(baseUrl, route),
     );
 
+    // Guard r.body / resp.body with (... || '') — if the server returns an
+    // error response, k6 may surface body as undefined/null, and the raw
+    // .includes()/.substring() calls would throw a TypeError before the
+    // status check can fail-fast on the actual problem.
     if (!check(resp, {
         'UIDL request succeeded': (r) => r.status === 200,
-        'no server error': (r) => !r.body.includes('"appError"'),
-        'session is valid': (r) => !r.body.includes('Your session needs to be refreshed'),
-        'security key valid': (r) => !r.body.includes('Invalid security key'),
-        'valid UIDL response': (r) => r.body.includes('"syncId"'),
+        'no server error': (r) => !(r.body || '').includes('"appError"'),
+        'session is valid': (r) => !(r.body || '').includes('Your session needs to be refreshed'),
+        'security key valid': (r) => !(r.body || '').includes('Invalid security key'),
+        'valid UIDL response': (r) => (r.body || '').includes('"syncId"'),
     })) {
-        fail(`UIDL request failed (status ${resp.status}): ${resp.body.substring(0, 200)}`);
+        fail(`UIDL request failed (status ${resp.status}): ${(resp.body || '').substring(0, 200)}`);
     }
 
     return resp;

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
@@ -469,6 +469,31 @@ class HarToK6ConverterTest {
                         + script);
     }
 
+    @Test
+    void reExtractionGuardCoercesResponseBody() throws IOException {
+        // Two init entries trigger the re-extraction code path. The
+        // status===200
+        // gate alone is not enough — a 200 with an empty body would still throw
+        // TypeError on response.body.includes(...) without the (... || '')
+        // guard.
+        String har = createHar(
+                vaadinInitEntry("http://localhost:8080/?v-r=init&location="),
+                vaadinInitEntry(
+                        "http://localhost:8080/?v-r=init&location=login"));
+
+        Path harFile = tempDir.resolve("test.har");
+        Path outputFile = tempDir.resolve("test.js");
+        Files.writeString(harFile, har);
+
+        new HarToK6Converter().convert(harFile, outputFile);
+
+        String script = Files.readString(outputFile);
+        assertTrue(script.contains(
+                "if (response.status === 200 && (response.body || '').includes('\"Vaadin-Security-Key\"'))"),
+                "Re-extraction guard must coerce response.body to ''. Got:\n"
+                        + script);
+    }
+
     // --- Helper methods to build HAR JSON ---
 
     private String vaadinInitEntry(String url) {


### PR DESCRIPTION
Server error responses can leave `r.body` undefined/null, causing generated scripts to throw "TypeError: Cannot read property 'includes' of undefined or null" before the status check can fail-fast on the real problem. Coerce to '' at every built-in body-access site in both the bundled `vaadin-k6-helpers.js` and `HarToK6Converter`'s emitted init/UIDL extraction blocks.
