### PR TITLE
test: do not assert on the order of theme names in a tree

### DIFF
--- a/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/MockVaadinTest.kt
+++ b/vaadin-testbench-unit-junit5/src/test/kotlin/com/vaadin/testbench/unit/internal/MockVaadinTest.kt
@@ -47,9 +47,9 @@ internal fun DynaNodeGroup.mockVaadinTest() {
         MockVaadin.setup(routes)
         expect("""
 └── MockedUI[]
-    └── WelcomeView[@theme='spacing padding']
+    └── WelcomeView[@theme='padding spacing']
         └── Text[text='Welcome!']
-""".trim()) { UI.getCurrent().toPrettyTree().trim() }
+""".trim()) { UI.getCurrent().toPrettyTree().trim().withSortedThemeNames() }
     }
     afterEach { MockVaadin.tearDown() }
 
@@ -291,10 +291,10 @@ internal fun DynaNodeGroup.mockVaadinTest() {
             expect(
                     """
 └── MockedUI[]
-    └── WelcomeView[@theme='spacing padding']
+    └── WelcomeView[@theme='padding spacing']
         └── Text[text='Welcome!']
 """.trim()
-            ) { UI.getCurrent().toPrettyTree().trim() }
+            ) { UI.getCurrent().toPrettyTree().trim().withSortedThemeNames() }
         }
     }
 
@@ -586,3 +586,16 @@ internal fun DynaNodeGroup.mockVaadinTest() {
         }
     }
 }
+
+/**
+ * Sorts the names within every `@theme='...'` of a pretty printed component
+ * tree.
+ *
+ * A component's theme names are a set, so the order they are printed in is
+ * whatever order the component happened to add them in — nothing a test should
+ * assert on. Sorting both sides keeps a tree assertion about the tree.
+ */
+private fun String.withSortedThemeNames(): String =
+        Regex("@theme='([^']*)'").replace(this) { match ->
+            "@theme='" + match.groupValues[1].split(' ').sorted().joinToString(" ") + "'"
+        }

--- a/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/MockVaadinTest.kt
+++ b/vaadin-testbench-unit/src/test/kotlin/com/vaadin/testbench/unit/internal/MockVaadinTest.kt
@@ -47,9 +47,9 @@ internal fun DynaNodeGroup.mockVaadinTest() {
         MockVaadin.setup(routes)
         expect("""
 └── MockedUI[]
-    └── WelcomeView[@theme='spacing padding']
+    └── WelcomeView[@theme='padding spacing']
         └── Text[text='Welcome!']
-""".trim()) { UI.getCurrent().toPrettyTree().trim() }
+""".trim()) { UI.getCurrent().toPrettyTree().trim().withSortedThemeNames() }
     }
     afterEach { MockVaadin.tearDown() }
 
@@ -291,10 +291,10 @@ internal fun DynaNodeGroup.mockVaadinTest() {
             expect(
                     """
 └── MockedUI[]
-    └── WelcomeView[@theme='spacing padding']
+    └── WelcomeView[@theme='padding spacing']
         └── Text[text='Welcome!']
 """.trim()
-            ) { UI.getCurrent().toPrettyTree().trim() }
+            ) { UI.getCurrent().toPrettyTree().trim().withSortedThemeNames() }
         }
     }
 
@@ -586,3 +586,16 @@ internal fun DynaNodeGroup.mockVaadinTest() {
         }
     }
 }
+
+/**
+ * Sorts the names within every `@theme='...'` of a pretty printed component
+ * tree.
+ *
+ * A component's theme names are a set, so the order they are printed in is
+ * whatever order the component happened to add them in — nothing a test should
+ * assert on. Sorting both sides keeps a tree assertion about the tree.
+ */
+private fun String.withSortedThemeNames(): String =
+        Regex("@theme='([^']*)'").replace(this) { match ->
+            "@theme='" + match.groupValues[1].split(' ').sorted().joinToString(" ") + "'"
+        }


### PR DESCRIPTION
#2312 pinned the tree assertions in `MockVaadinTest` to the new `spacing padding` order, but the order is not stable — it is whatever order the component happened to add the theme names in, so the assertions will fail again on the next reordering. One of the two assertions is in the `beforeEach` of the whole group, so when it flips, every test in the group fails:

```
Expected <└── MockedUI[]
    └── WelcomeView[@theme='padding spacing']
        └── Text[text='Welcome!']>, actual <└── MockedUI[]
    └── WelcomeView[@theme='spacing padding']
        └── Text[text='Welcome!']>.
```

Theme names are a set, and their print order is nothing a test should pin. This sorts the names inside every `@theme='...'` of the printed tree before comparing, and restores the alphabetical expected trees, so the assertions stay about the tree and survive the next reordering.

Same change as vaadin/browserless-test#207, applied to both `vaadin-testbench-unit` and `vaadin-testbench-unit-junit5`.

`AllTests` passes in both modules (172 and 173 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)