### PR TITLE
chore: bump project version to 25.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-testbench-parent</artifactId>
     <packaging>pom</packaging>
-    <version>10.2-SNAPSHOT</version>
+    <version>25.2-SNAPSHOT</version>
     <name>Vaadin TestBench parent</name>
 
     <organization>

--- a/testing-support/uiunit-component-testers/pom.xml
+++ b/testing-support/uiunit-component-testers/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing-support/uiunit-test-components/pom.xml
+++ b/testing-support/uiunit-test-components/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/vaadin-testbench-bom/pom.xml
+++ b/vaadin-testbench-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-bom</artifactId>
     <packaging>pom</packaging>

--- a/vaadin-testbench-core-junit5/pom.xml
+++ b/vaadin-testbench-core-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core-junit5</artifactId>

--- a/vaadin-testbench-core-junit6/pom.xml
+++ b/vaadin-testbench-core-junit6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core-junit6</artifactId>

--- a/vaadin-testbench-core/pom.xml
+++ b/vaadin-testbench-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-core</artifactId>

--- a/vaadin-testbench-integration-tests-junit5/pom.xml
+++ b/vaadin-testbench-integration-tests-junit5/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests-junit5</artifactId>

--- a/vaadin-testbench-integration-tests-junit6/pom.xml
+++ b/vaadin-testbench-integration-tests-junit6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests-junit6</artifactId>

--- a/vaadin-testbench-integration-tests/pom.xml
+++ b/vaadin-testbench-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-integration-tests</artifactId>

--- a/vaadin-testbench-loadtest/load-tests/demo-web-app-loadtest/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/demo-web-app-loadtest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>load-tests</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo-web-app-loadtest</artifactId>

--- a/vaadin-testbench-loadtest/load-tests/demo-web-app-playwright-loadtest/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/demo-web-app-playwright-loadtest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>load-tests</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo-web-app-playwright-loadtest</artifactId>

--- a/vaadin-testbench-loadtest/load-tests/demo-web-app-playwright/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/demo-web-app-playwright/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <groupId>com.vaadin</groupId>
     <artifactId>demo-web-app-playwright</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>25.2-SNAPSHOT</version>
     <name>Demo Web Application (Playwright)</name>
     <description>Demo Vaadin application with Playwright tests for k6 recording</description>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>testbench-loadtest-support</artifactId>
-            <version>10.2-SNAPSHOT</version>
+            <version>25.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/vaadin-testbench-loadtest/load-tests/demo-web-app/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/demo-web-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>load-tests</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo-web-app</artifactId>

--- a/vaadin-testbench-loadtest/load-tests/pom.xml
+++ b/vaadin-testbench-loadtest/load-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-loadtest</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>load-tests</artifactId>

--- a/vaadin-testbench-loadtest/pom.xml
+++ b/vaadin-testbench-loadtest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <groupId>com.vaadin</groupId>

--- a/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-converter-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-loadtest</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>testbench-converter-plugin</artifactId>

--- a/vaadin-testbench-loadtest/testbench-loadtest-support/pom.xml
+++ b/vaadin-testbench-loadtest/testbench-loadtest-support/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
     <artifactId>vaadin-testbench-loadtest</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>testbench-loadtest-support</artifactId>

--- a/vaadin-testbench-shared/pom.xml
+++ b/vaadin-testbench-shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-testbench-shared</artifactId>

--- a/vaadin-testbench-unit-junit5/pom.xml
+++ b/vaadin-testbench-unit-junit5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-junit5</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-junit6/pom.xml
+++ b/vaadin-testbench-unit-junit6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-junit6</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-quarkus/pom.xml
+++ b/vaadin-testbench-unit-quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-quarkus</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit-shared/pom.xml
+++ b/vaadin-testbench-unit-shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit-shared</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-testbench-unit/pom.xml
+++ b/vaadin-testbench-unit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-testbench-parent</artifactId>
-        <version>10.2-SNAPSHOT</version>
+        <version>25.2-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench-unit</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
- align TB with vaadin version