### PR TITLE
chore: satisfy artifact deployment metadata requirements

### DIFF
--- a/vaadin-testbench-loadtest/load-tests/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/pom.xml
@@ -11,8 +11,24 @@
     </parent>
 
     <artifactId>load-tests</artifactId>
-    <name>Load Tests</name>
+    <name>Vaadin TestBench Load Tests</name>
     <packaging>pom</packaging>
+    <description>Aggregator for Vaadin TestBench k6 load-test demo and integration test modules.</description>
+    <url>https://vaadin.com</url>
+
+    <scm>
+        <connection>scm:git:git://github.com/vaadin/testbench.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/vaadin/testbench.git</developerConnection>
+        <url>https://github.com/vaadin/testbench</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Vaadin Ltd</name>
+            <organization>Vaadin Ltd</organization>
+            <organizationUrl>https://vaadin.com</organizationUrl>
+        </developer>
+    </developers>
 
     <dependencyManagement>
         <dependencies>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -163,10 +163,51 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <configuration>
+                    <charset>UTF-8</charset>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.11.2</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <!--
              Opt-in profile that wires up the maven-invoker IT pipeline.
              Activate with `-Pmaven-invoker-it`.

--- a/vaadin-testbench-loadtest/testbench-loadtest-support/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-loadtest-support/pom.xml
@@ -99,6 +99,50 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <configuration>
+                    <charset>UTF-8</charset>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.11.2</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Add description, url, scm, and developers to load-tests so its deployed POM passes Sonatype validation. Attach sources and javadocs to testbench-loadtest-support and testbench-converter-plugin via maven-source-plugin (always-on) and maven-javadoc-plugin (release profile), matching the convention used by other deployable testbench modules.