### PR TITLE
chore: Add back slf4j-simple (V8)

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -217,6 +217,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>


### PR DESCRIPTION
Turns out WebDriverManager was not, in fact, the only thing using this.