### PR TITLE
fix: Use same default for mojos

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractK6Mojo.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.testbench.loadtest;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,6 +51,14 @@ public abstract class AbstractK6Mojo extends AbstractMojo {
      */
     @Parameter(property = "k6.utilsDir", defaultValue = "${project.build.directory}/k6-utils")
     protected String utilsDir;
+
+    /**
+     * Directory for generated k6 tests. Used as the destination by the record
+     * and convert goals, and as the default test directory by the run goal when
+     * {@code k6.testDir} is not set.
+     */
+    @Parameter(property = "k6.outputDir", defaultValue = "${project.build.directory}/k6/tests")
+    protected File outputDir;
 
     /**
      * Skip execution of this goal.

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractRecordMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/AbstractRecordMojo.java
@@ -68,12 +68,6 @@ public abstract class AbstractRecordMojo extends AbstractK6Mojo {
     protected File harDir;
 
     /**
-     * Output directory for generated k6 tests.
-     */
-    @Parameter(property = "k6.outputDir", defaultValue = "${project.build.directory}/k6/tests")
-    protected File outputDir;
-
-    /**
      * Timeout for test execution in seconds.
      */
     @Parameter(property = "k6.testTimeout", defaultValue = "300")

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6ConvertMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6ConvertMojo.java
@@ -43,13 +43,6 @@ public class K6ConvertMojo extends AbstractK6Mojo {
     private File harFile;
 
     /**
-     * Output directory for generated k6 tests. Defaults to k6/tests within the
-     * target directory.
-     */
-    @Parameter(property = "k6.outputDir", defaultValue = "${project.build.directory}/k6/tests")
-    private File outputDir;
-
-    /**
      * Output file name for the generated test. If not specified, derives from
      * HAR file name.
      */

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
@@ -623,8 +623,8 @@ public class K6RunMojo extends AbstractK6Mojo {
     /**
      * Builds the list of test files to run from configuration. Resolution
      * order: {@code testFiles} takes precedence; otherwise {@code testFile};
-     * otherwise the test directory ({@code testDir}, falling back to the
-     * shared {@code outputDir}).
+     * otherwise the test directory ({@code testDir}, falling back to the shared
+     * {@code outputDir}).
      */
     private List<Path> getTestFilesToRun() throws MojoExecutionException {
         List<Path> result = new ArrayList<>();
@@ -655,15 +655,13 @@ public class K6RunMojo extends AbstractK6Mojo {
         if (effectiveTestDir != null && effectiveTestDir.exists()
                 && effectiveTestDir.isDirectory()) {
             try (Stream<Path> files = Files.list(effectiveTestDir.toPath())) {
-                files.filter(p -> p.toString().endsWith(".js"))
-                        .filter(p -> !p.getFileName().toString()
-                                .contains("helper"))
+                files.filter(p -> p.toString().endsWith(".js")).filter(
+                        p -> !p.getFileName().toString().contains("helper"))
                         .filter(p -> !p.getFileName().toString()
                                 .contains("-generated"))
                         .filter(p -> !p.getFileName().toString()
                                 .equals("combined-scenarios.js"))
-                        .sorted()
-                        .forEach(p -> result.add(p.toAbsolutePath()));
+                        .sorted().forEach(p -> result.add(p.toAbsolutePath()));
             } catch (IOException e) {
                 throw new MojoExecutionException(
                         "Failed to list test directory: " + effectiveTestDir,

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/K6RunMojo.java
@@ -74,7 +74,7 @@ public class K6RunMojo extends AbstractK6Mojo {
 
     /**
      * Directory containing k6 test files. All .js files (excluding helpers)
-     * will be run.
+     * will be run. If not set, defaults to {@code k6.outputDir}.
      */
     @Parameter(property = "k6.testDir")
     private File testDir;
@@ -621,12 +621,14 @@ public class K6RunMojo extends AbstractK6Mojo {
     }
 
     /**
-     * Builds the list of test files to run from configuration.
+     * Builds the list of test files to run from configuration. Resolution
+     * order: {@code testFiles} takes precedence; otherwise {@code testFile};
+     * otherwise the test directory ({@code testDir}, falling back to the
+     * shared {@code outputDir}).
      */
     private List<Path> getTestFilesToRun() throws MojoExecutionException {
         List<Path> result = new ArrayList<>();
 
-        // Add from testFiles list
         if (testFiles != null && !testFiles.isEmpty()) {
             for (File f : testFiles) {
                 Path path = f.toPath().toAbsolutePath();
@@ -636,38 +638,36 @@ public class K6RunMojo extends AbstractK6Mojo {
                 }
                 result.add(path);
             }
+            return result;
         }
 
-        // Add single testFile if specified
         if (testFile != null) {
             Path path = testFile.toPath().toAbsolutePath();
             if (!Files.exists(path)) {
                 throw new MojoExecutionException(
                         "Test file not found: " + path);
             }
-            if (!result.contains(path)) {
-                result.add(path);
-            }
+            result.add(path);
+            return result;
         }
 
-        // Add all .js files from testDir (excluding helpers, generated, and
-        // combined)
-        if (testDir != null && testDir.exists() && testDir.isDirectory()) {
-            try (Stream<Path> files = Files.list(testDir.toPath())) {
-                files.filter(p -> p.toString().endsWith(".js")).filter(
-                        p -> !p.getFileName().toString().contains("helper"))
+        File effectiveTestDir = testDir != null ? testDir : outputDir;
+        if (effectiveTestDir != null && effectiveTestDir.exists()
+                && effectiveTestDir.isDirectory()) {
+            try (Stream<Path> files = Files.list(effectiveTestDir.toPath())) {
+                files.filter(p -> p.toString().endsWith(".js"))
+                        .filter(p -> !p.getFileName().toString()
+                                .contains("helper"))
                         .filter(p -> !p.getFileName().toString()
                                 .contains("-generated"))
                         .filter(p -> !p.getFileName().toString()
                                 .equals("combined-scenarios.js"))
-                        .sorted().forEach(p -> {
-                            if (!result.contains(p.toAbsolutePath())) {
-                                result.add(p.toAbsolutePath());
-                            }
-                        });
+                        .sorted()
+                        .forEach(p -> result.add(p.toAbsolutePath()));
             } catch (IOException e) {
                 throw new MojoExecutionException(
-                        "Failed to list test directory: " + testDir, e);
+                        "Failed to list test directory: " + effectiveTestDir,
+                        e);
             }
         }
 


### PR DESCRIPTION
Record and convert use the same
default outputDir.

Run mojo defaults to default
outputDir if testDir not specified.

testFiles, testFile and testDir
are not collected together.
if testFiles or testFile set no
testDir is checked.
if testFiles set no testFile is added.
