### PR TITLE
fix: Reconcile Javadoc @since tags against published release history

### DIFF
--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserDriverTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserDriverTestBase.java
@@ -13,6 +13,8 @@ import org.openqa.selenium.WebDriver;
 /**
  * Base class for tests using {@link WebDriver}. Provides wrapping for
  * {@link TestBenchDriverProxy}.
+ *
+ * @since 9.0
  */
 public abstract class AbstractBrowserDriverTestBase
         extends AbstractBrowserTestBase {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/AbstractBrowserTestBase.java
@@ -43,6 +43,8 @@ import com.vaadin.testbench.commands.TestBenchCommands;
 /**
  * A superclass with helper methods to aid TestBench developers create a JUnit
  * 5+ based tests.
+ *
+ * @since 9.0
  */
 public abstract class AbstractBrowserTestBase
         implements HasDriver, HasTestBenchCommandExecutor, HasElementQuery {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTest.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTest.java
@@ -23,6 +23,8 @@ import com.vaadin.testbench.browser.MultipleBrowsersExtension;
  * <p>
  * Combines JUnit 5+ {@code @TestTemplate} together with
  * {@code @ExtendWith(CapabilitiesInvocationContextProvider.class)}.
+ *
+ * @since 9.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestBase.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestBase.java
@@ -20,6 +20,8 @@ import com.vaadin.testbench.parallel.Browser;
 /**
  * A superclass with helper methods to aid TestBench developers create a JUnit
  * 5+ based tests.
+ *
+ * @since 9.0
  */
 @Execution(ExecutionMode.CONCURRENT)
 public abstract class BrowserTestBase extends AbstractBrowserDriverTestBase {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestClass.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/BrowserTestClass.java
@@ -20,6 +20,8 @@ import com.vaadin.testbench.browser.MultipleBrowsersExtension;
 /**
  * Shorthand annotation for enabling
  * {@code @ExtendWith(MultipleBrowsersExtension.class)} on test class.
+ *
+ * @since 9.0
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/DriverSupplier.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/DriverSupplier.java
@@ -13,6 +13,8 @@ import org.openqa.selenium.WebDriver;
 /**
  * Class implementing this interface can provide own {@link WebDriver} to be
  * used during test execution.
+ *
+ * @since 9.0
  */
 public interface DriverSupplier {
 

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/ParameterizedBrowserTest.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/ParameterizedBrowserTest.java
@@ -37,6 +37,7 @@ import com.vaadin.testbench.browser.BrowserExtension;
  *
  * @see ParameterizedTest
  * @see BrowserExtension
+ * @since 9.2.6
  */
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/ScreenshotOnFailureExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/ScreenshotOnFailureExtension.java
@@ -50,6 +50,8 @@ import com.vaadin.testbench.screenshot.ImageFileUtil;
  * before this extension is run and if the driver is closed it is no longer
  * possible to grab a screen shot of the situation.
  * </p>
+ *
+ * @since 9.0
  */
 public class ScreenshotOnFailureExtension implements TestWatcher {
 

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserExtension.java
@@ -44,6 +44,8 @@ import com.vaadin.testbench.parallel.setup.SetupDriver;
  * See {@link #beforeEach(ExtensionContext)} for more detailed information about
  * test preparation.
  * </p>
+ *
+ * @since 9.0
  */
 public class BrowserExtension implements Extension, BeforeEachCallback,
         ExecutionCondition, HasDriver, ParameterResolver {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/BrowserTestInfo.java
@@ -27,6 +27,7 @@ import com.vaadin.testbench.parallel.Browser;
  *            {@link Browser} used for local execution
  * @param runLocallyBrowserVersion
  *            version of {@link Browser} used for local execution
+ * @since 9.0
  */
 public record BrowserTestInfo(WebDriver driver, Capabilities capabilities,
         String hubHostname, Browser runLocallyBrowser,

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/CapabilitiesUtil.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/CapabilitiesUtil.java
@@ -32,6 +32,9 @@ import com.vaadin.testbench.parallel.DefaultBrowserFactory;
 import com.vaadin.testbench.parallel.TestBenchBrowserFactory;
 import com.vaadin.testbench.parallel.TestCategory;
 
+/**
+ * @since 9.0
+ */
 public class CapabilitiesUtil {
 
     private static Logger getLogger() {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/MultipleBrowsersExtension.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/browser/MultipleBrowsersExtension.java
@@ -28,6 +28,8 @@ import com.vaadin.testbench.parallel.TestNameSuffix;
 
 /**
  * Provides support for running test methods using multiple browsers.
+ *
+ * @since 9.0
  */
 public class MultipleBrowsersExtension
         implements TestTemplateInvocationContextProvider, BeforeAllCallback {

--- a/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/parallel/ParallelConfigurationStrategy.java
+++ b/vaadin-testbench-core-junit5/src/main/java/com/vaadin/testbench/parallel/ParallelConfigurationStrategy.java
@@ -17,6 +17,8 @@ import com.vaadin.testbench.Parameters;
 /**
  * Custom configuration strategy using TestBench
  * {@link Parameters#getTestsInParallel()}.
+ *
+ * @since 9.0
  */
 public class ParallelConfigurationStrategy implements
         ParallelExecutionConfiguration, ParallelExecutionConfigurationStrategy {

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/ElementQuery.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/ElementQuery.java
@@ -73,6 +73,8 @@ public class ElementQuery<T extends TestBenchElement> {
         /**
          * Attribute matching comparisons. This is a combination of a CSS
          * selection operator and a negation flag.
+         *
+         * @since 9.3
          */
         public enum Comparison {
             /**
@@ -218,6 +220,7 @@ public class ElementQuery<T extends TestBenchElement> {
          *            the comparison to use for matching
          * @param value
          *            the value to compare with the attribute's value
+         * @since 9.3
          */
         public AttributeMatch(String name, Comparison comparison,
                 String value) {
@@ -287,6 +290,7 @@ public class ElementQuery<T extends TestBenchElement> {
          * @param exists
          *            a boolean indicating whether the attribute exists (true)
          *            or does not exist (false)
+         * @since 9.4
          */
         public AttributeMatch(String name, boolean exists) {
             this(name, exists ? EXISTS : NOT_EXISTS, null);
@@ -360,6 +364,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @return this element query instance for chaining
      *
      * @deprecated use {@link #withAttribute(String)}
+     * @since 6.1
      */
     @Deprecated(since = "9.3")
     public ElementQuery<T> hasAttribute(String name) {
@@ -427,6 +432,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param attribute
      *            the attribute name
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withAttribute(String attribute) {
         attributes.add(new AttributeMatch(attribute));
@@ -447,6 +453,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param comparison
      *            the comparison to use
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withAttribute(String attribute, String value,
             AttributeMatch.Comparison comparison) {
@@ -472,6 +479,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withAttributeContaining(String, String)
      * @see #withAttributeContainingWord(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withAttribute(String attribute, String value) {
         return withAttribute(attribute, value, MATCHES_EXACTLY);
@@ -494,6 +502,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withAttribute(String, String)
      * @see #withAttributeContainingWord(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withAttributeContaining(String attribute,
             String text) {
@@ -519,6 +528,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withAttribute(String, String)
      * @see #withAttributeContaining(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withAttributeContainingWord(String attribute,
             String word) {
@@ -533,6 +543,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param attribute
      *            the attribute name
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withoutAttribute(String attribute) {
         return withAttribute(attribute, null, NOT_EXISTS);
@@ -557,6 +568,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withoutAttributeContaining(String, String)
      * @see #withoutAttributeContainingWord(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withoutAttribute(String attribute, String value) {
         return withAttribute(attribute, value, NOT_MATCHES_EXACTLY);
@@ -582,6 +594,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withoutAttribute(String, String)
      * @see #withoutAttributeContainingWord(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withoutAttributeContaining(String attribute,
             String text) {
@@ -609,6 +622,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withoutAttribute(String, String)
      * @see #withoutAttributeContaining(String, String)
+     * @since 9.3
      */
     public ElementQuery<T> withoutAttributeContainingWord(String attribute,
             String word) {
@@ -631,6 +645,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @see #id(String)
      * @see #single()
      * @see #get(int)
+     * @since 9.3
      */
     public ElementQuery<T> withId(String id) {
         return withAttribute("id", id);
@@ -642,6 +657,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param classNames
      *            the class names
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withClassName(String... classNames) {
         Arrays.stream(classNames).forEach(
@@ -655,6 +671,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param classNames
      *            the class names
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withoutClassName(String... classNames) {
         Arrays.stream(classNames)
@@ -669,6 +686,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param theme
      *            the theme
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withTheme(String theme) {
         return withAttribute("theme", theme);
@@ -680,6 +698,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param theme
      *            the theme
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withoutTheme(String theme) {
         return withoutAttribute("theme", theme);
@@ -699,6 +718,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @param condition
      *            the condition for the element to satisfy; not null
      * @return this element query instance for chaining
+     * @since 9.3
      */
     public ElementQuery<T> withCondition(Predicate<T> condition) {
         Objects.requireNonNull(condition, NULL_CONDITION_MSG);
@@ -736,6 +756,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @return this element query instance for chaining
      *
      * @see #withPropertyValue(Function, Object)
+     * @since 9.3
      */
     public <V> ElementQuery<T> withPropertyValue(Function<T, V> getter,
             V propertyValue, BiPredicate<V, V> comparison) {
@@ -760,6 +781,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @return this element query instance for chaining
      *
      * @see #withPropertyValue(Function, Object, BiPredicate)
+     * @since 9.3
      */
     public <V> ElementQuery<T> withPropertyValue(Function<T, V> getter,
             V propertyValue) {
@@ -790,6 +812,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withLabel(String)
      * @see #withLabelContaining(String)
+     * @since 9.3
      */
     public ElementQuery<T> withLabel(String text,
             BiPredicate<String, String> comparison) {
@@ -811,6 +834,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withLabelContaining(String)
      * @see #withLabel(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withLabel(String label) {
         return withLabel(label, String::equals);
@@ -827,6 +851,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withLabel(String)
      * @see #withLabel(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withLabelContaining(String text) {
         return withLabel(text, String::contains);
@@ -858,6 +883,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withPlaceholder(String)
      * @see #withPlaceholderContaining(String)
+     * @since 9.3
      */
     public ElementQuery<T> withPlaceholder(String text,
             BiPredicate<String, String> comparison) {
@@ -882,6 +908,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withPlaceholderContaining(String)
      * @see #withPlaceholder(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withPlaceholder(String placeholder) {
         return withPlaceholder(placeholder, String::equals);
@@ -900,6 +927,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withPlaceholder(String)
      * @see #withPlaceholder(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withPlaceholderContaining(String text) {
         return withPlaceholder(text, String::contains);
@@ -956,6 +984,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withCaption(String)
      * @see #withCaptionContaining(String)
+     * @since 9.3
      */
     @SuppressWarnings("java:S3776") // cognitive complexity > 15
     public ElementQuery<T> withCaption(String text,
@@ -1010,6 +1039,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withCaptionContaining(String)
      * @see #withCaption(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withCaption(String caption) {
         return withCaption(caption, String::equals);
@@ -1027,6 +1057,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withCaption(String)
      * @see #withCaption(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withCaptionContaining(String text) {
         return withCaption(text, String::contains);
@@ -1057,6 +1088,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withText(String)
      * @see #withTextContaining(String)
+     * @since 9.3
      */
     public ElementQuery<T> withText(String text,
             BiPredicate<String, String> comparison) {
@@ -1078,6 +1110,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withTextContaining(String)
      * @see #withText(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withText(String text) {
         return withText(text, String::equals);
@@ -1094,6 +1127,7 @@ public class ElementQuery<T extends TestBenchElement> {
      *
      * @see #withText(String)
      * @see #withText(String, BiPredicate)
+     * @since 9.3
      */
     public ElementQuery<T> withTextContaining(String text) {
         return withText(text, String::contains);
@@ -1160,6 +1194,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @return The element of the type specified in the constructor
      * @throws NoSuchElementException
      *             if no unique element is found
+     * @since 9.3
      */
     public T single() {
         List<T> all = all();
@@ -1245,6 +1280,7 @@ public class ElementQuery<T extends TestBenchElement> {
      * @see #first()
      * @deprecated Use a wait loop with {@link #single()} for more reliable
      *             tests that assert exactly one matching element exists.
+     * @since 6.3
      */
     @Deprecated(since = "10.0", forRemoval = true)
     public T waitForFirst(long timeOutInSeconds) {

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasClearButton.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasClearButton.java
@@ -12,6 +12,8 @@ package com.vaadin.testbench;
  * The {@code HasClearButton} interface provides methods to interact with an
  * element that may have a clear button. It includes functionality to check the
  * visibility of the clear button and to click it if it is visible.
+ *
+ * @since 9.4
  */
 public interface HasClearButton extends HasElementQuery, HasCallFunction {
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasHelper.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasHelper.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 /**
  * Implement by elements which support a label, i.e. text shown typically inside
  * (when field is empty) or above the field (when the field has a value).
+ *
+ * @since 6.4
  */
 public interface HasHelper extends HasPropertySettersGetters, HasElementQuery {
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasLabel.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasLabel.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 /**
  * Implement by elements which support a label, i.e. text shown typically inside
  * (when field is empty) or above the field (when the field has a value).
+ *
+ * @since 6.1
  */
 public interface HasLabel extends HasPropertySettersGetters {
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasLabelAsText.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasLabelAsText.java
@@ -12,6 +12,8 @@ import org.openqa.selenium.WebElement;
 
 /**
  * Implemented by elements which support a label via its text, such as buttons.
+ *
+ * @since 9.3
  */
 public interface HasLabelAsText extends WebElement {
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasPlaceholder.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasPlaceholder.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 /**
  * Implement by elements which support a placeholder, i.e. text shown when the
  * field is empty.
+ *
+ * @since 6.1
  */
 public interface HasPlaceholder extends HasPropertySettersGetters {
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasSelectByText.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasSelectByText.java
@@ -11,6 +11,8 @@ package com.vaadin.testbench;
 /**
  * Implemented by elements which support selecting an option by matching the
  * text shown to the user.
+ *
+ * @since 6.1
  */
 public interface HasSelectByText {
     /**

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasValidation.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/HasValidation.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 /**
  * Implement by elements which support a error message, required indicator and
  * invalid state.
+ *
+ * @since 9.4
  */
 public interface HasValidation
         extends HasPropertySettersGetters, HasElementQuery, HasCallFunction {

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/Parameters.java
@@ -331,6 +331,7 @@ public class Parameters {
      * system property {@code com.vaadin.testbench.Parameters.hubPort}.
      *
      * @return the port of the hub, defaults to 4444 if nothing is set
+     * @since 9.1
      */
     public static int getHubPort() {
         return hubPort;
@@ -341,6 +342,7 @@ public class Parameters {
      *
      * @param port
      *            The new port to use
+     * @since 9.1
      */
     public static void setHubPort(int port) {
         hubPort = port;
@@ -497,6 +499,7 @@ public class Parameters {
      *
      * @return <code>true</code>, if requested to run in headless mode,
      *         <code>false</code> otherwise
+     * @since 6.3
      */
     public static boolean isHeadless() {
         return headless;
@@ -509,6 +512,7 @@ public class Parameters {
      * @param headless
      *            <code>true</code>, to run in headless mode, <code>false</code>
      *            otherwise
+     * @since 6.3
      */
     public static void setHeadless(boolean headless) {
         Parameters.headless = headless;
@@ -528,6 +532,7 @@ public class Parameters {
      *
      * @param readTimeout
      *            the timeout in seconds
+     * @since 8.1
      */
     public static void setReadTimeout(int readTimeout) {
         Parameters.readTimeout = readTimeout;
@@ -538,6 +543,7 @@ public class Parameters {
      *
      * @param options
      *            a list of options separated with comma or spaces
+     * @since 9.2
      */
     public static void setChromeOptions(String options) {
         chromeOptions = options == null || options.isBlank() ? new String[0]
@@ -550,6 +556,7 @@ public class Parameters {
      * <code>com.vaadin.testbench.Parameters.chromeOptions</code>
      *
      * @return an array of options
+     * @since 9.2
      */
     public static String[] getChromeOptions() {
         return chromeOptions;
@@ -560,6 +567,7 @@ public class Parameters {
      * driver.
      *
      * @return the timeout in seconds
+     * @since 8.1
      */
     public static int getReadTimeout() {
         return readTimeout;

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchElement.java
@@ -151,6 +151,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * Gets the id set for this element.
      *
      * @return String value, can be null
+     * @since 9.4
      */
     public String getId() {
         return getAttribute("id");
@@ -183,6 +184,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      *
      * @return {@code true} if this element is the currently focused element,
      *         {@code false} otherwise.
+     * @since 9.4
      */
     public boolean isFocused() {
         return this.getWrappedElement()
@@ -298,6 +300,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * having readonly attribute set or not.
      *
      * @return true if the component has readonly attribute set.
+     * @since 9.4
      */
     public boolean isReadOnly() {
         waitForVaadin();
@@ -538,6 +541,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      *            {@code Map.of("block", "end", "inline", "end")}
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Element.scrollIntoView()</a>
+     * @since 10.1
      */
     public void scrollIntoView(Map<String, Object> options) {
         callFunction("scrollIntoView", options);
@@ -861,6 +865,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * @param customEventInit
      *            map with properties and values that will be used to initialize
      *            the event
+     * @since 6.1
      */
     public void dispatchEvent(String eventType,
             Map<String, Object> customEventInit) {
@@ -873,6 +878,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * Gets the parent element of this element.
      *
      * @return The parent as TestBenchElement, can be null.
+     * @since 9.4
      */
     public TestBenchElement getParent() {
         return getPropertyElement("parentElement");
@@ -895,6 +901,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * @return the {@link SearchContext} representing the shadow root.
      * @deprecated This method is deprecated. Use {@code $} instead to find
      *             elements in the shadow root.
+     * @since 9.4
      */
     @Override
     @Deprecated
@@ -906,6 +913,7 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * Get list of immediate children of this element.
      *
      * @return List of TestBenchElements
+     * @since 9.4
      */
     public List<TestBenchElement> getChildren() {
         return getPropertyElements("children");
@@ -915,6 +923,8 @@ public class TestBenchElement implements WrapsElement, WebElement, HasDriver,
      * Hover mouse pointer on this element.
      *
      * Note: This works well only if this element is atomic.
+     *
+     * @since 9.4
      */
     public void hover() {
         ensureInteractable();

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchVersion.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/TestBenchVersion.java
@@ -18,6 +18,9 @@ import com.vaadin.pro.licensechecker.Capabilities;
 import com.vaadin.pro.licensechecker.Capability;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 
+/**
+ * @since 9.0
+ */
 public class TestBenchVersion {
 
     public static final String testbenchVersion;

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/annotations/Attribute.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/annotations/Attribute.java
@@ -75,6 +75,7 @@ public @interface Attribute {
      * Specifies whether the attribute must exist on an element.
      *
      * @return true if the attribute must exist, false otherwise
+     * @since 9.4
      */
     boolean exists() default true;
 

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/BrowserUtil.java
@@ -181,6 +181,7 @@ public class BrowserUtil {
      * @param browserFactory
      *            BrowserFactory instance to use to generate default
      *            DesiredCapabilities
+     * @since 9.0
      */
     public static void setBrowserFactory(
             TestBenchBrowserFactory browserFactory) {

--- a/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
+++ b/vaadin-testbench-shared/src/main/java/com/vaadin/testbench/parallel/SauceLabsIntegration.java
@@ -48,6 +48,7 @@ public class SauceLabsIntegration {
      *
      * @param desiredCapabilities
      *            the capabilities object to populate, not null
+     * @since 8.1
      */
     public static void setDesiredCapabilities(
             DesiredCapabilities desiredCapabilities) {
@@ -89,6 +90,7 @@ public class SauceLabsIntegration {
      *            the option key
      * @param value
      *            the option value
+     * @since 8.1
      */
     public static void setSauceLabsOption(
             DesiredCapabilities desiredCapabilities, String key, Object value) {
@@ -123,6 +125,7 @@ public class SauceLabsIntegration {
      * @param key
      *            the option key
      * @return the option value that was set or null
+     * @since 8.1
      */
     public static Object getSauceLabsOption(
             DesiredCapabilities desiredCapabilities, String key) {
@@ -144,6 +147,7 @@ public class SauceLabsIntegration {
      * property is used.
      *
      * @return the configured Saucelabs tunnel identifier or null
+     * @since 8.1
      */
     public static String getSauceTunnelIdentifier() {
         String tunnelId = getSystemPropertyOrEnv(SAUCE_TUNNELID_PROP,
@@ -184,6 +188,7 @@ public class SauceLabsIntegration {
      * https://docs.saucelabs.com/basics/data-center-endpoints/#data-center-endpoints.
      *
      * @return url String to be used in Sauce Labs test run
+     * @since 8.1
      */
     public static String getHubUrl() {
         String hubUrl = getSystemPropertyOrEnv(SAUCE_HUB_URL_PROP,
@@ -198,6 +203,7 @@ public class SauceLabsIntegration {
      * Checks if parameters needed to run in Saucelabs have been set.
      *
      * @return true if the Saucelabs configuration was found
+     * @since 8.1
      */
     public static boolean isConfiguredForSauceLabs() {
         String user = getSauceUser();
@@ -216,6 +222,7 @@ public class SauceLabsIntegration {
      * property is used.
      *
      * @return the configured Saucelabs user name or null
+     * @since 8.1
      */
     public static String getSauceUser() {
         return getSystemPropertyOrEnv(SAUCE_USERNAME_PROP, SAUCE_USERNAME_ENV);
@@ -231,6 +238,7 @@ public class SauceLabsIntegration {
      * property is used.
      *
      * @return the configured Saucelabs access key or null
+     * @since 8.1
      */
     public static String getSauceAccessKey() {
         return getSystemPropertyOrEnv(SAUCE_ACCESS_KEY_PROP,

--- a/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
+++ b/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/SpringUIUnitTest.java
@@ -57,6 +57,7 @@ import com.vaadin.testbench.unit.mocks.SpringSecurityRequestCustomizer;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @ExtendWith({ SpringExtension.class })
 @TestExecutionListeners(listeners = UITestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)

--- a/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
+++ b/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/TreeOnFailureExtension.java
@@ -25,6 +25,7 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class TreeOnFailureExtension implements AfterTestExecutionCallback {

--- a/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
+++ b/vaadin-testbench-unit-junit5/src/main/java/com/vaadin/testbench/unit/UIUnitTest.java
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.BeforeEach;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public abstract class UIUnitTest extends BaseUIUnitTest

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusSecurityCustomizer.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusSecurityCustomizer.java
@@ -23,6 +23,7 @@ import com.vaadin.testbench.unit.mocks.MockRequest;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.2.3
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class QuarkusSecurityCustomizer implements MockRequestCustomizer {

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusTestLookupInitializer.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusTestLookupInitializer.java
@@ -30,6 +30,7 @@ import com.vaadin.testbench.unit.internal.MockRequestCustomizer;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.2.3
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class QuarkusTestLookupInitializer extends LookupInitializer {

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitTest.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/QuarkusUIUnitTest.java
@@ -67,6 +67,9 @@ import com.vaadin.testbench.unit.quarkus.mocks.MockQuarkusServlet;
  *             removed in a future version.
  */
 
+/**
+ * @since 9.2.3
+ */
 @Deprecated(forRemoval = true, since = "10.1")
 public abstract class QuarkusUIUnitTest extends UIUnitTest {
 

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServlet.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServlet.java
@@ -33,6 +33,7 @@ import com.vaadin.testbench.unit.mocks.MockVaadinHelper;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.2.3
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockQuarkusServlet extends QuarkusVaadinServlet {
@@ -59,6 +60,7 @@ public class MockQuarkusServlet extends QuarkusVaadinServlet {
      *            the CDI bean manager
      * @param uiFactory
      *            the factory used to build Flow UIs.
+     * @since 10.0
      */
     public MockQuarkusServlet(Routes routes, BeanManager beanManager,
             @NotNull UIFactory uiFactory) {

--- a/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServletService.java
+++ b/vaadin-testbench-unit-quarkus/src/main/java/com/vaadin/testbench/unit/quarkus/mocks/MockQuarkusServletService.java
@@ -36,6 +36,7 @@ import com.vaadin.testbench.unit.mocks.MockVaadinSession;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.2.3
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockQuarkusServletService extends QuarkusVaadinServletService {
@@ -53,6 +54,7 @@ public class MockQuarkusServletService extends QuarkusVaadinServletService {
      *            the CDI bean manager.
      * @param uiFactory
      *            the factory used to build Flow UIs.
+     * @since 10.0
      */
     public MockQuarkusServletService(QuarkusVaadinServlet servlet,
             DeploymentConfiguration configuration, BeanManager beanManager,

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.Nullable;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Accordion.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class AccordionTester<T extends Accordion> extends ComponentTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/button/ButtonTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/button/ButtonTester.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Button.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/charts/ChartTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/charts/ChartTester.java
@@ -39,6 +39,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Chart.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
@@ -35,6 +35,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = "com.vaadin.flow.component.checkbox.CheckboxGroup")
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
@@ -24,6 +24,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Checkbox.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/combobox/ComboBoxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/combobox/ComboBoxTester.java
@@ -22,6 +22,9 @@ import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 import com.vaadin.testbench.unit.internal.BasicUtilsKt;
 
+/**
+ * @since 8.1
+ */
 @Tests(fqn = "com.vaadin.flow.component.combobox.ComboBox")
 @Deprecated(forRemoval = true, since = "10.1")
 public class ComboBoxTester<T extends ComboBox<Y>, Y>

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTester.java
@@ -24,6 +24,9 @@ import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 import com.vaadin.testbench.unit.internal.BasicUtilsKt;
 
+/**
+ * @since 9.1
+ */
 @Tests(fqn = "com.vaadin.flow.component.combobox.MultiSelectComboBox")
 @Deprecated(forRemoval = true, since = "10.1")
 public class MultiSelectComboBoxTester<T extends MultiSelectComboBox<Y>, Y>

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(ConfirmDialog.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
@@ -33,6 +33,7 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(ContextMenu.class)
 @Deprecated(forRemoval = true, since = "10.1")
@@ -323,6 +324,8 @@ public class ContextMenuTester<T extends ContextMenu>
      * div = menuTester.find(Div.class).withText("Component Item").single();
      * Assertions.assertFalse(div.isAttached());
      * </pre>
+     *
+     * @since 10.0
      */
     @Override
     public <R extends Component> ComponentQuery<R> find(

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
@@ -25,6 +25,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(DatePicker.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
@@ -26,6 +26,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(DateTimePicker.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
@@ -21,6 +21,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Details.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.dialog;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Dialog.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class DialogTester extends ComponentTester<Dialog> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
@@ -42,6 +42,7 @@ import com.vaadin.testbench.unit.component.GridKt;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = { "com.vaadin.flow.component.grid.Grid" })
 @Deprecated(forRemoval = true, since = "10.1")
@@ -358,6 +359,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *             when column for property doesn't exist or the target column
      *             of the cell is not a LitRenderer or when the given type of
      *             the property does not match the actual property type
+     * @since 9.3
      */
     public <V> V getLitRendererPropertyValue(int row, String columnName,
             String propertyName, Class<V> propertyClass) {
@@ -383,6 +385,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *             when column for property doesn't exist or the target column
      *             of the cell is not a LitRenderer or when the given type of
      *             the property does not match the actual property type
+     * @since 9.3
      */
     public <V> V getLitRendererPropertyValue(int row, int column,
             String propertyName, Class<V> propertyClass) {
@@ -415,6 +418,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *            the name of the LitRenderer function to invoke
      * @param jsonArray
      *            the arguments to pass to the function
+     * @since 10.0
      */
     public void invokeLitRendererFunction(int row, String columnName,
             String functionName, ArrayNode jsonArray) {
@@ -431,6 +435,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *            key/property of column
      * @param functionName
      *            the name of the LitRenderer function to invoke
+     * @since 9.3
      */
     public void invokeLitRendererFunction(int row, String columnName,
             String functionName) {
@@ -450,6 +455,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *            the name of the LitRenderer function to invoke
      * @param jsonArray
      *            the arguments to pass to the function
+     * @since 10.0
      */
     public void invokeLitRendererFunction(int row, int column,
             String functionName, ArrayNode jsonArray) {
@@ -466,6 +472,7 @@ public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {
      *            column to get
      * @param functionName
      *            the name of the LitRenderer function to invoke
+     * @since 9.3
      */
     public void invokeLitRendererFunction(int row, int column,
             String functionName) {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/AnchorTester.java
@@ -31,6 +31,9 @@ import com.vaadin.flow.server.streams.DownloadEvent;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Anchor.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class AnchorTester extends HtmlContainerTester<Anchor> {
@@ -60,6 +63,7 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
      *
      * @return a {@link String} containing the navigation target path or empty
      *         if not present
+     * @since 9.3.4
      */
     public String getPath() {
         return URI.create(getHref()).getPath();
@@ -70,6 +74,7 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
      *
      * @return a {@link QueryParameters} containing the navigation target's
      *         query parameters
+     * @since 9.3.4
      */
     public QueryParameters getQueryParameters() {
         return QueryParameters.fromString(URI.create(getHref()).getQuery());
@@ -82,6 +87,7 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
      * @return navigated view
      * @throws IllegalStateException
      *             if anchor href is not a String or not a route
+     * @since 10.0
      */
     public HasElement navigate() {
         ensureComponentIsUsable();
@@ -128,6 +134,7 @@ public class AnchorTester extends HtmlContainerTester<Anchor> {
      *            output stream to write the stream resource to
      * @throws IllegalStateException
      *             if the anchor does not link to a stream resource
+     * @since 9.3
      */
     public void download(OutputStream outputStream) {
         ensureComponentIsUsable();

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListTester.java
@@ -14,6 +14,9 @@ import java.util.stream.Collectors;
 import com.vaadin.flow.component.html.DescriptionList;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(DescriptionList.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class DescriptionListTester extends HtmlClickContainer<DescriptionList> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/DivTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/DivTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Div.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class DivTester extends HtmlClickContainer<Div> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/EmphasisTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/EmphasisTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Emphasis;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Emphasis.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class EmphasisTester extends HtmlClickContainer<Emphasis> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H1Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H1Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H1.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H1Tester extends HtmlClickContainer<H1> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H2Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H2Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H2.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H2Tester extends HtmlClickContainer<H2> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H3Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H3Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H3.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H3Tester extends HtmlClickContainer<H3> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H4Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H4Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H4;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H4.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H4Tester extends HtmlClickContainer<H4> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H5Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H5Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H5;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H5.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H5Tester extends HtmlClickContainer<H5> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H6Tester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/H6Tester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.H6;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(H6.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class H6Tester extends HtmlClickContainer<H6> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HrTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HrTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Hr.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class HrTester extends HtmlComponentTester<Hr> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlClickContainer.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlClickContainer.java
@@ -10,6 +10,9 @@ package com.vaadin.flow.component.html.testbench;
 
 import com.vaadin.flow.component.HtmlContainer;
 
+/**
+ * @since 8.1
+ */
 @Deprecated(forRemoval = true, since = "10.1")
 public abstract class HtmlClickContainer<T extends HtmlContainer>
         extends HtmlContainerTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlComponentTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlComponentTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.testbench.unit.ComponentTester;
 
+/**
+ * @since 8.1
+ */
 @Deprecated(forRemoval = true, since = "10.1")
 public class HtmlComponentTester<T extends HtmlComponent>
         extends ComponentTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlContainerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/HtmlContainerTester.java
@@ -10,6 +10,9 @@ package com.vaadin.flow.component.html.testbench;
 
 import com.vaadin.flow.component.HtmlContainer;
 
+/**
+ * @since 8.1
+ */
 @Deprecated(forRemoval = true, since = "10.1")
 public class HtmlContainerTester<T extends HtmlContainer>
         extends HtmlComponentTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ImageTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ImageTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Image.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class ImageTester extends HtmlClickContainer<Image> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/InputTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/InputTester.java
@@ -12,6 +12,9 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Input.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class InputTester extends ComponentTester<Input> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ListItemTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ListItemTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(ListItem.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class ListItemTester extends HtmlClickContainer<ListItem> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(NativeButton.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class NativeButtonTester extends HtmlClickContainer<NativeButton> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsTester.java
@@ -13,6 +13,9 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.NativeDetails;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(NativeDetails.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class NativeDetailsTester extends HtmlComponentTester<NativeDetails> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeLabelTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/NativeLabelTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 9.1
+ */
 @Tests(NativeLabel.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class NativeLabelTester extends HtmlContainerTester<NativeLabel> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/OrderedListTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/OrderedListTester.java
@@ -15,6 +15,9 @@ import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.flow.component.html.OrderedList;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(OrderedList.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class OrderedListTester extends HtmlClickContainer<OrderedList> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ParagraphTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/ParagraphTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Paragraph.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class ParagraphTester extends HtmlClickContainer<Paragraph> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/PreTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/PreTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Pre;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Pre.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class PreTester extends HtmlClickContainer<Pre> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/RangeInputTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/RangeInputTester.java
@@ -14,6 +14,9 @@ import com.vaadin.flow.component.html.RangeInput;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 9.2
+ */
 @Tests(RangeInput.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class RangeInputTester extends ComponentTester<RangeInput> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/SpanTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/SpanTester.java
@@ -11,6 +11,9 @@ package com.vaadin.flow.component.html.testbench;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(Span.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class SpanTester extends HtmlClickContainer<Span> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/UnorderedListTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/html/testbench/UnorderedListTester.java
@@ -15,6 +15,9 @@ import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.flow.component.html.UnorderedList;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(UnorderedList.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class UnorderedListTester extends HtmlClickContainer<UnorderedList> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/listbox/ListBoxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/listbox/ListBoxTester.java
@@ -27,6 +27,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = { "com.vaadin.flow.component.listbox.ListBox" })
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTester.java
@@ -30,6 +30,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = { "com.vaadin.flow.component.listbox.MultiSelectListBox" })
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/AbstractLoginTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/AbstractLoginTester.java
@@ -21,6 +21,7 @@ import com.vaadin.testbench.unit.ComponentTester;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class AbstractLoginTester<T extends AbstractLogin>

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/LoginFormTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/LoginFormTester.java
@@ -20,6 +20,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(LoginForm.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(LoginOverlay.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/menubar/MenuBarTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/menubar/MenuBarTester.java
@@ -30,6 +30,7 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(MenuBar.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/messages/MessageInputTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/messages/MessageInputTester.java
@@ -22,6 +22,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(MessageInput.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/messages/MessageListTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/messages/MessageListTester.java
@@ -25,6 +25,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(MessageList.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
@@ -23,6 +23,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Notification.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
@@ -33,6 +33,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = "com.vaadin.flow.component.radiobutton.RadioButtonGroup")
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonTester.java
@@ -27,6 +27,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(fqn = "com.vaadin.flow.component.radiobutton.RadioButton")
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
@@ -31,6 +31,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.3.9
  */
 @Tests(RouterLink.class)
 @Deprecated(forRemoval = true, since = "10.1")
@@ -93,6 +94,7 @@ public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {
      * Navigate to the router-link target.
      *
      * @return navigated view
+     * @since 10.0
      */
     public HasElement navigate() {
         ensureComponentIsUsable();

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/select/SelectTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/select/SelectTester.java
@@ -16,6 +16,9 @@ import com.vaadin.flow.data.provider.DataViewUtils;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 8.1
+ */
 @Tests(fqn = { "com.vaadin.flow.component.select.Select" })
 @Deprecated(forRemoval = true, since = "10.1")
 public class SelectTester<T extends Select<Y>, Y> extends ComponentTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/sidenav/SideNavTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/sidenav/SideNavTester.java
@@ -14,6 +14,9 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.testbench.unit.ComponentTester;
 import com.vaadin.testbench.unit.Tests;
 
+/**
+ * @since 9.2
+ */
 @Tests(SideNav.class)
 @Deprecated(forRemoval = true, since = "10.1")
 public class SideNavTester<T extends SideNav> extends ComponentTester<T> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/tabs/TabSheetTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/tabs/TabSheetTester.java
@@ -24,6 +24,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.2
  */
 @Tests(TabSheet.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/tabs/TabsTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/tabs/TabsTester.java
@@ -24,6 +24,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Tabs.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
@@ -21,6 +21,7 @@ import com.vaadin.testbench.unit.Tests;
  *            component type
  * @param <V>
  *            value type
+ * @since 8.1
  */
 @Tests(fqn = { "com.vaadin.flow.component.textfield.IntegerField",
         "com.vaadin.flow.component.textfield.NumberField" })

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
@@ -23,6 +23,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(TextArea.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
@@ -21,6 +21,7 @@ import com.vaadin.testbench.unit.Tests;
  *            component type
  * @param <V>
  *            value type
+ * @since 8.1
  */
 @Tests({ TextField.class, PasswordField.class, EmailField.class,
         BigDecimalField.class })

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
@@ -26,6 +26,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(TimePicker.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
@@ -54,6 +54,7 @@ import com.vaadin.testbench.unit.internal.MockVaadin;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Tests(Upload.class)
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/virtuallist/VirtualListTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/flow/component/virtuallist/VirtualListTester.java
@@ -34,6 +34,7 @@ import com.vaadin.testbench.unit.Tests;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.3
  */
 @Tests(VirtualList.class)
 @Deprecated(forRemoval = true, since = "10.1")
@@ -211,6 +212,7 @@ public class VirtualListTester<T extends VirtualList<Y>, Y>
      * @see #invokeLitRendererFunction(int, String)
      * @throws IllegalArgumentException
      *             when the VirtualList is not using a LitRenderer
+     * @since 10.0
      */
     public void invokeLitRendererFunction(int index, String functionName,
             ArrayNode jsonArray) {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/BaseUIUnitTest.java
@@ -68,6 +68,7 @@ import com.vaadin.testbench.unit.mocks.MockedUI;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.0.7
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public abstract class BaseUIUnitTest {
@@ -451,6 +452,7 @@ public abstract class BaseUIUnitTest {
      * @param <T>
      *            the type of the component(s) to search for
      * @return a query object for finding components
+     * @since 25.2
      */
     public <T extends Component> ComponentQuery<T> find(
             Class<T> componentType) {
@@ -469,6 +471,7 @@ public abstract class BaseUIUnitTest {
      * @param <T>
      *            the type of the component(s) to search for
      * @return a query object for finding components
+     * @since 25.2
      */
     public <T extends Component> ComponentQuery<T> find(Class<T> componentType,
             Component fromThis) {
@@ -484,6 +487,7 @@ public abstract class BaseUIUnitTest {
      * @param <T>
      *            the type of the component(s) to search for
      * @return a query object for finding components
+     * @since 25.2
      */
     public <T extends Component> ComponentQuery<T> findInView(
             Class<T> componentType) {
@@ -603,6 +607,7 @@ public abstract class BaseUIUnitTest {
      * @return {@code true} if any pending Signals tasks were processed.
      * @see #runPendingSignalsTasks(long, TimeUnit)
      * @see TestSignalEnvironment#runPendingTasks(long, TimeUnit)
+     * @since 10.0
      */
     protected final boolean runPendingSignalsTasks() {
         return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
@@ -634,6 +639,7 @@ public abstract class BaseUIUnitTest {
      *            the time unit of the timeout value
      * @return {@code true} if any pending Signals tasks were processed.
      * @see TestSignalEnvironment#runPendingTasks(long, TimeUnit)
+     * @since 10.0
      */
     protected final boolean runPendingSignalsTasks(long maxWaitTime,
             TimeUnit unit) {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/Clickable.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/Clickable.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.ComponentUtil;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 10.0
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public interface Clickable<T extends Component> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/CommercialTesterWrappers.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/CommercialTesterWrappers.java
@@ -18,6 +18,7 @@ import com.vaadin.flow.component.charts.ChartTester;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 10.0
  */
 @SuppressWarnings("unchecked")
 @Deprecated(forRemoval = true, since = "10.1")

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentQuery.java
@@ -42,6 +42,7 @@ import com.vaadin.testbench.unit.internal.SearchSpec;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class ComponentQuery<T extends Component> {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentTester.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentTester.java
@@ -43,6 +43,7 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTreeKt;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class ComponentTester<T extends Component> implements Clickable<T> {
@@ -100,6 +101,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      * @return {@code true} if component can be interacted with by the user
      * @see #notUsableReasons(Consumer)
      * @see #ensureComponentIsUsable()
+     * @since 9.2
      */
     protected static boolean isUsable(Component component) {
         return component.getElement().isEnabled() && component.isAttached()
@@ -159,6 +161,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      *            the component to check
      * @param usableTest
      *            function that tests if the component is usable or not.
+     * @since 9.2
      */
     protected static void ensureComponentIsUsable(Component component,
             Predicate<Component> usableTest) {
@@ -205,6 +208,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      *
      * @see #isUsable()
      * @see #ensureComponentIsUsable()
+     * @since 9.2
      */
     protected static void notUsableReasons(Component component,
             Consumer<String> collector) {
@@ -235,6 +239,8 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
     /**
      * Check that the given component is visible for the user. Else throw an
      * {@link IllegalStateException}
+     *
+     * @since 9.2
      */
     protected static void ensureVisible(Component component) {
         if (!component.isVisible() || !component.isAttached()) {
@@ -339,6 +345,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      *            the type of the event, not null.
      * @param eventData
      *            additional data related to the event, not null
+     * @since 10.0
      */
     protected void fireDomEvent(String eventType, ObjectNode eventData) {
         DomEvent event = new DomEvent(getComponent().getElement(), eventType,
@@ -438,6 +445,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      *
      * @param value
      *            the new value, may be null.
+     * @since 9.4.1
      */
     protected <V> void setValueAsUser(V value) {
         if (component instanceof AbstractField) {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentTesterPackages.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ComponentTesterPackages.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ElementConditions.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ElementConditions.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.dom.Element;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public final class ElementConditions {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/LitRendererTestUtil.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/LitRendererTestUtil.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.function.ValueProvider;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 9.3
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class LitRendererTestUtil {
@@ -191,6 +192,7 @@ public class LitRendererTestUtil {
      *            the type being renderer by the LitRenderer
      * @throws IllegalArgumentException
      *             when the function is not registered in LitRenderer
+     * @since 10.0
      */
     public static <Y> void invokeFunction(LitRenderer<Y> litRenderer,
             BiFunction<Class<?>, String, Field> fieldGetter,

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/MetaKeys.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/MetaKeys.java
@@ -15,6 +15,7 @@ package com.vaadin.testbench.unit;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MetaKeys {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/MouseButton.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/MouseButton.java
@@ -26,6 +26,7 @@ package com.vaadin.testbench.unit;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public enum MouseButton {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/SerializationDebugUtil.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/SerializationDebugUtil.java
@@ -22,6 +22,9 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * @since 9.5.3
+ */
 @Deprecated(forRemoval = true, since = "10.1")
 public final class SerializationDebugUtil {
 

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/TesterWrappers.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/TesterWrappers.java
@@ -125,6 +125,9 @@ import com.vaadin.flow.component.virtuallist.VirtualList;
 import com.vaadin.flow.component.virtuallist.VirtualListTester;
 import com.vaadin.flow.router.RouterLink;
 
+/**
+ * @since 8.1
+ */
 @SuppressWarnings("unchecked")
 @Deprecated(forRemoval = true, since = "10.1")
 public interface TesterWrappers {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/Tests.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/Tests.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Component;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/UITestSpringLookupInitializer.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/UITestSpringLookupInitializer.java
@@ -39,6 +39,7 @@ import com.vaadin.testbench.unit.mocks.SpringSecurityRequestCustomizer;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class UITestSpringLookupInitializer extends SpringLookupInitializer

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/UIUnitTestSetupException.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/UIUnitTestSetupException.java
@@ -16,6 +16,7 @@ package com.vaadin.testbench.unit;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class UIUnitTestSetupException extends RuntimeException {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ViewPackages.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/ViewPackages.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Target;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServlet.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServlet.java
@@ -44,6 +44,7 @@ import com.vaadin.testbench.unit.internal.UtilsKt;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockSpringServlet extends SpringServlet {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServletService.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringServletService.java
@@ -38,6 +38,7 @@ import com.vaadin.testbench.unit.internal.UIFactory;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockSpringServletService extends SpringVaadinServletService {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringVaadinSession.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockSpringVaadinSession.java
@@ -34,6 +34,7 @@ import com.vaadin.testbench.unit.internal.UIFactory;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockSpringVaadinSession extends VaadinSession {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockWebApplicationContext.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/MockWebApplicationContext.java
@@ -40,6 +40,7 @@ import org.springframework.web.context.WebApplicationContext;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class MockWebApplicationContext implements WebApplicationContext {

--- a/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/SpringSecurityRequestCustomizer.java
+++ b/vaadin-testbench-unit-shared/src/main/java/com/vaadin/testbench/unit/mocks/SpringSecurityRequestCustomizer.java
@@ -19,6 +19,7 @@ import com.vaadin.testbench.unit.internal.MockRequestCustomizer;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public class SpringSecurityRequestCustomizer implements MockRequestCustomizer {

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/SpringUIUnit4Test.java
@@ -56,6 +56,7 @@ import com.vaadin.testbench.unit.mocks.SpringSecurityRequestCustomizer;
  *             browserless-test-junit6 and use the corresponding class from the
  *             com.vaadin.browserless package instead. This class will be
  *             removed in a future version.
+ * @since 8.1
  */
 @RunWith(SpringRunner.class)
 @TestExecutionListeners(listeners = UITestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)

--- a/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
+++ b/vaadin-testbench-unit/src/main/java/com/vaadin/testbench/unit/UIUnit4Test.java
@@ -71,6 +71,8 @@ import com.vaadin.testbench.unit.internal.PrettyPrintTree;
  * browserless-test-junit6 and use the corresponding class from the
  * com.vaadin.browserless package instead. This class will be removed in a
  * future version.
+ *
+ * @since 8.1
  */
 @Deprecated(forRemoval = true, since = "10.1")
 public abstract class UIUnit4Test extends BaseUIUnitTest


### PR DESCRIPTION
Add missing @since tags to public/protected API across the testbench modules, derived from the actual presence of each API element in the published -sources.jar artifacts on Maven Central (per-element contiguous presence reaching the latest release).

Only provable introductions are tagged: mid-history versions plus the genuine module births (unit 8.1, shared 9.0, quarkus 9.2.3) and API new in 25.2. Elements that resolve only to vaadin-testbench-core's earliest published jar (6.0.1) are left untouched, since that floor predates Maven Central source history and would understate their true age and overwrite the more accurate hand-written tags (RetryRule 5.0, SharedUtil 7.4/7.5), which are preserved.

Additions only; no existing tags changed or removed.
