### PR TITLE
fix: anchor gridKeys regex to grid item rows in generated k6

### DIFF
--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarToK6Converter.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/HarToK6Converter.java
@@ -817,8 +817,12 @@ public class HarToK6Converter {
         code.append("  syncId = Math.max(0, parseInt(syncIdMatch[1]))\n");
         code.append("  clientId++\n");
         code.append(
-                "  // Extract grid item keys from response (used for select/edit operations)\n");
-        code.append("  var found = body.match(/\"key\":\"[^\"]+\"/g)\n");
+                "  // Extract grid item keys from response (used for select/edit operations).\n");
+        code.append(
+                "  // Anchor on object-start so only the first key in a row matches; change-record\n");
+        code.append(
+                "  // keys (e.g. type+key+value triples) are preceded by other fields and skipped.\n");
+        code.append("  var found = body.match(/\\x7B\"key\":\"[^\"]+\"/g)\n");
         code.append(
                 "  if (found) gridKeys = found.map(s => s.split('\"')[3])\n");
         // Refresh stable-key → node-ID bindings from the response's changes

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombiner.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/main/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombiner.java
@@ -247,21 +247,12 @@ public class K6ScenarioCombiner {
         }
 
         int functionStart = matcher.end();
-        int braceCount = 1;
-        int functionEnd = functionStart;
-
-        // Find matching closing brace
-        for (int i = functionStart; i < content.length()
-                && braceCount > 0; i++) {
-            char c = content.charAt(i);
-            if (c == '{')
-                braceCount++;
-            else if (c == '}')
-                braceCount--;
-            functionEnd = i;
-        }
-
-        String functionBody = content.substring(functionStart, functionEnd);
+        // matcher.end() points one past the opening `{`. Step back to it so
+        // the helper can use a uniform "index of opening brace" contract.
+        int functionEnd = findMatchingClosingBrace(content, functionStart - 1);
+        // functionEnd points one past the closing `}` — drop it so the wrapper
+        // below can re-add a single `}` of its own.
+        String functionBody = content.substring(functionStart, functionEnd - 1);
 
         // Rename inputData references to scenario-specific name for combined
         // scripts
@@ -310,18 +301,94 @@ public class K6ScenarioCombiner {
 
         // Find the matching closing brace of the function
         int braceStart = content.indexOf('{', funcStart);
-        int i = braceStart + 1;
-        int braceCount = 1;
-        while (i < content.length() && braceCount > 0) {
+        int afterClose = findMatchingClosingBrace(content, braceStart);
+        return content.substring(funcStart, afterClose);
+    }
+
+    /**
+     * Returns the index one past the closing `}` that matches the opening `{`
+     * at {@code openBraceIndex}. Skips over single-line comments
+     * ({@code // ...}), block comments ({@code /* ... *}{@code /}), and string
+     * literals ({@code "..."}, {@code '...'}, {@code `...`}) so braces inside
+     * them do not affect the depth count. A backslash escape outside a string
+     * ({@code \{} or {@code \}} inside a regex literal) also consumes the
+     * following character without counting it.
+     *
+     * <p>
+     * This is a pragmatic shim — not a full JS tokenizer. It handles the shapes
+     * that arise in generated k6 scripts and is robust to braces appearing in
+     * comments, regex literals, and template strings.
+     *
+     * @param content
+     *            the JS source to walk
+     * @param openBraceIndex
+     *            index of the opening {@code &#123;} whose match is sought
+     * @return one past the matching closing brace, or {@code content.length()}
+     *         if no match is found before end-of-input
+     */
+    private static int findMatchingClosingBrace(String content,
+            int openBraceIndex) {
+        int n = content.length();
+        int i = openBraceIndex + 1;
+        int depth = 1;
+        while (i < n && depth > 0) {
             char c = content.charAt(i);
-            if (c == '{')
-                braceCount++;
-            else if (c == '}')
-                braceCount--;
+            // Single-line comment — skip to end of line so braces inside
+            // human-written comments are ignored.
+            if (c == '/' && i + 1 < n && content.charAt(i + 1) == '/') {
+                int eol = content.indexOf('\n', i + 2);
+                i = (eol < 0) ? n : eol;
+                continue;
+            }
+            // Block comment.
+            if (c == '/' && i + 1 < n && content.charAt(i + 1) == '*') {
+                int end = content.indexOf("*/", i + 2);
+                i = (end < 0) ? n : end + 2;
+                continue;
+            }
+            // String literals (single, double, backtick). Backtick template
+            // strings are treated as opaque — `${...}` interpolation has
+            // matched braces, so the depth net-zero across the literal.
+            if (c == '\'' || c == '"' || c == '`') {
+                char quote = c;
+                i++;
+                while (i < n) {
+                    char d = content.charAt(i);
+                    if (d == '\\' && i + 1 < n) {
+                        i += 2;
+                        continue;
+                    }
+                    if (d == quote) {
+                        i++;
+                        break;
+                    }
+                    // ' and " strings cannot span lines unescaped — bail out
+                    // on a stray newline rather than consuming the rest of
+                    // the file.
+                    if (d == '\n' && quote != '`') {
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+            // Backslash escape outside a string (e.g. `\{` in a regex
+            // literal). Consume the following character without counting it.
+            if (c == '\\' && i + 1 < n) {
+                i += 2;
+                continue;
+            }
+            if (c == '{') {
+                depth++;
+            } else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return i + 1;
+                }
+            }
             i++;
         }
-
-        return content.substring(funcStart, i);
+        return i;
     }
 
     /**

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/HarToK6ConverterTest.java
@@ -470,6 +470,29 @@ class HarToK6ConverterTest {
     }
 
     @Test
+    void gridKeysRegexIsAnchoredOnObjectStart() throws IOException {
+        // The regex must match grid item rows ({"key":"1","col0":...}) but
+        // not change-record keys ({"node":N,"type":"put","key":"highlight"}).
+        // Anchoring on the object-start `{` (encoded as `\x7B`) excludes the
+        // change-record case, where `key` is preceded by other fields.
+        String har = createHar(
+                vaadinInitEntry("http://localhost:8080/?v-r=init&location="),
+                vaadinUidlEntry("http://localhost:8080/?v-r=uidl&v-uiId=0"));
+
+        Path harFile = tempDir.resolve("test.har");
+        Path outputFile = tempDir.resolve("test.js");
+        Files.writeString(harFile, har);
+
+        new HarToK6Converter().convert(harFile, outputFile);
+
+        String script = Files.readString(outputFile);
+        assertTrue(script.contains("body.match(/\\x7B\"key\":\"[^\"]+\"/g)"),
+                "gridKeys regex must anchor on object-start. Got:\n" + script);
+        assertFalse(script.contains("body.match(/\"key\":\"[^\"]+\"/g)"),
+                "Old un-anchored regex should be gone. Got:\n" + script);
+    }
+
+    @Test
     void reExtractionGuardCoercesResponseBody() throws IOException {
         // Two init entries trigger the re-extraction code path. The
         // status===200

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
@@ -206,6 +206,46 @@ class K6ScenarioCombinerTest {
     }
 
     @Test
+    void combine_scenarioWithUnbalancedBracesInRegexAndCommentsClosesCleanly()
+            throws IOException {
+        // The brace walker must skip braces inside regex literals, comments,
+        // and strings. Each line of the body below contains a shape that
+        // broke the previous naive counter (regex `\{`, isolated `{` in a
+        // comment, isolated `{` and `}` in string literals); without
+        // lexer-aware skipping, the walker overshoots and slurps the
+        // trailing handleSummary export.
+        Path scenario = writeScenario("alpha", """
+                  // anchor on `{` to skip change-record keys
+                  let body = 'a { is hard to count'
+                  let body2 = 'and so is a } on its own'
+                  var found = body.match(/\\{"key":"[^"]+"/g)
+                  if (found) gridKeys = found.map(s => s.split('"')[3])
+                """);
+        String existing = Files.readString(scenario);
+        Files.writeString(scenario, existing
+                + "\nexport function handleSummary(data) {\n  return {}\n}\n");
+
+        K6ScenarioCombiner combiner = new K6ScenarioCombiner();
+        Path output = tempDir.resolve("combined.js");
+        combiner.combine(List.of(new ScenarioConfig("alpha", scenario, 100)),
+                output, 5, "10s");
+
+        String content = Files.readString(output);
+        int handleSummaryCount = 0;
+        int idx = 0;
+        while ((idx = content.indexOf("function handleSummary", idx)) != -1) {
+            handleSummaryCount++;
+            idx += "function handleSummary".length();
+        }
+        assertEquals(1, handleSummaryCount,
+                "Combined script must export exactly one handleSummary. Got:\n"
+                        + content);
+        assertTrue(content.contains("export function alphaScenario()"),
+                "Scenario function should still be wrapped properly:\n"
+                        + content);
+    }
+
+    @Test
     void combine_noSharedArrayWhenAbsent() throws IOException {
         Path a = writeScenario("alpha", "  http.get(`${BASE_URL}/a`);");
 

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/src/test/java/com/vaadin/testbench/loadtest/util/K6ScenarioCombinerTest.java
@@ -212,8 +212,15 @@ class K6ScenarioCombinerTest {
         // and strings. Each line of the body below contains a shape that
         // broke the previous naive counter (regex `\{`, isolated `{` in a
         // comment, isolated `{` and `}` in string literals); without
-        // lexer-aware skipping, the walker overshoots and slurps the
-        // trailing handleSummary export.
+        // lexer-aware skipping, the walker either truncates the body at a
+        // `}` inside a string or overshoots and slurps the trailing
+        // handleSummary export.
+        List<String> bodyLines = List.of(
+                "// anchor on `{` to skip change-record keys",
+                "let body = 'a { is hard to count'",
+                "let body2 = 'and so is a } on its own'",
+                "var found = body.match(/\\{\"key\":\"[^\"]+\"/g)",
+                "if (found) gridKeys = found.map(s => s.split('\"')[3])");
         Path scenario = writeScenario("alpha", """
                   // anchor on `{` to skip change-record keys
                   let body = 'a { is hard to count'
@@ -231,6 +238,10 @@ class K6ScenarioCombinerTest {
                 output, 5, "10s");
 
         String content = Files.readString(output);
+
+        // Overshoot guard: only the combiner's own handleSummary should
+        // survive. A second one means the walker absorbed the scenario
+        // file's trailing handleSummary into the wrapped body.
         int handleSummaryCount = 0;
         int idx = 0;
         while ((idx = content.indexOf("function handleSummary", idx)) != -1) {
@@ -240,9 +251,23 @@ class K6ScenarioCombinerTest {
         assertEquals(1, handleSummaryCount,
                 "Combined script must export exactly one handleSummary. Got:\n"
                         + content);
-        assertTrue(content.contains("export function alphaScenario()"),
-                "Scenario function should still be wrapped properly:\n"
-                        + content);
+
+        // Undershoot guard: every body line must appear between the wrapper
+        // opening and the combiner-appended handleSummary. A `}` inside a
+        // string literal misread as a real closing brace would truncate the
+        // body, dropping the lines after it from the output entirely.
+        int wrapperStart = content.indexOf("export function alphaScenario() {");
+        assertTrue(wrapperStart >= 0,
+                "Scenario function should be wrapped:\n" + content);
+        int handleSummaryStart = content.indexOf("function handleSummary",
+                wrapperStart);
+        String wrappedRegion = content.substring(wrapperStart,
+                handleSummaryStart);
+        for (String line : bodyLines) {
+            assertTrue(wrappedRegion.contains(line),
+                    "Wrapped scenario should contain body line: " + line
+                            + "\nWrapped region was:\n" + wrappedRegion);
+        }
     }
 
     @Test


### PR DESCRIPTION
The previous regex `/"key":"[^"]+"/g` matched both grid item rows `({"key":"1","col0":...})` and change-record keys `({"node":N,"type":"put","key":"highlight",...})`. On responses with no grid items it overwrote `gridKeys` with property names like "highlight" or "tag", causing select() RPCs to send garbage keys and downstream resolveNode() throws (e.g. "unresolved node: abc"). Anchoring on `{` matches only keys that are the first property of an object, so grid items are picked up and change-record keys are ignored; when no items are present, gridKeys keeps its previous valid contents.

Replace the naive walker in `K6ScenarioCombiner`. The combiner is now agnostic to braces in human-written comments and string literals.
