### PR TITLE
chore: update k6 warmup command

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -23,7 +23,7 @@
         <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
         <!-- Pinned k6 version for the auto-install integration test (000-install-k6).
              Bumping this updates every IT that consumes the downloaded binary. -->
-        <k6.version>0.54.0</k6.version>
+        <k6.version>1.6.1</k6.version>
         <!--
             OS-agnostic install location for the k6 binary. The 000-install-k6
             IT does the actual download and writes the resolved absolute path

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
@@ -144,8 +144,9 @@ public class K6RunMojo extends AbstractK6Mojo {
      * When true, runs a single 1-VU / 1-iteration warmup pass before each load
      * test to prime caches, JIT, and class loaders on the target application.
      * The warmup runs the recorded scenario(s) once with
-     * {@code --no-summary --no-thresholds} so its metrics never appear in
-     * reports and threshold violations during warmup never fail the build.
+     * {@code --summary-mode=disabled --no-thresholds} so its metrics never
+     * appear in reports and threshold violations during warmup never fail the
+     * build.
      */
     @Parameter(property = "k6.warmup", defaultValue = "false")
     private boolean warmup;

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/NodeRunner.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/NodeRunner.java
@@ -105,7 +105,7 @@ public class NodeRunner {
      * Enables or disables a 1-VU / 1-iteration warmup pass that runs before
      * each load test. The warmup primes caches, JIT, and class loaders on the
      * target application so the first measured iterations are not skewed by
-     * cold-start cost. Warmup runs with {@code --no-summary
+     * cold-start cost. Warmup runs with {@code --summary-mode=disabled
      * --no-thresholds} so it never appears in reports or fails the build.
      *
      * @param warmup
@@ -444,8 +444,8 @@ public class NodeRunner {
 
     /**
      * Runs a single 1-VU / 1-iteration warmup pass against the given test file.
-     * Output is suppressed via {@code --no-summary --no-thresholds} so the
-     * warmup never appears in reports or fails the build on threshold
+     * Output is suppressed via {@code --summary-mode=disabled --no-thresholds}
+     * so the warmup never appears in reports or fails the build on threshold
      * violations.
      *
      * <p>
@@ -478,7 +478,7 @@ public class NodeRunner {
             command.add("1");
             command.add("--iterations");
             command.add("1");
-            command.add("--no-summary");
+            command.add("--summary-mode=disabled");
             command.add("--no-thresholds");
             command.add("-e");
             command.add("APP_IP=" + appIp);


### PR DESCRIPTION
Replace deprecated --no-summary with --summary-mode=disabled to remove warning in logs.