### PR TITLE
chore: Define jetty-maven-plugin version in non-profile pluginManagement

### DIFF
--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -32,6 +32,15 @@
         </repository>
     </repositories>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <version>${jetty.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>   
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Needed for the build phase in GitHub Actions.